### PR TITLE
The distributive bicategory of relations FinOrdRel

### DIFF
--- a/src/categorical_algebra/FinRelations.jl
+++ b/src/categorical_algebra/FinRelations.jl
@@ -33,6 +33,7 @@ end
 
 Base.zero(::Type{BoolRig}) = BoolRig(false)
 Base.one(::Type{BoolRig}) = BoolRig(true)
+Base.float(x::BoolRig) = float(x.value)
 Base.show(io::IO, x::BoolRig) = print(io, x.value)
 
 # Category of finite ordinals and relations

--- a/src/categorical_algebra/FinRelations.jl
+++ b/src/categorical_algebra/FinRelations.jl
@@ -1,28 +1,127 @@
 """ Computing in the category of finite sets and relations, and its skeleton.
 """
 module FinRelations
-export BoolRig, RelationMatrix
+export BoolRig, FinOrdRelOb, FinOrdRelation, force
 
-import Base: +, *, zero, one
+import Base: +, *
 using AutoHashEquals
 
+using ...GAT
+using ...Theories: Category
+import ...Theories: dom, codom, id, compose, ⋅, ∘
+import ..FinSets: force
 using ..Matrices
+using ..Matrices: zero_matrix
+
+# Rig of booleans
+#################
 
 """ The rig of booleans.
 
 This struct is needed because in base Julia, the product of booleans is another
-boolean, but a sum of booleans is coerced to an integer: `true + true == 2`.
+boolean, but the sum of booleans is coerced to an integer: `true + true == 2`.
 """
-@auto_hash_equals struct BoolRig
+@auto_hash_equals struct BoolRig <: Number
   value::Bool
 end
-+(x::BoolRig, y::BoolRig) = x.value || y.value
-*(x::BoolRig, y::BoolRig) = x.value && y.value
-zero(::Type{BoolRig}) = false
-one(::Type{BoolRig}) = true
 
