### PR TITLE
Proper typing of presentations

### DIFF
--- a/src/core/Present.jl
+++ b/src/core/Present.jl
@@ -9,8 +9,7 @@ in applications like knowledge representation.
 """
 module Present
 export @present, Presentation, Equation, generator, generators, has_generator,
-  equations, add_generator!, add_generators!, add_definition!, add_equation!,
-  merge_presentation!
+  equations, add_generator!, add_generators!, add_definition!, add_equation!
 
 using Base.Meta: ParseError
 using Compat
@@ -104,17 +103,6 @@ function add_definition!(pres::Presentation, name::Symbol, rhs::GATExpr)
   add_generator!(pres, generator)
   add_equation!(pres, generator, rhs)
   return generator
-end
-
-""" Merge the second presentation into the first.
-
-The first presentation is mutated and returned; the second is not.
-"""
-function merge_presentation!(pres::Presentation{T}, other::Presentation{T}) where T
-  union!(pres.generators, other.generators)
-  merge!(pres.generators_by_name, other.generators_by_name)
-  union!(pres.equations, other.equations)
-  return pres
 end
 
 # Presentation macro

--- a/src/core/Present.jl
+++ b/src/core/Present.jl
@@ -23,6 +23,7 @@ import ..Syntax: parse_json_sexpr, to_json_sexpr
 ############
 
 struct Presentation{Theory,Name}
+  syntax::Module
   generators::NamedTuple
   generator_name_index::Dict{Name,Pair{Symbol,Int}}
   equations::Vector{Pair}
@@ -32,7 +33,7 @@ struct Presentation{Theory,Name}
     theory = GAT.theory(Theory)
     names = Tuple(type.name for type in theory.types)
     vectors = ((getfield(syntax, name){:generator})[] for name in names)
-    new{Theory,Name}(NamedTuple{names}(vectors),
+    new{Theory,Name}(syntax, NamedTuple{names}(vectors),
                      Dict{Name,Pair{Symbol,Int}}(), Pair[])
   end
 end

--- a/src/programs/ParseJuliaPrograms.jl
+++ b/src/programs/ParseJuliaPrograms.jl
@@ -64,10 +64,8 @@ function parse_wiring_diagram(pres::Presentation, expr::Expr)::WiringDiagram
 end
 
 function parse_wiring_diagram(pres::Presentation, call::Expr0, body::Expr)::WiringDiagram
-  # FIXME: Presentations should be uniquely associated with syntax systems.
-  syntax_module = Syntax.syntax_module(first(pres.generators))
-
   # Parse argument names and types from call expression.
+  syntax_module = pres.syntax
   call_args = @match call begin
     Expr(:call, [name, args...]) => args
     Expr(:tuple, args) => args

--- a/test/core/Present.jl
+++ b/test/core/Present.jl
@@ -3,6 +3,8 @@ module TestPresentation
 using Test
 using Catlab, Catlab.Theories
 
+presentation_theory(::Presentation{Theory}) where Theory = Theory
+
 # Presentation
 ##############
 
@@ -11,7 +13,8 @@ f = Hom(:f, A, B)
 g = Hom(:g, B, C)
 
 # Generators
-pres = Presentation{Category}()
+pres = Presentation(FreeCategory)
+@test presentation_theory(pres) == Category
 @test !has_generator(pres, :A)
 add_generator!(pres, A)
 @test generators(pres) == [ A ]
@@ -23,10 +26,10 @@ add_generator!(pres, B)
 
 add_generators!(pres, (f,g))
 @test generators(pres) == [ A, B, f, g ]
+@test generators(pres, :Ob) == [ A, B ]
+@test generators(pres, :Hom) == [ f, g ]
 @test generators(pres, FreeCategory.Ob) == [ A, B ]
 @test generators(pres, FreeCategory.Hom) == [ f, g ]
-@test generators(pres, (:A, :B)) == [ A, B ]
-@test generators(pres, [:f, :g]) == [ f, g ]
 
 # Presentation macro
 ####################
@@ -57,12 +60,11 @@ add_generators!(pres, (f,g))
 end
 
 # Check type parameter.
-presentation_theory(::Presentation{Theory}) where Theory = Theory
 @test presentation_theory(Company) == Category
 
 # Check generators.
 Employee, Department, Str = Ob(FreeCategory, :Employee, :Department, :Str)
-@test collect(generators(Company)) == [
+@test generators(Company) == [
   Employee,
   Department,
   Str,
@@ -79,7 +81,7 @@ Employee, Department, Str = Ob(FreeCategory, :Employee, :Department, :Str)
 manager = Hom(:manager, Employee, Employee)
 works_in = Hom(:works_in, Employee, Department)
 secretary = Hom(:secretary, Department, Employee)
-@test collect(equations(Company)) == Equation[
+@test equations(Company) == [
   Hom(:second_level_manager, Employee, Employee) => compose(manager, manager),
   Hom(:third_level_manager, Employee, Employee) => compose(manager, manager, manager),
   compose(manager, works_in) => works_in,

--- a/test/core/Present.jl
+++ b/test/core/Present.jl
@@ -11,7 +11,7 @@ f = Hom(:f, A, B)
 g = Hom(:g, B, C)
 
 # Generators
-pres = Presentation()
+pres = Presentation{Category}()
 @test !has_generator(pres, :A)
 add_generator!(pres, A)
 @test generators(pres) == [ A ]
@@ -55,6 +55,10 @@ add_generators!(pres, (f,g))
   # The secretary of a department works in that department.
   compose(secretary, works_in) == id(Department)
 end
+
+# Check type parameter.
+presentation_theory(::Presentation{Theory}) where Theory = Theory
+@test presentation_theory(Company) == Category
 
 # Check generators.
 Employee, Department, Str = Ob(FreeCategory, :Employee, :Department, :Str)

--- a/test/core/Present.jl
+++ b/test/core/Present.jl
@@ -28,17 +28,6 @@ add_generators!(pres, (f,g))
 @test generators(pres, (:A, :B)) == [ A, B ]
 @test generators(pres, [:f, :g]) == [ f, g ]
 
-# Merge presentations
-pres = Presentation()
-add_generators!(pres, (A, B, f))
-other = Presentation()
-add_generators!(other, (B, C, g))
-merge_presentation!(pres, other)
-@test generator(pres, :f) == f
-@test generator(pres, :g) == g
-@test generators(pres, FreeCategory.Ob) == [ A, B, C ]
-@test generators(pres, FreeCategory.Hom) == [ f, g ]
-
 # Presentation macro
 ####################
 

--- a/test/programs/ParseJuliaPrograms.jl
+++ b/test/programs/ParseJuliaPrograms.jl
@@ -22,8 +22,8 @@ end
 # Parsing
 #########
 
-W, X, Y, Z = generators(C, [:W, :X, :Y, :Z])
-f, g, h, m, n = generators(C, [:f, :g, :h, :m, :n])
+W, X, Y, Z = (generator(C, name) for name in [:W, :X, :Y, :Z])
+f, g, h, m, n = (generator(C, name) for name in [:f, :g, :h, :m, :n])
 
 # Generator.
 
@@ -178,7 +178,7 @@ function test_roundtrip(f::HomExpr)
   @test roundtrip(f) == to_wiring_diagram(f)
 end
 
-f, g, h, l, m, n = generators(C, [:f, :g, :h, :l, :m, :n])
+f, g, h, l, m, n = (generator(C, name) for name in [:f, :g, :h, :l, :m, :n])
 
 test_roundtrip(f)
 test_roundtrip(id(X))


### PR DESCRIPTION
Clean up to the presentation system, enabled by #175:

- Type parameterize presentations by theory, so that a presentation of a category will have type `Presentation{Category}`. This fixes a longstanding known issue.
- Index generators by GAT type, so that, for example, it is fast to retrieve all the object generators, or all the morphism generators, in a presentation of a category.