### PR TITLE
Begin refactoring of GATs

### DIFF
--- a/experiments/Markov/src/MarkovCategories.jl
+++ b/experiments/Markov/src/MarkovCategories.jl
@@ -33,13 +33,13 @@ end
 # Wiring diagrams
 #################
 
-mcopy(A::Ports{MarkovCategory.Hom}, n::Int) = implicit_mcopy(A, n)
+mcopy(A::Ports{MarkovCategory}, n::Int) = implicit_mcopy(A, n)
 
-function expectation(M::WiringDiagram{MarkovCategory.Hom})
+function expectation(M::WiringDiagram{MarkovCategory})
   if nboxes(M) <= 1
     functor(M, identity, expectation_box)
   else
-    singleton_diagram(MarkovCategory.Hom, expectation_box(M))
+    singleton_diagram(MarkovCategory, expectation_box(M))
   end
 end
 

--- a/experiments/Markov/test/MarkovCategories.jl
+++ b/experiments/Markov/test/MarkovCategories.jl
@@ -23,9 +23,9 @@ M = Hom(:M, A, B)
 # Wiring diagrams
 #################
 
-A, B, C = [ Ports{MarkovCategory.Hom}([sym]) for sym in [:A, :B, :C] ]
-M = singleton_diagram(MarkovCategory.Hom, Box(:M,[:A],[:B]))
-N = singleton_diagram(MarkovCategory.Hom, Box(:N,[:B],[:C]))
+A, B, C = [ Ports{MarkovCategory}([sym]) for sym in [:A, :B, :C] ]
+M = singleton_diagram(MarkovCategory, Box(:M,[:A],[:B]))
+N = singleton_diagram(MarkovCategory, Box(:N,[:B],[:C]))
 
 # Non-functoriality of expectation.
 @test expectation(compose(M,N)) != compose(expectation(M),expectation(N))

--- a/src/core/Rewrite.jl
+++ b/src/core/Rewrite.jl
@@ -18,7 +18,7 @@ function associate(expr::E)::E where E <: GATExpr
   op, e1, e2 = head(expr), first(expr), last(expr)
   args1 = head(e1) == op ? args(e1) : [e1]
   args2 = head(e2) == op ? args(e2) : [e2]
-  E([args1; args2], type_args(expr))
+  E([args1; args2], gat_type_args(expr))
 end
 
 """ Simplify associative binary operation with unit.

--- a/src/core/Syntax.jl
+++ b/src/core/Syntax.jl
@@ -4,9 +4,9 @@ In general, a single theory may have many different syntaxes. The purpose of
 this module to enable the simple but flexible construction of syntax systems.
 """
 module Syntax
-export @syntax, GATExpr, SyntaxDomainError, head, args, type_args, first, last,
-  invoke_term, functor, to_json_sexpr, parse_json_sexpr, show_sexpr,
-  show_unicode, show_latex
+export @syntax, GATExpr, SyntaxDomainError, head, args, gat_type_args,
+  first, last, invoke_term, functor, to_json_sexpr, parse_json_sexpr,
+  show_sexpr, show_unicode, show_latex
 
 import Base: first, last
 import Base.Meta: ParseError, show_sexpr
@@ -40,10 +40,10 @@ head(::GATExpr{T}) where T = T
 args(expr::GATExpr) = expr.args
 first(expr::GATExpr) = first(args(expr))
 last(expr::GATExpr) = last(args(expr))
-type_args(expr::GATExpr) = expr.type_args
+gat_type_args(expr::GATExpr) = expr.type_args
 
-function Base.:(==)(e1::GATExpr, e2::GATExpr)
-  head(e1) == head(e2) && args(e1) == args(e2) && type_args(e1) == type_args(e2)
+function Base.:(==)(e1::GATExpr{T}, e2::GATExpr{S}) where {T,S}
+  T == S && e1.args == e2.args && e1.type_args == e2.type_args
 end
 function Base.hash(e::GATExpr, h::UInt)
   hash(args(e), hash(head(e), h))
@@ -337,7 +337,7 @@ end
 """
 function generator_like(expr::GATExpr, value)::GATExpr
   invoke_term(
-    syntax_module(expr), nameof(typeof(expr)), value, type_args(expr)...)
+    syntax_module(expr), nameof(typeof(expr)), value, gat_type_args(expr)...)
 end
 
 """ Get syntax module of given expression.

--- a/src/core/Syntax.jl
+++ b/src/core/Syntax.jl
@@ -110,11 +110,10 @@ macro syntax(syntax_head, mod_name, body=nothing)
     :(Core.@__doc__ $(esc(syntax_name))))
 end
 function syntax_code(name::Symbol, base_types::Vector{Type},
-                     theory_module::Module, outer_module::Module,
+                     theory_type::Type, outer_module::Module,
                      functions::Vector)