-""" A relation matrix, also known as a boolean matrix or logical matrix.
++(x::BoolRig, y::BoolRig) = BoolRig(x.value || y.value)
+*(x::BoolRig, y::BoolRig) = BoolRig(x.value && y.value)
+
+Base.zero(::Type{BoolRig}) = BoolRig(false)
+Base.one(::Type{BoolRig}) = BoolRig(true)
+Base.show(io::IO, x::BoolRig) = print(io, x.value)
+
+# Category of finite ordinals and relations
+###########################################
+
+""" Finite ordinal (natural number).
+
+An object in the category `FinOrdRel` of finite ordinals and relations, which is
+the skeleton of the category `FinRel` of finite sets and relations.
 """
-const RelationMatrix = AbstractMatrix{BoolRig}
+@auto_hash_equals struct FinOrdRelOb
+  n::Int
+end
+Base.eachindex(X::FinOrdRelOb) = 1:X.n
+
+""" Binary relation between sets in the form of finite ordinals.
+
+A morphism in the category `FinOrdRel` of finite ordinals and relations, which
+is the skeleton of the category `FinRel` of finite sets and relations. The
+relation can be represented implicitly by an arbitrary Julia function mapping
+pairs of integers to booleans or explicitly by a matrix (dense or sparse) taking
+values in the rig of booleans ([`BoolRig`](@ref)).
+"""
+abstract type FinOrdRelation end
+
+FinOrdRelation(R, dom::FinOrdRelOb, codom::FinOrdRelOb) =
+  FinOrdRelation(R, dom.n, codom.n)
+
+""" Relation in FinOrdRel represented by an arbitrary Julia function.
+"""
+@auto_hash_equals struct FinOrdRelationLazy <: FinOrdRelation
+  rel::Function
+  dom::Int
+  codom::Int
+end
+FinOrdRelation(R::Function, dom::Int, codom::Int) =
+  FinOrdRelationLazy(R, dom, codom)
+
+(R::FinOrdRelationLazy)(x, y) = R.rel(x, y)
+
+""" Relation in FinOrdRel represented by a boolean matrix.
+
+Boolean matrices are also known as logical matrices or relation matrices.
+"""
+@auto_hash_equals struct FinOrdRelationMatrix{T <: AbstractMatrix{BoolRig}} <: FinOrdRelation
+  rel::T
+end
+
+FinOrdRelation(R::AbstractMatrix{BoolRig}) = FinOrdRelationMatrix(R)
+
+function FinOrdRelation(R::AbstractMatrix{BoolRig}, dom::Int, codom::Int)
+  @assert size(R,2) == dom && size(R,1) == codom
+  FinOrdRelationMatrix(R)
+end
+
+(R::FinOrdRelationMatrix)(x, y) = R.rel[y, x].value
+
+function force(::Type{T}, R::FinOrdRelation) where T <: AbstractMatrix{BoolRig}
+  m, n = dom(R).n, codom(R).n
+  M = zero_matrix(T, n, m)
+  for i in 1:m, j in 1:n
+    if R(i,j)
+      M[j,i] = BoolRig(true)
+    end
+  end
+  FinOrdRelationMatrix(M)
+end
+force(::Type{T}, R::FinOrdRelationMatrix{T}) where T <: AbstractMatrix{BoolRig} = R
+force(R::FinOrdRelation) = force(Matrix{BoolRig}, R)
+
+""" Category of finite ordinals and relations.
+"""
+@instance Category(FinOrdRelOb, FinOrdRelation) begin
+  dom(R::FinOrdRelation) = FinOrdRelOb(R.dom)
+  codom(R::FinOrdRelation) = FinOrdRelOb(R.codom)
+
+  id(X::FinOrdRelOb) = FinOrdRelation((x1,x2) -> x1 == x2, X, X)
+
+  function compose(R::FinOrdRelation, S::FinOrdRelation)
+    @assert codom(R) == dom(S)
+    FinOrdRelation(compose_impl(R,S), dom(R), codom(S))
+  end
+end
+
+dom(R::FinOrdRelationMatrix) = FinOrdRelOb(size(R.rel, 2))
+codom(R::FinOrdRelationMatrix) = FinOrdRelOb(size(R.rel, 1))
+
+function compose_impl(R::FinOrdRelation, S::FinOrdRelation)
+  (x,z) -> any(R(x,y) && S(y,z) for y in eachindex(codom(R)))
+end
+function compose_impl(R::FinOrdRelationMatrix, S::FinOrdRelationMatrix)
+  compose(R.rel, S.rel)
+end
 
 end

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -13,8 +13,8 @@ import ...Theories: dom, codom, id, compose, ⋅, ∘,
   terminal, product, equalizer, initial, coproduct, coequalizer
 using ..ShapeDiagrams
 
-# Data types
-############
+# Category of finite ordinals
+#############################
 
 """ Finite ordinal (natural number).
 
@@ -47,10 +47,10 @@ To be evaluated lazily unless forced.
   dom::Int
   codom::Int
 end
-(f::FinOrdFunctionLazy)(i) = f.func(i)
-
 FinOrdFunction(f::Function, dom::Int, codom::Int) =
   FinOrdFunctionLazy(f, dom, codom)
+
+(f::FinOrdFunctionLazy)(x) = f.func(x)
 
 """ Function in FinOrd represented explicitly by a vector.
 """
@@ -58,8 +58,6 @@ FinOrdFunction(f::Function, dom::Int, codom::Int) =
   func::T
   codom::Int
 end
-(f::FinOrdFunctionMap)(i) = f.func[i]
-
 FinOrdFunction(f::AbstractVector) = FinOrdFunctionMap(f, maximum(f))
 FinOrdFunction(f::AbstractVector, codom::Int) = FinOrdFunctionMap(f, codom)
 
@@ -68,14 +66,15 @@ function FinOrdFunction(f::AbstractVector, dom::Int, codom::Int)
   FinOrdFunctionMap(f, codom)
 end
 
