### PR TITLE
Binary limits in FinOrd

### DIFF
--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -1,6 +1,6 @@
 module FinSets
-export FinOrd, FinOrdFunction, force, product, equalizer, pullback,
-  coproduct, coequalizer, pushout
+export FinOrd, FinOrdFunction, force, terminal, product, equalizer, pullback,
+  initial, coproduct, coequalizer, pushout
 
 using AutoHashEquals
 using DataStructures: IntDisjointSets, union!, find_root
@@ -75,8 +75,11 @@ compose_functions(f::AbstractVector, g::AbstractVector) = g[f]
 as_function(f) = f
 as_function(f::AbstractVector) = x -> f[x]
 
-# Limits and colimits
-#####################
+# Limits
+########
+
+terminal(::Type{FinOrd}) = FinOrd(1)
+terminal(::Type{FinOrd{T}}) where T = FinOrd(one(T))
 
 function product(A::FinOrd, B::FinOrd)
   m, n = A.n, B.n
@@ -103,6 +106,12 @@ function pullback(cospan::Cospan{<:FinOrdFunction,<:FinOrdFunction})
   eq = equalizer(π1⋅f, π2⋅g)
   Span(eq⋅π1, eq⋅π2)
 end
+
+# Colimits
+##########
+
+initial(::Type{FinOrd}) = FinOrd(0)
+initial(::Type{FinOrd{T}}) where T = FinOrd(zero(T))
 
 function coproduct(A::FinOrd, B::FinOrd)
   m, n = A.n, B.n

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -1,5 +1,6 @@
 module FinSets
-export FinOrd, FinOrdFunction, force, product, coproduct, coequalizer, pushout
+export FinOrd, FinOrdFunction, force, product, equalizer, coproduct,
+  coequalizer, pushout
 
 using AutoHashEquals
 using DataStructures: IntDisjointSets, union!, find_root
@@ -83,6 +84,12 @@ function product(A::FinOrd, B::FinOrd)
   π1 = FinOrdFunction(i -> indices[i][1], m*n, m)
   π2 = FinOrdFunction(i -> indices[i][2], m*n, n)
   Span(π1, π2)
+end
+
+function equalizer(f::FinOrdFunction, g::FinOrdFunction)
+  @assert dom(f) == dom(g) && codom(f) == codom(g)
+  m = f.dom
+  FinOrdFunction(filter(i -> f(i) == g(i), 1:m), m)
 end
 
 function coproduct(A::FinOrd, B::FinOrd)

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -1,6 +1,6 @@
 module FinSets
-export FinOrd, FinOrdFunction, force, product, equalizer, coproduct,
-  coequalizer, pushout
+export FinOrd, FinOrdFunction, force, product, equalizer, pullback,
+  coproduct, coequalizer, pushout
 
 using AutoHashEquals
 using DataStructures: IntDisjointSets, union!, find_root
@@ -92,6 +92,18 @@ function equalizer(f::FinOrdFunction, g::FinOrdFunction)
   FinOrdFunction(filter(i -> f(i) == g(i), 1:m), m)
 end
 
+""" Pullback of cospan of functions between finite ordinals.
+
+TODO: This logic is completely generic. Make it independent of FinOrd.
+"""
+function pullback(cospan::Cospan{<:FinOrdFunction,<:FinOrdFunction})
+  f, g = left(cospan), right(cospan)
+  prod = product(dom(f), dom(g))
+  π1, π2 = left(prod), right(prod)
+  eq = equalizer(π1⋅f, π2⋅g)
+  Span(eq⋅π1, eq⋅π2)
+end
+
 function coproduct(A::FinOrd, B::FinOrd)
   m, n = A.n, B.n
   ι1 = FinOrdFunction(1:m, m, m+n)
@@ -111,9 +123,7 @@ function coequalizer(f::FinOrdFunction, g::FinOrdFunction)
   FinOrdFunction([ searchsortedfirst(roots, r) for r in h], length(roots))
 end
 