-  theory = theory_module.theory()
-  theory_ref = GlobalRef(parentmodule(theory_module),
-                            nameof(theory_module))
+  theory = GAT.theory(theory_type)
+  theory_ref = GlobalRef(parentmodule(theory_type), nameof(theory_type))
 
   # Generate module with syntax types and type/term generators.
   mod = Expr(:module, true, name,
@@ -316,10 +315,10 @@ This method provides reflection for syntax systems. In everyday use the generic
 method for the constructor should be called directly, not through this function.
 """
 function invoke_term(syntax_module::Module, constructor_name::Symbol, args...)
-  theory_module = syntax_module.theory()
-  theory = theory_module.theory()
+  theory_type = syntax_module.theory()
+  theory = GAT.theory(theory_type)
   syntax_types = Tuple(getfield(syntax_module, cons.name) for cons in theory.types)
-  invoke_term(theory_module, syntax_types, constructor_name, args...)
+  invoke_term(theory_type, syntax_types, constructor_name, args...)
 end
 
 """ Name of constructor that created expression.
@@ -389,8 +388,8 @@ function functor(types::Tuple, expr::GATExpr;
   end
 
   # Invoke the constructor in the codomain category!
-  theory_module = syntax_module(expr).theory()
-  invoke_term(theory_module, types, name, term_args...)
+  theory_type = syntax_module(expr).theory()
+  invoke_term(theory_type, types, name, term_args...)
 end
 
 # Serialization
@@ -422,8 +421,8 @@ function parse_json_sexpr(syntax_module::Module, sexpr;
     parse_value::Function = identity,
     symbols::Bool = true,
   )
-  theory_module = syntax_module.theory()
-  theory = theory_module.theory()
+  theory_type = syntax_module.theory()
+  theory = GAT.theory(theory_type)
   type_lens = Dict(cons.name => length(cons.params) for cons in theory.types)
 
   function parse_impl(sexpr::Vector, ::Val{:expr})

--- a/src/core/Syntax.jl
+++ b/src/core/Syntax.jl
@@ -4,9 +4,9 @@ In general, a single theory may have many different syntaxes. The purpose of
 this module to enable the simple but flexible construction of syntax systems.
 """
 module Syntax
-export @syntax, GATExpr, SyntaxDomainError, head, args, gat_type_args,
-  first, last, invoke_term, functor, to_json_sexpr, parse_json_sexpr,
-  show_sexpr, show_unicode, show_latex
+export @syntax, GATExpr, SyntaxDomainError, head, args, first, last,
+  gat_typeof, gat_type_args, invoke_term, functor,
+  to_json_sexpr, parse_json_sexpr, show_sexpr, show_unicode, show_latex
 
 import Base: first, last
 import Base.Meta: ParseError, show_sexpr
@@ -40,6 +40,7 @@ head(::GATExpr{T}) where T = T
 args(expr::GATExpr) = expr.args
 first(expr::GATExpr) = first(args(expr))
 last(expr::GATExpr) = last(args(expr))
+gat_typeof(expr::GATExpr) = nameof(typeof(expr))
 gat_type_args(expr::GATExpr) = expr.type_args
 
 function Base.:(==)(e1::GATExpr{T}, e2::GATExpr{S}) where {T,S}
@@ -325,19 +326,14 @@ end
 
 """ Name of constructor that created expression.
 """
-function constructor_name(expr::GATExpr)::Symbol
-  if head(expr) == :generator
-    nameof(typeof(expr))
-  else
-    head(expr)
-  end
-end
+constructor_name(expr::GATExpr) = head(expr)
+constructor_name(expr::GATExpr{:generator}) = gat_typeof(expr)
 
 """ Create generator of the same type as the given expression.
 """
 function generator_like(expr::GATExpr, value)::GATExpr
-  invoke_term(
-    syntax_module(expr), nameof(typeof(expr)), value, gat_type_args(expr)...)
+  invoke_term(syntax_module(expr), gat_typeof(expr),
+              value, gat_type_args(expr)...)
 end
 
 """ Get syntax module of given expression.

--- a/src/programs/ParseJuliaPrograms.jl
+++ b/src/programs/ParseJuliaPrograms.jl
@@ -117,7 +117,7 @@ end
 """ Make a lookup table assigning names to generators or term constructors.
 """
 function make_lookup_table(pres::Presentation, syntax_module::Module, names)
-  theory = syntax_module.theory().theory()
+  theory = GAT.theory(syntax_module.theory())
   terms = Set([ term.name for term in theory.terms ])
 
   table = Dict{Symbol,Any}()

--- a/src/programs/ParseJuliaPrograms.jl
+++ b/src/programs/ParseJuliaPrograms.jl
@@ -117,7 +117,7 @@ end
 """ Make a lookup table assigning names to generators or term constructors.
 """
 function make_lookup_table(pres::Presentation, syntax_module::Module, names)
-  theory = syntax_module.theory().class().theory
+  theory = syntax_module.theory().theory()
   terms = Set([ term.name for term in theory.terms ])
 
   table = Dict{Symbol,Any}()

--- a/src/wiring_diagrams/Algebraic.jl
+++ b/src/wiring_diagrams/Algebraic.jl
@@ -243,32 +243,32 @@ cozero(A::Ports) = coplus(A, 0)
 # Cartesian category
 #-------------------
 
-mcopy(A::Ports{MonoidalCategoryWithDiagonals.Hom}, n::Int) = implicit_mcopy(A, n)
+mcopy(A::Ports{MonoidalCategoryWithDiagonals}, n::Int) = implicit_mcopy(A, n)
 
-mcopy(A::Ports{CartesianCategory.Hom}, n::Int) = implicit_mcopy(A, n)
+mcopy(A::Ports{CartesianCategory}, n::Int) = implicit_mcopy(A, n)
 
 # Cocartesian category
 #---------------------
 
-mmerge(A::Ports{MonoidalCategoryWithCodiagonals.Hom}, n::Int) = implicit_mmerge(A, n)
+mmerge(A::Ports{MonoidalCategoryWithCodiagonals}, n::Int) = implicit_mmerge(A, n)
 
-mmerge(A::Ports{CocartesianCategory.Hom}, n::Int) = implicit_mmerge(A, n)
+mmerge(A::Ports{CocartesianCategory}, n::Int) = implicit_mmerge(A, n)
 
 # Biproduct category
 #-------------------
 
 # The coherence laws relating diagonal to codiagonal do not hold for general
 # bidiagonals, so an explicit representation is needed.
-mcopy(A::Ports{MonoidalCategoryWithBidiagonals.Hom}, n::Int) = junctioned_mcopy(A, n)
-mmerge(A::Ports{MonoidalCategoryWithBidiagonals.Hom}, n::Int) = junctioned_mmerge(A, n)
+mcopy(A::Ports{MonoidalCategoryWithBidiagonals}, n::Int) = junctioned_mcopy(A, n)
+mmerge(A::Ports{MonoidalCategoryWithBidiagonals}, n::Int) = junctioned_mmerge(A, n)
 
-mcopy(A::Ports{BiproductCategory.Hom}, n::Int) = implicit_mcopy(A, n)
-mmerge(A::Ports{BiproductCategory.Hom}, n::Int) = implicit_mmerge(A, n)
+mcopy(A::Ports{BiproductCategory}, n::Int) = implicit_mcopy(A, n)
+mmerge(A::Ports{BiproductCategory}, n::Int) = implicit_mmerge(A, n)
 
 # Dagger category
 #----------------
 
-dagger(f::WiringDiagram{DaggerSymmetricMonoidalCategory.Hom}) =
+dagger(f::WiringDiagram{DaggerSymmetricMonoidalCategory}) =
   functor(f, identity, dagger, contravariant=true)
 
 # Compact closed category
@@ -277,18 +277,18 @@ dagger(f::WiringDiagram{DaggerSymmetricMonoidalCategory.Hom}) =
 junctioned_dunit(A::Ports) = junction_caps(A, otimes(dual(A),A))
 junctioned_dcounit(A::Ports) = junction_cups(A, otimes(A,dual(A)))
 
-dual(A::Ports{CompactClosedCategory.Hom}) = dual_ports(A)
-dunit(A::Ports{CompactClosedCategory.Hom}) = junctioned_dunit(A)
-dcounit(A::Ports{CompactClosedCategory.Hom}) = junctioned_dcounit(A)
-mate(f::WiringDiagram{CompactClosedCategory.Hom}) =
+dual(A::Ports{CompactClosedCategory}) = dual_ports(A)
+dunit(A::Ports{CompactClosedCategory}) = junctioned_dunit(A)
+dcounit(A::Ports{CompactClosedCategory}) = junctioned_dcounit(A)
+mate(f::WiringDiagram{CompactClosedCategory}) =
   functor(f, dual, mate, contravariant=true, monoidal_contravariant=true)
 
-dual(A::Ports{DaggerCompactCategory.Hom}) = dual_ports(A)
-dunit(A::Ports{DaggerCompactCategory.Hom}) = junctioned_dunit(A)
-dcounit(A::Ports{DaggerCompactCategory.Hom}) = junctioned_dcounit(A)
-dagger(f::WiringDiagram{DaggerCompactCategory.Hom}) =
+dual(A::Ports{DaggerCompactCategory}) = dual_ports(A)
+dunit(A::Ports{DaggerCompactCategory}) = junctioned_dunit(A)
+dcounit(A::Ports{DaggerCompactCategory}) = junctioned_dcounit(A)
+dagger(f::WiringDiagram{DaggerCompactCategory}) =
   functor(f, identity, dagger, contravariant=true)
-mate(f::WiringDiagram{DaggerCompactCategory.Hom}) =
+mate(f::WiringDiagram{DaggerCompactCategory}) =
   functor(f, dual, mate, contravariant=true, monoidal_contravariant=true)
 
 # Traced monoidal category
@@ -310,53 +310,50 @@ end
 
 const TracedMon = TracedMonoidalCategory
 
-trace(X::Ports{TracedMon.Hom}, A::Ports{TracedMon.Hom},
-      B::Ports{TracedMon.Hom}, f::WiringDiagram{TracedMon.Hom}) = trace(X, f)
+trace(X::Ports{TracedMon}, A::Ports{TracedMon},
+      B::Ports{TracedMon}, f::WiringDiagram{TracedMon}) = trace(X, f)
 
 # Bicategory of relations
 #------------------------
 
 const BiRel = BicategoryRelations
 
-mcopy(A::Ports{BiRel.Hom}, n::Int) = junctioned_mcopy(A, n)
-mmerge(A::Ports{BiRel.Hom}, n::Int) = junctioned_mmerge(A, n)
+mcopy(A::Ports{BiRel}, n::Int) = junctioned_mcopy(A, n)
+mmerge(A::Ports{BiRel}, n::Int) = junctioned_mmerge(A, n)
 
-dunit(A::Ports{BiRel.Hom}) = junction_caps(A)
-dcounit(A::Ports{BiRel.Hom}) = junction_cups(A)
+dunit(A::Ports{BiRel}) = junction_caps(A)
+dcounit(A::Ports{BiRel}) = junction_cups(A)
 
-dagger(f::WiringDiagram{BiRel.Hom}) =
+dagger(f::WiringDiagram{BiRel}) =
   functor(f, identity, dagger, contravariant=true)
 
-meet(f::WiringDiagram{BiRel.Hom}, g::WiringDiagram{BiRel.Hom}) =
+meet(f::WiringDiagram{BiRel}, g::WiringDiagram{BiRel}) =
   compose(mcopy(dom(f)), otimes(f,g), mmerge(codom(f)))
-top(A::Ports{BiRel.Hom}, B::Ports{BiRel.Hom}) =
-  compose(delete(A), create(B))
+top(A::Ports{BiRel}, B::Ports{BiRel}) = compose(delete(A), create(B))
 
 # Abelian bicategory of relations
 #--------------------------------
 
 const AbBiRel = AbelianBicategoryRelations
 
-mcopy(A::Ports{AbBiRel.Hom}, n::Int) = junctioned_mcopy(A, n; op=:times)
-mmerge(A::Ports{AbBiRel.Hom}, n::Int) = junctioned_mmerge(A, n; op=:times)
+mcopy(A::Ports{AbBiRel}, n::Int) = junctioned_mcopy(A, n; op=:times)
+mmerge(A::Ports{AbBiRel}, n::Int) = junctioned_mmerge(A, n; op=:times)
 
-dunit(A::Ports{AbBiRel.Hom}) = junction_caps(A; op=:times)
-dcounit(A::Ports{AbBiRel.Hom}) = junction_cups(A; op=:times)
+dunit(A::Ports{AbBiRel}) = junction_caps(A; op=:times)
+dcounit(A::Ports{AbBiRel}) = junction_cups(A; op=:times)
 
-plus(A::Ports{AbBiRel.Hom}, n::Int) = junctioned_mmerge(A, n, op=:plus)
-coplus(A::Ports{AbBiRel.Hom}, n::Int) = junctioned_mcopy(A, n, op=:plus)
+plus(A::Ports{AbBiRel}, n::Int) = junctioned_mmerge(A, n, op=:plus)
+coplus(A::Ports{AbBiRel}, n::Int) = junctioned_mcopy(A, n, op=:plus)
 
-dagger(f::WiringDiagram{AbBiRel.Hom}) =
+dagger(f::WiringDiagram{AbBiRel}) =
   functor(f, identity, dagger, contravariant=true)
 
-meet(f::WiringDiagram{AbBiRel.Hom}, g::WiringDiagram{AbBiRel.Hom}) =
+meet(f::WiringDiagram{AbBiRel}, g::WiringDiagram{AbBiRel}) =
   compose(mcopy(dom(f)), otimes(f,g), mmerge(codom(f)))
-join(f::WiringDiagram{AbBiRel.Hom}, g::WiringDiagram{AbBiRel.Hom}) =
+join(f::WiringDiagram{AbBiRel}, g::WiringDiagram{AbBiRel}) =
   compose(coplus(dom(f)), otimes(f,g), plus(codom(f)))
-top(A::Ports{AbBiRel.Hom}, B::Ports{AbBiRel.Hom}) =
-  compose(delete(A), create(B))
-bottom(A::Ports{AbBiRel.Hom}, B::Ports{AbBiRel.Hom}) =
-  compose(cozero(A), zero(B))
+top(A::Ports{AbBiRel}, B::Ports{AbBiRel}) = compose(delete(A), create(B))
+bottom(A::Ports{AbBiRel}, B::Ports{AbBiRel}) = compose(cozero(A), zero(B))
 
 # Operadic interface
 ####################

--- a/src/wiring_diagrams/Expressions.jl
+++ b/src/wiring_diagrams/Expressions.jl
@@ -28,8 +28,8 @@ using ..WiringDiagramAlgorithms: crossing_minimization_by_sort
 """ Convert a morphism expression into a wiring diagram.
 """
 function to_wiring_diagram(expr::GATExpr, args...)
-  theory = syntax_module(expr).theory()
-  to_wiring_diagram(theory.Hom, expr, args...)
+  T = syntax_module(expr).theory()
+  to_wiring_diagram(T, expr, args...)
 end
 function to_wiring_diagram(T::Type, expr::GATExpr)
   to_wiring_diagram(T, expr, first, first)

--- a/test/core/GAT.jl
+++ b/test/core/GAT.jl
@@ -165,7 +165,7 @@ axioms = [
 aliases = Dict(:⋅ => :compose, :→ => :Hom)
 category_theory = GAT.Theory(types, terms, axioms, aliases)
 
-@test Category.class().theory == category_theory
+@test Category.theory() == category_theory
 
 """ Equivalent shorthand definition of Category theory
 """
@@ -187,7 +187,7 @@ category_theory = GAT.Theory(types, terms, axioms, aliases)
   id(A) ⋅ f == f ⊣ (A::Ob, B::Ob, f::(A → B))
 end
 
-@test CategoryAbbrev.class().theory == category_theory
+@test CategoryAbbrev.theory() == category_theory
 
 # Methods for theory
 accessors = [ GAT.JuliaFunction(:(dom(::Hom)), :Ob),
@@ -198,10 +198,10 @@ alias_functions = [
   GAT.JuliaFunction(:(⋅(f::Hom, g::Hom)), :Hom, :(compose(f, g))),
   GAT.JuliaFunction(:(→(dom::Ob, codom::Ob)), :Hom, :(Hom(dom, codom))),
 ]
-@test GAT.accessors(Category.class().theory) == accessors
-@test GAT.constructors(Category.class().theory) == constructors
-@test GAT.alias_functions(Category.class().theory) == alias_functions
-@test GAT.interface(Category.class()) ==
+@test GAT.accessors(Category.theory()) == accessors
+@test GAT.constructors(Category.theory()) == constructors
+@test GAT.alias_functions(Category.theory()) == alias_functions
+@test GAT.interface(Category.theory()) ==
   [accessors; constructors; alias_functions]
 
 # Theory extension
@@ -227,12 +227,12 @@ theory = GAT.Theory(
   Dict{Symbol,Symbol}()
 )
 
-@test MonoidExt.class().theory == theory
+@test MonoidExt.theory() == theory
 
 # GAT expressions in a theory
 ################################
 
-theory = Category.class().theory
+theory = Category.theory()
 context = GAT.Context((:X => :Ob, :Y => :Ob, :Z => :Ob,
                        :f => :(Hom(X,Y)), :g => :(Hom(Y,Z))))
 @test GAT.expand_in_context(:X, [:f,:g], context, theory) == :(dom(f))

--- a/test/core/GAT.jl
+++ b/test/core/GAT.jl
@@ -133,10 +133,8 @@ end
   id(A) ⋅ f == f ⊣ (A::Ob, B::Ob, f::(A → B))
 end
 
-@test Category isa Module
+@test Category isa Type
 @test occursin("theory of categories", lowercase(string(Docs.doc(Category))))
-@test sort(names(Category)) == sort([:Category, :Ob, :Hom])
-@test Category.Ob isa Type && Category.Hom isa Type
 @test isempty(methods(dom)) && isempty(methods(codom))
 @test isempty(methods(id)) && isempty(methods(compose))
 
@@ -165,7 +163,7 @@ axioms = [
 aliases = Dict(:⋅ => :compose, :→ => :Hom)
 category_theory = GAT.Theory(types, terms, axioms, aliases)
 
-@test Category.theory() == category_theory
+@test GAT.theory(Category) == category_theory
 
 """ Equivalent shorthand definition of Category theory
 """
@@ -187,7 +185,7 @@ category_theory = GAT.Theory(types, terms, axioms, aliases)
   id(A) ⋅ f == f ⊣ (A::Ob, B::Ob, f::(A → B))
 end
 
-@test CategoryAbbrev.theory() == category_theory
+@test GAT.theory(CategoryAbbrev) == category_theory
 
 # Methods for theory
 accessors = [ GAT.JuliaFunction(:(dom(::Hom)), :Ob),
@@ -198,11 +196,11 @@ alias_functions = [
   GAT.JuliaFunction(:(⋅(f::Hom, g::Hom)), :Hom, :(compose(f, g))),
   GAT.JuliaFunction(:(→(dom::Ob, codom::Ob)), :Hom, :(Hom(dom, codom))),
 ]
-@test GAT.accessors(Category.theory()) == accessors
-@test GAT.constructors(Category.theory()) == constructors
-@test GAT.alias_functions(Category.theory()) == alias_functions
-@test GAT.interface(Category.theory()) ==
-  [accessors; constructors; alias_functions]
+theory = GAT.theory(Category)
+@test GAT.accessors(theory) == accessors
+@test GAT.constructors(theory) == constructors
+@test GAT.alias_functions(theory) == alias_functions
+@test GAT.interface(theory) == [accessors; constructors; alias_functions]
 
 # Theory extension
 @signature Semigroup(S) begin
@@ -214,7 +212,7 @@ end
   munit()::M
 end
 
-@test Semigroup isa Module && MonoidExt isa Module
+@test Semigroup isa Type && MonoidExt isa Type
 
 theory = GAT.Theory(
   [ GAT.TypeConstructor(:M, [], GAT.Context()) ],
@@ -225,12 +223,12 @@ theory = GAT.Theory(
   Dict{Symbol,Symbol}()
 )
 
-@test MonoidExt.theory() == theory
+@test GAT.theory(MonoidExt) == theory
 
 # GAT expressions in a theory
 ################################
 
-theory = Category.theory()
+theory = GAT.theory(Category)
 context = GAT.Context((:X => :Ob, :Y => :Ob, :Z => :Ob,
                        :f => :(Hom(X,Y)), :g => :(Hom(Y,Z))))
 @test GAT.expand_in_context(:X, [:f,:g], context, theory) == :(dom(f))

--- a/test/core/GAT.jl
+++ b/test/core/GAT.jl
@@ -133,12 +133,12 @@ end
   id(A) ⋅ f == f ⊣ (A::Ob, B::Ob, f::(A → B))
 end
 
-@test isa(Category, Module)
+@test Category isa Module
 @test occursin("theory of categories", lowercase(string(Docs.doc(Category))))
 @test sort(names(Category)) == sort([:Category, :Ob, :Hom])
-@test isa(Category.Ob, Type) && isa(Category.Hom, Type)
-@test isa(dom, Function) && isa(codom, Function)
-@test isa(id, Function) && isa(compose, Function)
+@test Category.Ob isa Type && Category.Hom isa Type
+@test isempty(methods(dom)) && isempty(methods(codom))
+@test isempty(methods(id)) && isempty(methods(compose))
 
 # Manually constructed theory of categories
 types = [
@@ -214,9 +214,7 @@ end
   munit()::M
 end
 
-@test isa(Semigroup, Module) && isa(MonoidExt, Module)
-@test length(methods(times)) == 2 # Semigroup.S, MonoidExt.M
-@test length(methods(munit)) == 1 # MonoidExt.M
+@test Semigroup isa Module && MonoidExt isa Module
 
 theory = GAT.Theory(
   [ GAT.TypeConstructor(:M, [], GAT.Context()) ],
@@ -283,7 +281,6 @@ end
   times(x::String, y::String) = string(x,y)
 end
 
-@test length(methods(munit)) == 3 # Monoid, MonoidExt, String
 @test munit(String) == ""
 @test times("a", "b") == "ab"
 

--- a/test/core/Syntax.jl
+++ b/test/core/Syntax.jl
@@ -32,6 +32,8 @@ Elem(mod::Module, args...) = Elem(mod.Elem, args...)
 x, y, z = Elem(FreeMonoid,:x), Elem(FreeMonoid,:y), Elem(FreeMonoid,:z)
 @test isa(mtimes(x,y), FreeMonoid.Elem)
 @test isa(munit(FreeMonoid.Elem), FreeMonoid.Elem)
+@test gat_typeof(x) == :Elem
+@test gat_typeof(mtimes(x,y)) == :Elem
 @test mtimes(mtimes(x,y),z) != mtimes(x,mtimes(y,z))
 
 # Test equality
@@ -86,6 +88,7 @@ x = elem_int(FreeMonoidNumeric.Elem, 1)
   one()::Elem
   two()::Elem
 end
+
 """ The free monoid on two generators.
 """
 @syntax FreeMonoidTwo MonoidTwo begin

--- a/test/programs/ParseJuliaPrograms.jl
+++ b/test/programs/ParseJuliaPrograms.jl
@@ -29,7 +29,7 @@ f, g, h, m, n = generators(C, [:f, :g, :h, :m, :n])
 
 parsed = @program(C, (x::X) -> f(x))
 @test parsed == to_wiring_diagram(f)
-@test parsed isa WiringDiagram{BiproductCategory.Hom}
+@test parsed isa WiringDiagram{BiproductCategory}
 
 # Composition: one-dimensional.
 

--- a/test/wiring_diagrams/Algebraic.jl
+++ b/test/wiring_diagrams/Algebraic.jl
@@ -94,7 +94,7 @@ A = Ports([:A])
 @test compose(mcopy(A), otimes(id(A),delete(A))) == id(A)
 
 # Cartesian categories
-A = Ports{CartesianCategory.Hom}([:A])
+A = Ports{CartesianCategory}([:A])
 @test mcopy(A) == mcopy(Ports([:A]))
 @test delete(A) == delete(Ports([:A]))
 @test_throws MethodError mmerge(A)
@@ -121,7 +121,7 @@ A = Ports([:A])
 @test compose(otimes(id(A),create(A)), mmerge(A)) == id(A)
 
 # Cocartesian categories
-A = Ports{CocartesianCategory.Hom}([:A])
+A = Ports{CocartesianCategory}([:A])
 @test mmerge(A) == mmerge(Ports([:A]))
 @test create(A) == create(Ports([:A]))
 @test_throws MethodError mcopy(A)
@@ -132,22 +132,22 @@ A = Ports{CocartesianCategory.Hom}([:A])
 
 # Monoidal categories with bidiagonals, and non-naturality of explicit
 # representation.
-A = Ports{MonoidalCategoryWithBidiagonals.Hom}([:A])
+A = Ports{MonoidalCategoryWithBidiagonals}([:A])
 @test boxes(mcopy(A)) == [ Junction(:A,1,2) ]
 @test boxes(mcopy(otimes(A,A))) == repeat([ Junction(:A,1,2) ], 2)
 @test compose(create(A), mcopy(A)) != create(otimes(A,A))
 @test compose(mmerge(A), delete(A)) != delete(otimes(A,A))
 
 # Biproduct categories, and naturality of implicit representation.
-A = Ports{BiproductCategory.Hom}([:A])
+A = Ports{BiproductCategory}([:A])
 @test compose(create(A), mcopy(A)) == create(otimes(A,A))
 @test compose(mmerge(A), delete(A)) == delete(otimes(A,A))
 
 # Dagger category
 #----------------
 
-f = singleton_diagram(DaggerSymmetricMonoidalCategory.Hom, Box(:f,[:A],[:B]))
-g = singleton_diagram(DaggerSymmetricMonoidalCategory.Hom, Box(:g,[:B],[:A]))
+f = singleton_diagram(DaggerSymmetricMonoidalCategory, Box(:f,[:A],[:B]))
+g = singleton_diagram(DaggerSymmetricMonoidalCategory, Box(:g,[:B],[:A]))
 
 @test boxes(dagger(f)) == [ BoxOp{:dagger}(Box(:f,[:A],[:B])) ]
 
@@ -169,7 +169,7 @@ g = singleton_diagram(DaggerSymmetricMonoidalCategory.Hom, Box(:g,[:B],[:A]))
 
 ### Duals
 
-A, B = [ Ports{CompactClosedCategory.Hom}([sym]) for sym in [:A, :B] ]
+A, B = [ Ports{CompactClosedCategory}([sym]) for sym in [:A, :B] ]
 I = munit(typeof(A))
 
 @test boxes(dunit(A)) == [ Junction(:A, [], [PortOp{:dual}(:A), :A]) ]
@@ -189,8 +189,8 @@ I = munit(typeof(A))
 
 ### Adjoint mates
 
-f = singleton_diagram(CompactClosedCategory.Hom, Box(:f,[:A],[:B]))
-g = singleton_diagram(CompactClosedCategory.Hom, Box(:g,[:B],[:A]))
+f = singleton_diagram(CompactClosedCategory, Box(:f,[:A],[:B]))
+g = singleton_diagram(CompactClosedCategory, Box(:g,[:B],[:A]))
 
 @test boxes(mate(f)) == [ BoxOp{:mate}(Box(:f,[:A],[:B])) ]
 
@@ -211,32 +211,32 @@ g = singleton_diagram(CompactClosedCategory.Hom, Box(:g,[:B],[:A]))
 #-------------------------
 
 const TracedMon = TracedMonoidalCategory
-A, B, X, Y = [ Ports{TracedMon.Hom}([sym]) for sym in [:A,:B,:X,:Y] ]
+A, B, X, Y = [ Ports{TracedMon}([sym]) for sym in [:A,:B,:X,:Y] ]
 I = munit(typeof(A))
-f = singleton_diagram(TracedMon.Hom, Box(:f, [:X,:A], [:X,:B]))
+f = singleton_diagram(TracedMon, Box(:f, [:X,:A], [:X,:B]))
 
 # Domain and codomain
 @test dom(trace(X, A, B, f)) == A
 @test codom(trace(X, A, B, f)) == B
 
 # Naturality
-g = singleton_diagram(TracedMon.Hom, Box(:g, [:A], [:A]))
-h = singleton_diagram(TracedMon.Hom, Box(:h, [:B], [:B]))
+g = singleton_diagram(TracedMon, Box(:g, [:A], [:A]))
+h = singleton_diagram(TracedMon, Box(:h, [:B], [:B]))
 @test trace(X, compose(id(X)⊗g, f, id(X)⊗h)) == compose(g, trace(X,f), h)
 
 # Stength, aka superposing
-g = singleton_diagram(TracedMon.Hom, Box(:g, [:C], [:C]))
+g = singleton_diagram(TracedMon, Box(:g, [:C], [:C]))
 @test trace(X, otimes(f,g)) == otimes(trace(X,f), g)
 
 # Symmetry sliding
-f = singleton_diagram(TracedMon.Hom, Box(:f, [:X,:Y,:A], [:Y,:X,:B]))
+f = singleton_diagram(TracedMon, Box(:f, [:X,:Y,:A], [:Y,:X,:B]))
 @test trace(X⊗Y, compose(f, braid(Y,X)⊗id(B))) ==
   trace(Y⊗X, compose(braid(Y,X)⊗id(A), f))
 
 # Vanishing
-f = singleton_diagram(TracedMon.Hom, Box(:f, [:X,:Y,:A], [:X,:Y,:B]))
+f = singleton_diagram(TracedMon, Box(:f, [:X,:Y,:A], [:X,:Y,:B]))
 @test trace(X⊗Y, f) == trace(Y, trace(X, f))
-f = singleton_diagram(TracedMon.Hom, Box(:f, [:A], [:B]))
+f = singleton_diagram(TracedMon, Box(:f, [:A], [:B]))
 @test trace(I, f) == f
 
 # Yanking
@@ -245,9 +245,9 @@ f = singleton_diagram(TracedMon.Hom, Box(:f, [:A], [:B]))
 # Bicategory of relations
 #------------------------
 
-A, B = [ Ports{BicategoryRelations.Hom}([sym]) for sym in [:A, :B] ]
-R = singleton_diagram(BicategoryRelations.Hom, Box(:R,[:A],[:B]))
-S = singleton_diagram(BicategoryRelations.Hom, Box(:S,[:A],[:B]))
+A, B = [ Ports{BicategoryRelations}([sym]) for sym in [:A, :B] ]
+R = singleton_diagram(BicategoryRelations, Box(:R,[:A],[:B]))
+S = singleton_diagram(BicategoryRelations, Box(:S,[:A],[:B]))
 
 # Domains and codomains
 @test dom(meet(R,S)) == A
@@ -262,9 +262,9 @@ S = singleton_diagram(BicategoryRelations.Hom, Box(:S,[:A],[:B]))
 # Abelian bicategory of relations
 #--------------------------------
 
-A, B = [ Ports{AbelianBicategoryRelations.Hom}([sym]) for sym in [:A, :B] ]
-R = singleton_diagram(AbelianBicategoryRelations.Hom, Box(:R,[:A],[:B]))
-S = singleton_diagram(AbelianBicategoryRelations.Hom, Box(:S,[:A],[:B]))
+A, B = [ Ports{AbelianBicategoryRelations}([sym]) for sym in [:A, :B] ]
+R = singleton_diagram(AbelianBicategoryRelations, Box(:R,[:A],[:B]))
+S = singleton_diagram(AbelianBicategoryRelations, Box(:S,[:A],[:B]))
 
 # Domains and codomains.
 @test dom(plus(A)) == dom(mmerge(A)) && codom(plus(A)) == codom(mmerge(A))


### PR DESCRIPTION
Some first steps towards refactoring the GAT system (see #165):

- The `Typeclass` wrapper struct, a holdover from the days when GATs mixed with Julia code, has been removed.
- The `@theory`/`@signature` macros no longer generate a whole module with stub Julia types. Instead, they generate a single abstract type representing the theory, e.g. an abstract type `Category`. The theory of categories can then be retrieved by calling `theory(Category)`. So we are now abusing the module system somewhat less.
- The stub methods generated by `@theory`/`@signature` have been replaced with a mere generic function declaration, reducing the size of the method tables for `compose`, `id`, etc by about a half. (I don't know why I didn't do this before. Probably because when I first wrote that code I barely knew Julia.)

Most of these changes will be invisible to most users. The main breaking change is that instead of writing `Port{CartesianCategory.Hom}` and `WiringDiagram{CartesianCategory.Hom}`, we will now write `Port{CartesianCategory}` and `WiringDiagram{CartesianCategory}`, which is cleaner anyway.