-""" Force evaluation of function, yielding the vector representation.
+(f::FinOrdFunctionMap)(x) = f.func[x]
+
+""" Force evaluation of lazy function or relation.
 """
 force(f::FinOrdFunction) = FinOrdFunctionMap(map(f, 1:dom(f).n), codom(f).n)
 force(f::FinOrdFunctionMap) = f
 
-# Category of finite ordinals
-#############################
-
+""" Category of finite ordinals and functions.
+"""
 @instance Category(FinOrd, FinOrdFunction) begin
   dom(f::FinOrdFunction) = FinOrd(f.dom)
   codom(f::FinOrdFunction) = FinOrd(f.codom)

--- a/src/categorical_algebra/Matrices.jl
+++ b/src/categorical_algebra/Matrices.jl
@@ -88,7 +88,7 @@ zero(m::MatrixDom{M}, n::MatrixDom{M}) where M = zero_matrix(M, m.dim, n.dim)
 blockdiag(A::AbstractMatrix...) = cat(A..., dims=(1,2))
 
 # Dense and sparse matrices have different APIs for creating zero matrices.
-zero_matrix(::Type{<:AbstractMatrix{T}}, dims...) where T = zeros(T, dims...)
+zero_matrix(::Type{Matrix{T}}, dims...) where T = zeros(T, dims...)
 zero_matrix(::Type{SparseMatrixCSC{T}}, dims...) where T = spzeros(T, dims...)
 
 function unit_vector(::Type{M}, n::Int, i::Int) where {T, M <: AbstractMatrix{T}}

--- a/src/theories/MonoidalMultiple.jl
+++ b/src/theories/MonoidalMultiple.jl
@@ -57,6 +57,18 @@ FIXME: Should also inherit `CocartesianCategory`.
   zero(A)⋅f == zero(B) ⊣ (A::Ob, B::Ob, f::(A → B))
 end
 
+""" Theory of a *distributive monoidal category with diagonals*
+
+FIXME: Should also inherit `MonoidalCategoryWithDiagonals`.
+"""
+@theory DistributiveMonoidalCategory(Ob,Hom) =>
+    DistributiveMonoidalCategoryWithDiagonals(Ob,Hom) begin
+  mcopy(A::Ob)::(A → (A ⊗ A))
+  @op (Δ) := mcopy
+  delete(A::Ob)::(A → munit())
+  @op (◊) := delete
+end
+
 """ Theory of a *distributive semiadditive category*
 
 This terminology is not standard but the concept occurs frequently. A
@@ -88,12 +100,7 @@ is the cartesian product, see [`DistributiveMonoidalCategory`](@ref).
 
 FIXME: Should also inherit `CartesianCategory`.
 """
-@theory DistributiveMonoidalCategory(Ob,Hom) => DistributiveCategory(Ob,Hom) begin
-  mcopy(A::Ob)::(A → (A ⊗ A))
-  @op (Δ) := mcopy
-  delete(A::Ob)::(A → munit())
-  @op (◊) := delete
-  
+@theory DistributiveMonoidalCategoryWithDiagonals(Ob,Hom) => DistributiveCategory(Ob,Hom) begin
   pair(f::(A → B), g::(A → C))::(A → (B ⊗ C)) ⊣ (A::Ob, B::Ob, C::Ob)
   proj1(A::Ob, B::Ob)::((A ⊗ B) → A)
   proj2(A::Ob, B::Ob)::((A ⊗ B) → B)

--- a/src/theories/Relations.jl
+++ b/src/theories/Relations.jl
@@ -1,5 +1,6 @@
 export BicategoryRelations, FreeBicategoryRelations,
   AbelianBicategoryRelations, FreeAbelianBicategoryRelations,
+  DistributiveBicategoryRelations,
   meet, join, top, bottom, plus, zero, coplus, cozero
 
 import Base: join, zero
@@ -19,7 +20,7 @@ References:
 """
 @signature MonoidalCategoryWithBidiagonals(Ob,Hom) => BicategoryRelations(Ob,Hom) begin
   # Self-dual dagger compact category.
-  dagger(R::(A → B))::(B → A) ⊣ (A::Ob,B::Ob)
+  dagger(R::(A → B))::(B → A) ⊣ (A::Ob, B::Ob)
   dunit(A::Ob)::(munit() → (A ⊗ A))
   dcounit(A::Ob)::((A ⊗ A) → munit())
 