-""" Pushout of span of functions between finite sets.
-
-Returns a cospan whose legs are the inclusions into the quotient set.
+""" Pushout of span of functions between finite ordinals.
 
 TODO: This logic is completely generic. Make it independent of FinOrd.
 """

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -1,5 +1,5 @@
 module FinSets
-export FinOrd, FinOrdFunction, force, coproduct, coequalizer, pushout
+export FinOrd, FinOrdFunction, force, product, coproduct, coequalizer, pushout
 
 using AutoHashEquals
 using DataStructures: IntDisjointSets, union!, find_root
@@ -76,6 +76,14 @@ as_function(f::AbstractVector) = x -> f[x]
 
 # Limits and colimits
 #####################
+
+function product(A::FinOrd, B::FinOrd)
+  m, n = A.n, B.n
+  indices = CartesianIndices((m, n))
+  π1 = FinOrdFunction(i -> indices[i][1], m*n, m)
+  π2 = FinOrdFunction(i -> indices[i][2], m*n, n)
+  Span(π1, π2)
+end
 
 function coproduct(A::FinOrd, B::FinOrd)
   m, n = A.n, B.n

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -28,6 +28,12 @@ h = FinOrdFunction([3,1,2], 3)
 # Limits and colimits
 #####################
 
+# Product.
+span = product(FinOrd(2), FinOrd(3))
+@test apex(span) == FinOrd(6)
+@test force(left(span)) == FinOrdFunction([1,2,1,2,1,2])
+@test force(right(span)) == FinOrdFunction([1,1,2,2,3,3])
+
 # Coproduct.
 cospan = coproduct(FinOrd(2), FinOrd(3))
 @test base(cospan) == FinOrd(5)

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -25,14 +25,29 @@ h = FinOrdFunction([3,1,2], 3)
 @test compose(id(dom(f)),f) == f
 @test compose(f,id(codom(f))) == f
 
-# Limits and colimits
-#####################
+# Limits
+########
 
 # Product.
 span = product(FinOrd(2), FinOrd(3))
 @test apex(span) == FinOrd(6)
 @test force(left(span)) == FinOrdFunction([1,2,1,2,1,2])
 @test force(right(span)) == FinOrdFunction([1,1,2,2,3,3])
+
+# Equalizer.
+f, g = FinOrdFunction([1,2,3]), FinOrdFunction([3,2,1])
+@test equalizer(f,g) == FinOrdFunction([2], 3)
+
+# Equalizer in case of identical functions.
+f = FinOrdFunction([4,2,3,1], 5)
+@test equalizer(f,f) == force(id(FinOrd(4)))
+
+# Equalizer matching nothing.
+f, g = id(FinOrd(5)), FinOrdFunction([2,3,4,5,1], 5)
+@test equalizer(f,g) == FinOrdFunction([], 5)
+
+# Colimits
+##########
 
 # Coproduct.
 cospan = coproduct(FinOrd(2), FinOrd(3))
@@ -42,18 +57,15 @@ cospan = coproduct(FinOrd(2), FinOrd(3))
 
 # Coequalizer from a singleton set.
 f, g = FinOrdFunction([1], 3), FinOrdFunction([3], 3)
-coeq = coequalizer(f,g)
-@test coeq == FinOrdFunction([1,2,1], 2)
+@test coequalizer(f,g) == FinOrdFunction([1,2,1], 2)
 
-# Coequalizer in degenerate case of identical functions.
+# Coequalizer in case of identical functions.
 f = FinOrdFunction([4,2,3,1], 5)
-coeq = coequalizer(f,f)
-@test coeq == force(id(FinOrd(5)))
+@test coequalizer(f,f) == force(id(FinOrd(5)))
 
 # Coequalizer identifying everything.
 f, g = id(FinOrd(5)), FinOrdFunction([2,3,4,5,1], 5)
-coeq = coequalizer(f,g)
-@test coeq == FinOrdFunction(repeat([1],5))
+@test coequalizer(f,g) == FinOrdFunction(repeat([1],5))
 
 # Pushout from the empty set: the degenerate case of the coproduct.
 f, g = FinOrdFunction([], 2), FinOrdFunction([], 3)

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -46,6 +46,18 @@ f = FinOrdFunction([4,2,3,1], 5)
 f, g = id(FinOrd(5)), FinOrdFunction([2,3,4,5,1], 5)
 @test equalizer(f,g) == FinOrdFunction([], 5)
 
+# Pullback.
+span = pullback(Cospan(FinOrdFunction([1,1,3,2],4), FinOrdFunction([1,1,4,2],4)))
+@test apex(span) == FinOrd(5)
+@test force(left(span)) == FinOrdFunction([1,2,1,2,4], 4)
+@test force(right(span)) == FinOrdFunction([1,1,2,2,4], 4)
+
+# Pullback from a singleton set: the degenerate case of a product.
+span = pullback(Cospan(FinOrdFunction([1,1]), FinOrdFunction([1,1,1])))
+@test apex(span) == FinOrd(6)
+@test force(left(span)) == FinOrdFunction([1,2,1,2,1,2])
+@test force(right(span)) == FinOrdFunction([1,1,2,2,3,3])
+
 # Colimits
 ##########
 

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -28,6 +28,9 @@ h = FinOrdFunction([3,1,2], 3)
 # Limits
 ########
 
+# Terminal object.
+@test terminal(FinOrd) == FinOrd(1)
+
 # Product.
 span = product(FinOrd(2), FinOrd(3))
 @test apex(span) == FinOrd(6)
@@ -60,6 +63,9 @@ span = pullback(Cospan(FinOrdFunction([1,1]), FinOrdFunction([1,1,1])))
 
 # Colimits
 ##########
+
+# Initial object.
+@test initial(FinOrd) == FinOrd(0)
 
 # Coproduct.
 cospan = coproduct(FinOrd(2), FinOrd(3))


### PR DESCRIPTION
Implements binary products, equalizers, and pullbacks in FinOrd. Sequel to #169.