@@ -50,7 +51,7 @@ References:
 @signature MonoidalCategoryWithBidiagonalsAdditive(Ob,Hom) =>
     AbelianBicategoryRelations(Ob,Hom) begin
   # Self-dual dagger compact category.
-  dagger(R::(A → B))::(B → A) ⊣ (A::Ob,B::Ob)
+  dagger(R::(A → B))::(B → A) ⊣ (A::Ob, B::Ob)
   dunit(A::Ob)::(mzero() → (A ⊕ A))
   dcounit(A::Ob)::((A ⊕ A) → mzero())
 
@@ -81,4 +82,44 @@ end
   join(R::Hom, S::Hom) = compose(coplus(dom(R)), oplus(R,S), plus(codom(R)))
   top(A::Ob, B::Ob) = compose(delete(A), create(B))
   bottom(A::Ob, B::Ob) = compose(cozero(A), zero(B))
+end
+
+""" Theory of a *distributive bicategory of relations*
+
+References:
+  - Carboni & Walters, 1987, "Cartesian bicategories I", Remark 3.7 (mention
+    in passing only)
+  - Patterson, 2017, "Knowledge representation in bicategories of relations",
+    Section 9.2
+
+FIXME: Should also inherit `BicategoryOfRelations`, but multiple inheritance is
+not yet supported.
+"""
+@signature DistributiveMonoidalCategoryWithDiagonals(Ob,Hom) =>
+    DistributiveBicategoryRelations(Ob,Hom) begin
+  # Self-dual dagger compact category.
+  dagger(R::(A → B))::(B → A) ⊣ (A::Ob, B::Ob)
+  dunit(A::Ob)::(munit() → (A ⊗ A))
+  dcounit(A::Ob)::((A ⊗ A) → munit())
+  
+  # Merging and creating (right adjoints of copying and deleting maps).
+  mmerge(A::Ob)::((A ⊗ A) → A)
+  @op (∇) := mmerge
+  create(A::Ob)::(munit() → A)
+  @op (□) := create
+
+  # Co-addition and co-zero (right adjoints of addition and zero maps).
+  coplus(A::Ob)::(A → (A ⊕ A))
+  cozero(A::Ob)::(A → mzero())
+  
+  # The coproduct is automatically a biproduct, due to compact closed structure.
+  pair(R::(A → B), S::(A → C))::(A → (B ⊕ C)) ⊣ (A::Ob, B::Ob, C::Ob)
+  proj1(A::Ob, B::Ob)::((A ⊕ B) → A)
+  proj2(A::Ob, B::Ob)::((A ⊕ B) → B)
+  
+  # Logical operations.
+  meet(R::(A → B), S::(A → B))::(A → B) ⊣ (A::Ob, B::Ob)
+  top(A::Ob, B::Ob)::(A → B)
+  join(R::(A → B), S::(A → B))::(A → B) ⊣ (A::Ob, B::Ob)
+  bottom(A::Ob, B::Ob)::(A → B)
 end

--- a/test/categorical_algebra/CategoricalAlgebra.jl
+++ b/test/categorical_algebra/CategoricalAlgebra.jl
@@ -14,6 +14,10 @@ end
   include("FinSets.jl")
 end
 
+@testset "FinRelations" begin
+  include("FinRelations.jl")
+end
+
 @testset "Permutations" begin
   include("Permutations.jl")
 end

--- a/test/categorical_algebra/FinRelations.jl
+++ b/test/categorical_algebra/FinRelations.jl
@@ -26,8 +26,16 @@ A_mat, B_mat = MatrixDom{Matrix{BoolRig}}(A.n), MatrixDom{Matrix{BoolRig}}(B.n)
 @test force(R ⋅ S) == R_mat ⋅ S_mat
 @test force(R ⋅ id(codom(R))) == R_mat
 @test force(id(dom(R)) ⋅ R) == R_mat
+@test force(dagger(R)) == dagger(R_mat)
 
 @test force(R ⊗ S) == R_mat ⊗ S_mat
 @test force(braid(A, B)) == FinOrdRelation(braid(A_mat, B_mat))
+
+S = FinOrdRelation((x,y) -> (x+y) % 2 == 0, 10, 5)
+S_mat = force(S)
+@test force(meet(R, S)) == meet(R_mat, S_mat)
+@test force(mcopy(dom(R))⋅(R⊗S)⋅mmerge(codom(R))) == meet(R_mat, S_mat)
+@test force(top(A, B)) == FinOrdRelation(ones(BoolRig, B.n, A.n))
+@test force(delete(A)⋅create(B)) == FinOrdRelation(ones(BoolRig, B.n, A.n))
 
 end

--- a/test/categorical_algebra/FinRelations.jl
+++ b/test/categorical_algebra/FinRelations.jl
@@ -2,23 +2,32 @@ module TestFinRelations
 using Test
 
 using Catlab.Theories, Catlab.CategoricalAlgebra.FinRelations
+using Catlab.CategoricalAlgebra.Matrices: MatrixDom
 
 # Category of finite ordinals and relations
 ###########################################
 
 R = FinOrdRelation(Matrix{BoolRig}([true false true; false true false]))
-S = FinOrdRelation(Matrix{BoolRig}([false true; true false]))
+@test dom(R) == FinOrdRelOb(3)
+@test codom(R) == FinOrdRelOb(2)
 
 # Evaluation.
 @test map(R, [1,3], [1,2]) == [true, false]
 @test map(id(FinOrdRelOb(3)), [1,1], [1,2]) == [true, false]
 @test map(FinOrdRelation((x,y) -> 2x == y, 3, 6), [1,1], [2,1]) == [true, false]
 
-# Composition and identities.
-@test dom(R) == FinOrdRelOb(3)
-@test codom(R) == FinOrdRelOb(2)
-@test compose(R,S) == FinOrdRelation(Matrix{BoolRig}([false true false; true false true]))
-@test force(compose(id(dom(R)),R)) == R
-@test force(compose(R,id(codom(R)))) == R
+# Compatibility of function and matrix representations.
+R = FinOrdRelation((x,y) -> x == y || x == 2y || x == 3y, 10, 5)
+S = FinOrdRelation((x,y) -> (x+y) % 2 == 0, 5, 10)
+A, B = dom(R), dom(S)
+R_mat, S_mat = force(R), force(S)
+A_mat, B_mat = MatrixDom{Matrix{BoolRig}}(A.n), MatrixDom{Matrix{BoolRig}}(B.n)
+
+@test force(R ⋅ S) == R_mat ⋅ S_mat
+@test force(R ⋅ id(codom(R))) == R_mat
+@test force(id(dom(R)) ⋅ R) == R_mat
+
+@test force(R ⊗ S) == R_mat ⊗ S_mat
+@test force(braid(A, B)) == FinOrdRelation(braid(A_mat, B_mat))
 
 end

--- a/test/categorical_algebra/FinRelations.jl
+++ b/test/categorical_algebra/FinRelations.jl
@@ -1,0 +1,24 @@
+module TestFinRelations
+using Test
+
+using Catlab.Theories, Catlab.CategoricalAlgebra.FinRelations
+
+# Category of finite ordinals and relations
+###########################################
+
+R = FinOrdRelation(Matrix{BoolRig}([true false true; false true false]))
+S = FinOrdRelation(Matrix{BoolRig}([false true; true false]))
+
+# Evaluation.
+@test map(R, [1,3], [1,2]) == [true, false]
+@test map(id(FinOrdRelOb(3)), [1,1], [1,2]) == [true, false]
+@test map(FinOrdRelation((x,y) -> 2x == y, 3, 6), [1,1], [2,1]) == [true, false]
+
+# Composition and identities.
+@test dom(R) == FinOrdRelOb(3)
+@test codom(R) == FinOrdRelOb(2)
+@test compose(R,S) == FinOrdRelation(Matrix{BoolRig}([false true false; true false true]))
+@test force(compose(id(dom(R)),R)) == R
+@test force(compose(R,id(codom(R)))) == R
+
+end

--- a/test/categorical_algebra/FinRelations.jl
+++ b/test/categorical_algebra/FinRelations.jl
@@ -31,11 +31,22 @@ A_mat, B_mat = MatrixDom{Matrix{BoolRig}}(A.n), MatrixDom{Matrix{BoolRig}}(B.n)
 @test force(R ⊗ S) == R_mat ⊗ S_mat
 @test force(braid(A, B)) == FinOrdRelation(braid(A_mat, B_mat))
 
+@test force(R ⊕ S) == R_mat ⊕ S_mat
+@test force(swap(A, B)) == FinOrdRelation(swap(A_mat, B_mat))
+
 S = FinOrdRelation((x,y) -> (x+y) % 2 == 0, 10, 5)
 S_mat = force(S)
 @test force(meet(R, S)) == meet(R_mat, S_mat)
+@test force(join(R, S)) == join(R_mat, S_mat)
 @test force(mcopy(dom(R))⋅(R⊗S)⋅mmerge(codom(R))) == meet(R_mat, S_mat)
+@test force(coplus(dom(R))⋅(R⊕S)⋅plus(codom(R))) == join(R_mat, S_mat)
+
 @test force(top(A, B)) == FinOrdRelation(ones(BoolRig, B.n, A.n))
+@test force(bottom(A, B)) == FinOrdRelation(zeros(BoolRig, B.n, A.n))
 @test force(delete(A)⋅create(B)) == FinOrdRelation(ones(BoolRig, B.n, A.n))
+@test force(cozero(A)⋅zero(B)) == FinOrdRelation(zeros(BoolRig, B.n, A.n))
+
+@test force(pair(R, S)) == pair(R_mat, S_mat)
+@test force(copair(R, S)) == copair(R_mat, S_mat)
 
 end

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -22,8 +22,8 @@ h = FinOrdFunction([3,1,2], 3)
 @test compose(f,g) == FinOrdFunction([1,2,2], 3)
 @test compose(g,h) == FinOrdFunction([3,3,1,1,2], 3)
 @test compose(compose(f,g),h) == compose(f,compose(g,h))
-@test compose(id(dom(f)),f) == f
-@test compose(f,id(codom(f))) == f
+@test force(compose(id(dom(f)),f)) == f
+@test force(compose(f,id(codom(f)))) == f
 
 # Limits
 ########
@@ -47,7 +47,7 @@ f = FinOrdFunction([4,2,3,1], 5)
 
 # Equalizer matching nothing.
 f, g = id(FinOrd(5)), FinOrdFunction([2,3,4,5,1], 5)
-@test equalizer(f,g) == FinOrdFunction([], 5)
+@test equalizer(f,g) == FinOrdFunction(Int[], 5)
 
 # Pullback.
 span = pullback(Cospan(FinOrdFunction([1,1,3,2],4), FinOrdFunction([1,1,4,2],4)))
@@ -86,7 +86,7 @@ f, g = id(FinOrd(5)), FinOrdFunction([2,3,4,5,1], 5)
 @test coequalizer(f,g) == FinOrdFunction(repeat([1],5))
 
 # Pushout from the empty set: the degenerate case of the coproduct.
-f, g = FinOrdFunction([], 2), FinOrdFunction([], 3)
+f, g = FinOrdFunction(Int[], 2), FinOrdFunction(Int[], 3)
 cospan = pushout(Span(f,g))
 @test base(cospan) == FinOrd(5)
 @test left(cospan) == FinOrdFunction([1,2], 5)


### PR DESCRIPTION
- Adds a GAT for distributive bicategories of relations
- As an instance, implements the category `FinOrdRel` of finite ordinals and binary relations
- Fixes an issue with type parameter explosion in `FinOrd`

Similarly to the existing type `FinOrdFunction`, the abstract type `FinOrdRelation` has concrete subtypes where the relation is represented implicitly by a boolean-valued Julia function or explicitly by a boolean matrix, where the latter case uses #178.