### PR TITLE
Undirected wiring diagrams

### DIFF
--- a/docs/src/apis/wiring_diagrams.md
+++ b/docs/src/apis/wiring_diagrams.md
@@ -2,7 +2,7 @@
 
 ```@autodocs
 Modules = [
-  WiringDiagrams.WiringDiagramCore,
+  WiringDiagrams.DirectedWiringDiagrams,
   WiringDiagrams.AlgebraicWiringDiagrams,
   WiringDiagrams.WiringDiagramAlgorithms,
   WiringDiagrams.WiringDiagramSerialization,

--- a/docs/src/apis/wiring_diagrams.md
+++ b/docs/src/apis/wiring_diagrams.md
@@ -3,7 +3,6 @@
 ```@autodocs
 Modules = [
   WiringDiagrams.WiringDiagramCore,
-  WiringDiagrams.WiringLayers,
   WiringDiagrams.AlgebraicWiringDiagrams,
   WiringDiagrams.WiringDiagramAlgorithms,
   WiringDiagrams.WiringDiagramSerialization,

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -33,9 +33,9 @@ abstract type AbstractCSet{Ob,Hom,Dom,Codom,Data,DataDom} end
 
 """ Data type for C-sets (presheaves).
 
-Instead of filling out the type parameters yourself, you should use the function
-[`CSetType`](@ref) to generate a `CSet` type from a presentation of a category.
-Nevertheless, the first six type parameters are documented at
+Instead of filling out the type parameters manually, we recommend using the
+function [`CSetType`](@ref) to generate a `CSet` type from a presentation of a
+category. Nevertheless, the first six type parameters are documented at
 [`AbstractCSet`](@ref). The remaining type parameters are an implementation
 detail and should be ignored.
 
@@ -120,9 +120,8 @@ Both single and vectorized access are supported.
 """
 subpart(cset::CSet, part, name::Symbol) = _subpart(cset, part, Val(name))
 
-@generated function _subpart(
-    cset::CSet{obs,homs,doms,codoms,data}, part,
-    ::Val{name}) where {obs,homs,doms,codoms,data,name}
+@generated function _subpart(cset::T, part, ::Val{name}) where
+    {name, obs,homs,doms,codoms,data, T <: CSet{obs,homs,doms,codoms,data}}
   if name ∈ homs
     :(cset.subparts.$name[part])
   elseif name ∈ data
@@ -145,9 +144,8 @@ end
 get_subpart(cset::CSet, part, name::Symbol, default) =
   _get_subpart(cset, part, Val(name), default)
 
-@generated function _get_subpart(
-    cset::CSet{obs,homs,doms,codoms,data}, part,
-    ::Val{name}, default) where {obs,homs,doms,codoms,data,name}
+@generated function _get_subpart(cset::T, part, ::Val{name}, default) where
+    {name, obs,homs,doms,codoms,data, T<: CSet{obs,homs,doms,codoms,data}}
   if name ∈ homs
     :(cset.subparts.$name[part])
   elseif name ∈ data
@@ -189,10 +187,9 @@ function add_parts!(cset::CSet, type::Symbol, n::Int, subparts)
   parts
 end
 
-@generated function _add_parts!(
-    cset::CSet{obs,homs,doms,codoms,data,data_doms,indexed},
-    ::Val{type}, n::Int) where
-    {obs,homs,doms,codoms,data,data_doms,indexed,type}
+@generated function _add_parts!(cset::T, ::Val{type}, n::Int) where
+    {type, obs,homs,doms,codoms,data,data_doms,indexed,
+     T <: CSet{obs,homs,doms,codoms,data,data_doms,indexed}}
   ob = findfirst(obs .== type)::Int
   in_homs = [ homs[i] for (i, codom) in enumerate(codoms) if codom == ob ]
   out_homs = [ homs[i] for (i, dom) in enumerate(doms) if dom == ob ]
@@ -226,7 +223,7 @@ copy_parts!(cset::CSet, from::CSet, type::Symbol, parts) =
   _copy_parts!(cset, from, Val(type), parts)
 
 @generated function _copy_parts!(cset::T, from::T, ::Val{type}, parts) where
-    {obs,homs,doms,codoms,data,data_doms,type,
+    {type, obs,homs,doms,codoms,data,data_doms,
      T <: CSet{obs,homs,doms,codoms,data,data_doms}}
   ob = findfirst(obs .== type)::Int
   data_homs = [ data[i] for (i, dom) in enumerate(data_doms) if dom == ob ]
@@ -253,10 +250,9 @@ function set_subpart!(cset::CSet, part::AbstractVector{Int},
     _set_subpart!(cset, part, Val(name), subpart)
   end
 end
-@generated function _set_subpart!(
-    cset::CSet{obs,homs,doms,codoms,data,data_doms,indexed},
-    part::Int, ::Val{name}, subpart) where
-    {obs,homs,doms,codoms,data,data_doms,indexed,name}
+@generated function _set_subpart!(cset::T, part::Int, ::Val{name}, subpart) where
+    {name, obs,homs,doms,codoms,data,data_doms,indexed,
+     T <: CSet{obs,homs,doms,codoms,data,data_doms,indexed}}
   if name ∈ indexed
     quote
       old = cset.subparts.$name[part]

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -286,8 +286,10 @@ function set_subpart!(cset::CSet, part::AbstractVector{Int},
   end
 end
 
-set_subpart!(cset::CSet, part::Colon, name::Symbol, sub) =
-  set_subpart!(cset, 1:length(subpart(cset, name)), name, sub)
+set_subpart!(cset::CSet, ::Colon, name::Symbol, subpart) =
+  set_subpart!(cset, name, subpart)
+set_subpart!(cset::CSet, name::Symbol, new_subpart) =
+  set_subpart!(cset, 1:length(subpart(cset, name)), name, new_subpart)
 
 @generated function _set_subpart!(cset::T, part::Int, ::Val{name}, subpart) where
     {name, obs,homs,doms,codoms,data,data_doms,indexed,

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -2,7 +2,7 @@
 """
 module CSets
 export AbstractCSet, AbstractCSetType, CSet, CSetType,
-  nparts, subpart, get_subpart, incident,
+  nparts, subpart, has_subpart, incident,
   add_part!, add_parts!, copy_parts!, set_subpart!, set_subparts!
 
 using Compat
@@ -131,28 +131,13 @@ subpart(cset::CSet, part, name::Symbol) = _subpart(cset, part, Val(name))
   end
 end
 
-""" Get subpart of part in C-set, with default if there is no such subpart.
-
-The relationship between [`subpart`](@ref) and this function is the same as that
-between `[` and `get` for dictionaries.
+""" Whether a C-set has a subpart with the given name.
 """
-function get_subpart(f, cset::CSet, part, name::Symbol)
-  value = get_subpart(cset, part, name, undef)
-  value == undef ? f() : value
-end
+has_subpart(cset::CSet, name::Symbol) = _has_subpart(cset, Val(name))
 
-get_subpart(cset::CSet, part, name::Symbol, default) =
-  _get_subpart(cset, part, Val(name), default)
-
-@generated function _get_subpart(cset::T, part, ::Val{name}, default) where
+@generated function _has_subpart(cset::T, ::Val{name}) where
     {name, obs,homs,doms,codoms,data, T<: CSet{obs,homs,doms,codoms,data}}
-  if name ∈ homs
-    :(cset.subparts.$name[part])
-  elseif name ∈ data
-    :(cset.data.$name[part])
-  else
-    :default
-  end
+  name ∈ homs || name ∈ data
 end
 
 """ Get superparts incident to part in C-set.

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -123,10 +123,12 @@ subpart(cset::CSet, part::Union{Int,AbstractVector{Int},Colon}, name) =
     cset::CSet{obs,homs,doms,codoms,data},
     part::Union{Int,AbstractVector{Int},Colon},
     ::Val{name}) where {obs,homs,doms,codoms,data,name}
-  if name ∈ data
+  if name ∈ homs
+    :(cset.subparts.$name[part])
+  elseif name ∈ data
     :(cset.data.$name[part])
   else
-    :(cset.subparts.$name[part])
+    throw(KeyError(name))
   end
 end
 
@@ -226,10 +228,12 @@ end
         insertsorted!(cset.incident.$name[subpart], part)
       end
     end
+  elseif name ∈ homs
+    :(cset.subparts.$name[part] = subpart)
   elseif name ∈ data
     :(cset.data.$name[part] = subpart)
   else
-    :(cset.subparts.$name[part] = subpart)
+    throw(KeyError(name))
   end
 end
 

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -4,6 +4,7 @@ module CSets
 export AbstractCSet, AbstractCSetType, CSet, CSetType, nparts, subpart,
   incident, add_part!, add_parts!, set_subpart!, set_subparts!
 
+using Compat: only
 using LabelledArrays, StaticArrays
 
 using ...Present
@@ -135,9 +136,11 @@ incident(cset::CSet, part::Int, name) = cset.incident[name][part]
 
 """ Add part of given type to C-set, optionally setting its subparts.
 
+Returns the ID of the added part.
+
 See also: [`add_parts!`](@ref).
 """
-add_part!(cset::CSet, type) = _add_parts!(cset, Val(type), 1)
+add_part!(cset::CSet, type) = only(_add_parts!(cset, Val(type), 1))
 
 function add_part!(cset::CSet, type, subparts)
   part = add_part!(cset, type)
@@ -147,15 +150,16 @@ end
 
 """ Add parts of given type to C-set, optionally setting their subparts.
 
+Returns the range of IDs for the added parts.
+
 See also: [`add_part!`](@ref).
 """
 add_parts!(cset::CSet, type, n::Int) = _add_parts!(cset, Val(type), n)
 
 function add_parts!(cset::CSet, type, n::Int, subparts)
-  startpart = nparts(cset, type) + 1
-  endpart = add_parts!(cset, type, n)
-  set_subparts!(cset, startpart:endpart, subparts)
-  endpart
+  parts = add_parts!(cset, type, n)
+  set_subparts!(cset, parts, subparts)
+  parts
 end
 
 @generated function _add_parts!(
@@ -189,7 +193,7 @@ end
     for name in $(Tuple(data_homs))
       resize!(cset.data[name], nparts)
     end
-    nparts
+    start:nparts
   end
 end
 

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -49,15 +49,6 @@ mutable struct CSet{Ob,Hom,Dom,Codom,Data,DataDom,Index,NOb,NHom,NIndex} <:
   subparts::SLArray{Tuple{NHom},Vector{Int},1,NHom,Hom}
   incident::SLArray{Tuple{NIndex},Vector{Vector{Int}},1,NIndex,Index}
   data::NamedTuple{Data}
-
-  function CSet{Ob,Hom,Dom,Codom,Data,DataDom,Index,NOb,NHom,NIndex}(
-      datatypes::NamedTuple{Data}) where {Ob,Hom,Dom,Codom,Data,DataDom,Index,NOb,NHom,NIndex}
-    new{Ob,Hom,Dom,Codom,Data,DataDom,Index,NOb,NHom,NIndex}(
-      SLArray{Tuple{NOb},Ob}(zeros(SVector{NOb,Int})),
-      SLArray{Tuple{NHom},Hom}(Tuple(Int[] for i in 1:NHom)),
-      SLArray{Tuple{NIndex},Index}(Tuple(Vector{Int}[] for i in 1:NIndex)),
-      NamedTuple{Data}(T[] for T in datatypes))
-  end
 end
 
 function CSet{Ob,Hom,Dom,Codom,Data,DataDom,Index}(; kw...) where
@@ -70,6 +61,14 @@ function CSet{Ob,Hom,Dom,Codom,Data,DataDom,Index}(
   @assert length(Dom) == NHom && length(Codom) == NHom
   @assert length(DataDom) == length(Data)
   CSet{Ob,Hom,Dom,Codom,Data,DataDom,Index,NOb,NHom,NIndex}(datatypes)
+end
+function CSet{Ob,Hom,Dom,Codom,Data,DataDom,Index,NOb,NHom,NIndex}(
+    datatypes::NamedTuple{Data}) where {Ob,Hom,Dom,Codom,Data,DataDom,Index,NOb,NHom,NIndex}
+  CSet{Ob,Hom,Dom,Codom,Data,DataDom,Index,NOb,NHom,NIndex}(
+    SLArray{Tuple{NOb},Ob}(zeros(SVector{NOb,Int})),
+    SLArray{Tuple{NHom},Hom}(Tuple(Int[] for i in 1:NHom)),
+    SLArray{Tuple{NIndex},Index}(Tuple(Vector{Int}[] for i in 1:NIndex)),
+    NamedTuple{Data}(T[] for T in datatypes))
 end
 
 """ Generate an abstract C-set type from a presentation of a category.
@@ -103,6 +102,11 @@ separate(f, a::AbstractArray) = (i = f.(a); (a[i], a[.!i]))
 function Base.:(==)(x1::T, x2::T) where T <: CSet
   # The incidence data is redundant, so need not be compared.
   x1.nparts == x2.nparts && x1.subparts == x2.subparts && x1.data == x2.data
+end
+
+function Base.copy(cset::T) where T <: CSet
+  T(cset.nparts, map(copy, cset.subparts),
+    map(copy, cset.incident), map(copy, cset.data))
 end
 
 Base.empty(cset::T) where T <: CSet = T(map(eltype, cset.data))

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -73,6 +73,8 @@ end
 force(f::FinOrdFunction) = FinOrdFunctionMap(map(f, 1:dom(f).n), codom(f).n)
 force(f::FinOrdFunctionMap) = f
 
+Base.collect(f::FinOrdFunction) = force(f).func
+
 """ Category of finite ordinals and functions.
 """
 @instance Category(FinOrd, FinOrdFunction) begin

--- a/src/categorical_algebra/Graphs.jl
+++ b/src/categorical_algebra/Graphs.jl
@@ -38,8 +38,8 @@ ne(g::AbstractCSet) = nparts(g, :E)
 ne(g::AbstractCSet, src::Int, tgt::Int) =
   count(subpart(g, e, :tgt) == tgt for e in incident(g, src, :src))
 
-src(g::AbstractCSet, e=:) = subpart(g, e, :src)
-tgt(g::AbstractCSet, e=:) = subpart(g, e, :tgt)
+src(g::AbstractCSet, args...) = subpart(g, args..., :src)
+tgt(g::AbstractCSet, args...) = subpart(g, args..., :tgt)
 dst(g::AbstractCSet, args...) = tgt(g, args...) # LightGraphs compatibility
 
 vertices(g::AbstractCSet) = 1:nv(g)
@@ -85,7 +85,7 @@ end
 const AbstractSymmetricGraph = AbstractCSetType(TheorySymmetricGraph)
 const SymmetricGraph = CSetType(TheorySymmetricGraph, index=[:src])
 
-inv(g::AbstractCSet, e=:) = subpart(g, e, :inv)
+inv(g::AbstractCSet, args...) = subpart(g, args..., :inv)
 
 add_vertex!(g::AbstractSymmetricGraph) = add_part!(g, :V)
 add_vertices!(g::AbstractSymmetricGraph, n::Int) = add_parts!(g, :V, n)

--- a/src/categorical_algebra/Graphs.jl
+++ b/src/categorical_algebra/Graphs.jl
@@ -30,8 +30,8 @@ using ..CSets
   tgt::Hom(E,V)
 end
 
+const AbstractGraph = AbstractCSetType(TheoryGraph)
 const Graph = CSetType(TheoryGraph, index=[:src,:tgt])
-const AbstractGraph = supertype(Graph)
 
 nv(g::AbstractCSet) = nparts(g, :V)
 ne(g::AbstractCSet) = nparts(g, :E)
@@ -82,8 +82,8 @@ end
 
 # Don't index `inv` because it is self-inverse and don't index `tgt`
 # because `src` contains the same information due to symmetry of graph.
+const AbstractSymmetricGraph = AbstractCSetType(TheorySymmetricGraph)
 const SymmetricGraph = CSetType(TheorySymmetricGraph, index=[:src])
-const AbstractSymmetricGraph = supertype(SymmetricGraph)
 
 inv(g::AbstractCSet, e=:) = subpart(g, e, :inv)
 
@@ -121,9 +121,10 @@ abstract type AbstractPropertyGraph{T} end
   eprops::Hom(E,Props)
 end
 
-const _PropertyGraph = CSetType(TheoryPropertyGraph,
-                                data=[:Props], index=[:src,:tgt])
-const _AbstractPropertyGraph = supertype(_PropertyGraph)
+const _AbstractPropertyGraph =
+  AbstractCSetType(TheoryPropertyGraph, data=[:Props])
+const _PropertyGraph =
+  CSetType(TheoryPropertyGraph, data=[:Props], index=[:src,:tgt])
 
 """ Graph with properties.
 
@@ -152,9 +153,10 @@ PropertyGraph{T}() where T = PropertyGraph{T,_PropertyGraph}()
   compose(inv,eprops) == eprops # Edge involution preserves edge properties.
 end
 
-const _SymmetricPropertyGraph = CSetType(TheorySymmetricPropertyGraph,
-                                         data=[:Props], index=[:src])
-const _AbstractSymmetricPropertyGraph = supertype(_SymmetricPropertyGraph)
+const _AbstractSymmetricPropertyGraph =
+  AbstractCSetType(TheorySymmetricPropertyGraph, data=[:Props])
+const _SymmetricPropertyGraph =
+  CSetType(TheorySymmetricPropertyGraph, data=[:Props], index=[:src])
 
 """ Symmetric graphs with properties.
 

--- a/src/programs/ParseJuliaPrograms.jl
+++ b/src/programs/ParseJuliaPrograms.jl
@@ -9,7 +9,7 @@ using Match
 
 using ...Catlab
 import ...Meta: Expr0
-using ...Theories: ObExpr, HomExpr
+using ...Theories: ObExpr, HomExpr, otimes, munit
 using ...WiringDiagrams
 using ..GenerateJuliaPrograms: make_return_value
 

--- a/src/wiring_diagrams/Algebraic.jl
+++ b/src/wiring_diagrams/Algebraic.jl
@@ -6,10 +6,7 @@ types and functions to represent diagonals, codiagonals, duals, caps, cups,
 daggers, and other structures in wiring diagrams.
 """
 module AlgebraicWiringDiagrams
-export Ports, Junction, PortOp, BoxOp, functor, dom, codom, id, compose, ⋅, ∘,
-  otimes, ⊗, munit, braid, σ, oplus, ⊕, mzero, swap, permute,
-  mcopy, delete, Δ, ◊, mmerge, create, ∇, □, dual, dunit, dcounit, mate, dagger,
-  plus, zero, coplus, cozero, meet, join, top, bottom, trace, ocompose,
+export Ports, Junction, PortOp, BoxOp, functor, ocompose, permute,
   implicit_mcopy, implicit_mmerge, junctioned_mcopy, junctioned_mmerge,
   junction_diagram, add_junctions, add_junctions!, rem_junctions, merge_junctions,
   junction_caps, junction_cups, junctioned_dunit, junctioned_dcounit

--- a/src/wiring_diagrams/Algebraic.jl
+++ b/src/wiring_diagrams/Algebraic.jl
@@ -20,8 +20,8 @@ import ...Theories: dom, codom, id, compose, ⋅, ∘,
   mcopy, delete, Δ, ◊, mmerge, create, ∇, □, dual, dunit, dcounit, mate, dagger,
   plus, zero, coplus, cozero, meet, join, top, bottom, trace
 import ...Syntax: functor, head
-using ..WiringDiagramCore
-import ..WiringDiagramCore: Box, WiringDiagram, input_ports, output_ports
+using ..DirectedWiringDiagrams
+import ..DirectedWiringDiagrams: Box, WiringDiagram, input_ports, output_ports
 
 # Categorical interface
 #######################

--- a/src/wiring_diagrams/Algebraic.jl
+++ b/src/wiring_diagrams/Algebraic.jl
@@ -364,11 +364,11 @@ bottom(A::Ports{AbBiRel}, B::Ports{AbBiRel}) = compose(cozero(A), zero(B))
 
 """ Operadic composition of wiring diagrams.
 
-This generic function has two different signatures, corresponding to the two
-standard definitions of an operad (Yau, 2018, *Operads of Wiring Diagrams*,
-Definitions 2.3 and 2.10).
+This generic function has two different signatures, corresponding to the "full"
+and "partial" notions of operadic composition (Yau, 2018, *Operads of Wiring
+Diagrams*, Definitions 2.3 and 2.10).
 
-This operation is a simple wrapper around substitution (`substitute`).
+This operation is a simple wrapper around [`substitute`](@ref).
 """
 function ocompose(f::WiringDiagram, gs::Vector{<:WiringDiagram})
   @assert length(gs) == nboxes(f)

--- a/src/wiring_diagrams/Algorithms.jl
+++ b/src/wiring_diagrams/Algorithms.jl
@@ -8,8 +8,8 @@ using DataStructures
 import LightGraphs
 using Statistics: mean
 
-using ..WiringDiagramCore
-import ..WiringDiagramCore: set_box
+using ..DirectedWiringDiagrams
+import ..DirectedWiringDiagrams: set_box
 
 # Traversal
 ###########

--- a/src/wiring_diagrams/Directed.jl
+++ b/src/wiring_diagrams/Directed.jl
@@ -1,4 +1,4 @@
-""" Generic data structures for wiring diagrams (aka, string diagrams).
+""" Data structure for (directed) wiring diagrams, aka string diagrams.
 
 A (directed) wiring diagram consists of a collection of boxes with input and
 output ports connected by wires. A box can be atomic (possessing no internal
@@ -15,7 +15,7 @@ raster or vector graphics. However, they form a useful intermediate
 representation that can be serialized to and from GraphML or translated into
 Graphviz or other declarative diagram languages.
 """
-module WiringDiagramCore
+module DirectedWiringDiagrams
 export AbstractBox, Box, WiringDiagram, Wire, Port, PortKind,
   InputPort, OutputPort, input_ports, output_ports, input_id, output_id,
   outer_ids, boxes, box_ids, nboxes, nwires, box, wires, has_wire, graph,

--- a/src/wiring_diagrams/Expressions.jl
+++ b/src/wiring_diagrams/Expressions.jl
@@ -18,7 +18,7 @@ using LightGraphs
 using ...Syntax, ...Theories
 using ...Syntax: syntax_module
 using ...CategoricalAlgebra.Permutations
-using ..WiringDiagramCore, ..AlgebraicWiringDiagrams
+using ..DirectedWiringDiagrams, ..AlgebraicWiringDiagrams
 using ..WiringDiagramAlgorithms: crossing_minimization_by_sort
 
 # Expression -> Diagram

--- a/src/wiring_diagrams/GraphML.jl
+++ b/src/wiring_diagrams/GraphML.jl
@@ -23,8 +23,8 @@ import JSON
 using LightXML
 
 using ...CategoricalAlgebra.Graphs
-using ..WiringDiagramCore, ..WiringDiagramSerialization
-import ..WiringDiagramCore: PortData
+using ..DirectedWiringDiagrams, ..WiringDiagramSerialization
+import ..DirectedWiringDiagrams: PortData
 
 # Data types
 ############

--- a/src/wiring_diagrams/JSON.jl
+++ b/src/wiring_diagrams/JSON.jl
@@ -21,8 +21,8 @@ export read_json_graph, parse_json_graph, write_json_graph, generate_json_graph,
 using DataStructures: OrderedDict
 import JSON
 
-using ..WiringDiagramCore, ..WiringDiagramSerialization
-import ..WiringDiagramCore: PortData
+using ..DirectedWiringDiagrams, ..WiringDiagramSerialization
+import ..DirectedWiringDiagrams: PortData
 
 const JSONObject = OrderedDict{String,Any}
 

--- a/src/wiring_diagrams/Serialization.jl
+++ b/src/wiring_diagrams/Serialization.jl
@@ -8,7 +8,7 @@ module WiringDiagramSerialization
 export box_id, wire_id, port_name,
   convert_from_graph_data, convert_to_graph_data
 
-using ..WiringDiagramCore
+using ..DirectedWiringDiagrams
 
 # Identifiers
 #############

--- a/src/wiring_diagrams/Undirected.jl
+++ b/src/wiring_diagrams/Undirected.jl
@@ -90,9 +90,11 @@ ports(d::AbstractUWD, box) =
 linked_ports(d::AbstractUWD, link; outer::Bool=false) =
   incident(d, link, outer ? :outer_link : :link)
 
-link_type(d::AbstractUWD, link) = get_subpart(d, link, :link_type, NoPortType())
+link_type(d::AbstractUWD, link) =
+  has_subpart(d, :link_type) ? subpart(d, link, :link_type) : NoPortType()
 port_type(d::AbstractUWD, port; outer::Bool=false) =
-  get_subpart(d, port, outer ? :outer_port_type : :port_type, NoPortType())
+  has_subpart(d, :port_type) ?
+    subpart(d, port, outer ? :outer_port_type : :port_type) : NoPortType()
 
 function port_type(d::AbstractUWD, port::Tuple{Int,Int})
   box, nport = port

--- a/src/wiring_diagrams/Undirected.jl
+++ b/src/wiring_diagrams/Undirected.jl
@@ -1,0 +1,116 @@
+""" Data structure for undirected wiring diagrams.
+"""
+module UndirectedWiringDiagrams
+export AbstractUndirectedWiringDiagram, UndirectedWiringDiagram,
+  box, link, nboxes, nlinks, boxes, links, ports, linked_ports,
+  outer_id, outer_link, outer_ports, linked_outer_ports,
+  add_box!, add_link!, add_links!, set_link!, set_outer_link!
+
+using ...CategoricalAlgebra.CSets, ...Present
+using ...Theories: FreeCategory
+
+import ..DirectedWiringDiagrams: boxes, nboxes, add_box!
+
+# Data types
+############
+
+@present TheoryUWD(FreeCategory) begin
+  Box::Ob
+  Port::Ob
+  OuterPort::Ob
+  Link::Ob
+
+  box::Hom(Port,Box)
+  link::Hom(Port,Link)
+  outer_link::Hom(OuterPort,Link)
+end
+
+const AbstractUndirectedWiringDiagram = const AbstractUWD =
+  AbstractCSetType(TheoryUWD)
+const UntypedUndirectedWiringDiagram = const UntypedUWD =
+  CSetType(TheoryUWD, index=[:box, :link, :outer_link])
+
+@present TheoryTypedUWD <: TheoryUWD begin
+  Type::Ob
+
+  port_type::Hom(Port,Type)
+  outer_port_type::Hom(OuterPort,Type)
+  link_type::Hom(Link,Type)
+
+  compose(link, link_type) == port_type
+  compose(outer_link, link_type) == outer_port_type
+end
+
+const TypedUndirectedWiringDiagram = const TypedUWD =
+  CSetType(TheoryTypedUWD, data=[:Type], index=[:box, :link, :outer_link])
+
+# Imperative interface
+######################
+
+function UndirectedWiringDiagram(nports::Int)
+  d = UntypedUWD()
+  add_parts!(d, :OuterPort, nports)
+  return d
+end
+
+UndirectedWiringDiagram(port_types::AbstractVector{T}) where T =
+  UndirectedWiringDiagram(T, port_types)
+
+function UndirectedWiringDiagram(
+    ::Type{T}, port_types::AbstractVector{S}) where {T, S<:T}
+  d = TypedUWD(port_type=T, outer_port_type=T, link_type=T)
+  nports = length(port_types)
+  add_parts!(d, :OuterPort, nports, (outer_port_type=port_types,))
+  return d
+end
+
+box(d::AbstractUWD, port) = subpart(d, port, :box)
+link(d::AbstractUWD, port) = subpart(d, port, :link)
+
+function link(d::AbstractUWD, port::Tuple)
+  box, nport = port
+  box == outer_id(d) ? outer_link(d, nport) : link(d, ports(d, box)[nport])
+end
+
+nboxes(d::AbstractUWD) = nparts(d, :Box)
+nlinks(d::AbstractUWD) = nparts(d, :Link)
+boxes(d::AbstractUWD) = 1:nboxes(d)
+links(d::AbstractUWD) = 1:nlinks(d)
+ports(d::AbstractUWD) = 1:nparts(d, :Port)
+ports(d::AbstractUWD, box) = incident(d, box, :box)
+linked_ports(d::AbstractUWD, link) = incident(d, link, :link)
+
+outer_id(::AbstractUWD) = 0
+outer_link(d::AbstractUWD, outer_port) = subpart(d, outer_port, :outer_link)
+outer_ports(d::AbstractUWD) = 1:nparts(d, :OuterPort)
+linked_outer_ports(d::AbstractUWD, outer_port) =
+  incident(d, outer_port, :outer_link)
+
+add_box!(d::AbstractUWD; data...) = add_part!(d, :Box, (; data...))
+
+function add_box!(d::AbstractUWD, nports::Int; data...)
+  box = add_box!(d; data...)
+  ports = add_parts!(d, :Port, nports, (box=box,))
+  (box, ports)
+end
+
+function add_box!(d::AbstractUWD, port_types::AbstractVector; data...)
+  box = add_box!(d; data...)
+  nports = length(port_types)
+  ports = add_parts!(d, :Port, nports, (box=box, port_type=port_types))
+  (box, ports)
+end
+
+add_link!(d::AbstractUWD) = add_part!(d, :Link)
+add_link!(d::AbstractUWD, link_type) = add_part!(d, :Link, (link_type=link_type))
+add_links!(d::AbstractUWD, nlinks::Int) = add_parts!(d, :Link, nlinks)
+add_links!(d::AbstractUWD, link_types::AbstractVector) =
+  add_parts!(d, :Link, length(link_types), (link_type=link_types,))
+
+set_link!(d::AbstractUWD, port, link) = set_subpart!(d, port, :link, link)
+set_link!(d::AbstractUWD, box, port, link) =
+  set_link!(d, ports(d, box)[port], link)
+set_outer_link!(d::AbstractUWD, outer_port, link) =
+  set_subpart!(d, outer_port, :outer_link, link)
+
+end

--- a/src/wiring_diagrams/Undirected.jl
+++ b/src/wiring_diagrams/Undirected.jl
@@ -4,12 +4,15 @@ module UndirectedWiringDiagrams
 export AbstractUndirectedWiringDiagram, UndirectedWiringDiagram,
   outer_box, box, link, nboxes, nlinks, boxes, links, ports, linked_ports,
   link_type, port_type, add_box!, add_link!, add_links!, set_link!, add_wire!,
-  add_wires!
+  add_wires!, ocompose
 
 using ...CategoricalAlgebra.CSets, ...Present
-using ...Theories: FreeCategory
+using ...CategoricalAlgebra.ShapeDiagrams: Span
+using ...CategoricalAlgebra.FinSets: FinOrdFunction, pushout
+using ...Theories: FreeCategory, dom, codom, compose, ⋅, id
 
 import ..DirectedWiringDiagrams: boxes, nboxes, add_box!, add_wire!, add_wires!
+import ..AlgebraicWiringDiagrams: ocompose
 
 # Data types
 ############
@@ -43,10 +46,6 @@ end
 
 const TypedUndirectedWiringDiagram = const TypedUWD =
   CSetType(TheoryTypedUWD, data=[:Type], index=[:box, :link, :outer_link])
-
-struct NoPortType end
-
-Base.broadcastable(x::NoPortType) = Base.RefValue(x) # Broadcast like singleton.
 
 # Imperative interface
 ######################
@@ -90,11 +89,9 @@ ports(d::AbstractUWD, box) =
 linked_ports(d::AbstractUWD, link; outer::Bool=false) =
   incident(d, link, outer ? :outer_link : :link)
 
-link_type(d::AbstractUWD, link) =
-  has_subpart(d, :link_type) ? subpart(d, link, :link_type) : NoPortType()
+link_type(d::AbstractUWD, link) = subpart(d, link, :link_type)
 port_type(d::AbstractUWD, port; outer::Bool=false) =
-  has_subpart(d, :port_type) ?
-    subpart(d, port, outer ? :outer_port_type : :port_type) : NoPortType()
+  subpart(d, port, outer ? :outer_port_type : :port_type)
 
 function port_type(d::AbstractUWD, port::Tuple{Int,Int})
   box, nport = port
@@ -118,16 +115,17 @@ function add_box!(d::AbstractUWD, port_types::AbstractVector; data...)
 end
 
 add_link!(d::AbstractUWD) = add_part!(d, :Link)
-add_link!(d::AbstractUWD, ::NoPortType) = add_part!(d, :Link)
 add_link!(d::AbstractUWD, link_type) = add_part!(d, :Link, (link_type=link_type,))
 add_links!(d::AbstractUWD, nlinks::Int) = add_parts!(d, :Link, nlinks)
 add_links!(d::AbstractUWD, link_types::AbstractVector) =
   add_parts!(d, :Link, length(link_types), (link_type=link_types,))
 
 function set_link!(d::AbstractUWD, port, link; outer::Bool=false)
-  ptype, ltype = port_type(d, port, outer=outer), link_type(d, link)
-  if !all(ptype .== ltype)
-    error("Domain error: port type $ptype and link type $ltype do not match")
+  if has_subpart(d, :link_type)
+    ptype, ltype = port_type(d, port, outer=outer), link_type(d, link)
+    if !all(ptype .== ltype)
+      error("Domain error: port type $ptype and link type $ltype do not match")
+    end
   end
   set_subpart!(d, port, outer ? :outer_link : :link, link)
 end
@@ -144,9 +142,12 @@ end
 """ Wire together two ports in an undirected wiring diagram.
 
 A convenience method that creates and sets links as needed. Ports are only
-allowed to have one link, so if both ports already have links, the second port
-is assigned the link of the first. The handling of the two arguments is
+allowed to have one link, so if both ports already have links, then the second
+port is assigned the link of the first. The handling of the two arguments is
 otherwise symmetric.
+
+FIXME: When both ports already have links, the two links should be *merged*.
+To do this, we must implement `merge_links!` and thus also `rem_part!`.
 """
 function add_wire!(d::AbstractUWD, port1::Tuple{Int,Int}, port2::Tuple{Int,Int})
   link1, link2 = link(d, port1), link(d, port2)
@@ -155,7 +156,8 @@ function add_wire!(d::AbstractUWD, port1::Tuple{Int,Int}, port2::Tuple{Int,Int})
   elseif link2 > 0
     set_link!(d, port1, link2)
   else
-    new_link = add_link!(d, port_type(d, port1))
+    new_link = has_subpart(d, :link_type) ?
+      add_link!(d, port_type(d, port1)) : add_link!(d)
     set_link!(d, port1, new_link)
     set_link!(d, port2, new_link)
   end
@@ -167,5 +169,44 @@ function add_wires!(d::AbstractUWD, wires)
     add_wire!(d, wire)
   end
 end
+
+# Operadic interface
+####################
+
+function ocompose(f::AbstractUWD, i::Int, g::AbstractUWD)
+  @assert 1 <= i <= nboxes(f)
+  h = empty(f)
+  copy_parts!(h, f, (OuterPort=ports(f, outer=true),))
+  copy_boxes!(h, f, 1:(i-1))
+  copy_boxes!(h, g, boxes(g))
+  copy_boxes!(h, f, (i+1):nboxes(f))
+
+  f_i = FinOrdFunction(link(f, ports(f, i)), nlinks(f))
+  g_outer = FinOrdFunction(link(g, ports(g, outer=true), outer=true), nlinks(g))
+  cospan = pushout(Span(f_i, g_outer))
+  f_inc, g_inc = cospan.left, cospan.right
+  links = add_links!(h, codom(f_inc).n)
+  if has_subpart(h, :link_type)
+    set_subpart!(h, [collect(f_inc); collect(g_inc)]
+                 :link_type, [link_type(f, :); link_type(g, :)])
+  end
+
+  f_outer = FinOrdFunction(link(f, ports(f, outer=true), outer=true), nlinks(f))
+  f_start = FinOrdFunction(link(f, flat(ports(f, 1:(i-1)))), nlinks(f))
+  g_link = FinOrdFunction(link(g, ports(g)), nlinks(g))
+  f_end = FinOrdFunction(link(f, flat(ports(f, (i+1):nboxes(f)))), nlinks(f))
+  set_link!(h, :, collect(f_outer ⋅ f_inc), outer=true)
+  set_link!(h, :, [
+    collect(f_start ⋅ f_inc);
+    collect(g_link ⋅ g_inc);
+    collect(f_end ⋅ f_inc);
+  ])
+  return h
+end
+
+copy_boxes!(d::AbstractUWD, from::AbstractUWD, boxes) =
+  copy_parts!(d, from, (Box=boxes, Port=flat(ports(from, boxes))))
+
+flat(vs) = reduce(vcat, vs, init=Int[])
 
 end

--- a/src/wiring_diagrams/Undirected.jl
+++ b/src/wiring_diagrams/Undirected.jl
@@ -11,7 +11,8 @@ using ...CategoricalAlgebra.ShapeDiagrams: Span
 using ...CategoricalAlgebra.FinSets: FinOrdFunction, pushout
 using ...Theories: FreeCategory, dom, codom, compose, ⋅, id
 
-import ..DirectedWiringDiagrams: boxes, nboxes, add_box!, add_wire!, add_wires!
+import ..DirectedWiringDiagrams: box, boxes, nboxes, add_box!, add_wire!,
+  add_wires!
 import ..AlgebraicWiringDiagrams: ocompose
 
 # Data types
@@ -129,6 +130,7 @@ function set_link!(d::AbstractUWD, port, link; outer::Bool=false)
   end
   set_subpart!(d, port, outer ? :outer_link : :link, link)
 end
+set_link!(d::AbstractUWD, link; kw...) = set_link!(d, :, link; kw...)
 
 function set_link!(d::AbstractUWD, port::Tuple{Int,Int}, link)
   box, nport = port
@@ -201,8 +203,8 @@ function ocompose(f::AbstractUWD, gs::AbstractVector{<:AbstractUWD})
   gs_link = FinOrdFunction(
     flat(link(g) .+ n for (g,n) in zip(gs, gs_nlinks[1:end-1])),
     gs_nlinks[end])
-  set_link!(h, :, collect(f_outer ⋅ f_inc), outer=true)
-  set_link!(h, :, collect(gs_link ⋅ g_inc))
+  set_link!(h, collect(f_outer ⋅ f_inc), outer=true)
+  set_link!(h, collect(gs_link ⋅ g_inc))
   return h
 end
 
@@ -228,8 +230,8 @@ function ocompose(f::AbstractUWD, i::Int, g::AbstractUWD)
   f_start = FinOrdFunction(link(f, flat(ports(f, 1:(i-1)))), nlinks(f))
   g_link = FinOrdFunction(link(g), nlinks(g))
   f_end = FinOrdFunction(link(f, flat(ports(f, (i+1):nboxes(f)))), nlinks(f))
-  set_link!(h, :, collect(f_outer ⋅ f_inc), outer=true)
-  set_link!(h, :, [
+  set_link!(h, collect(f_outer ⋅ f_inc), outer=true)
+  set_link!(h, [
     collect(f_start ⋅ f_inc);
     collect(g_link ⋅ g_inc);
     collect(f_end ⋅ f_inc);

--- a/src/wiring_diagrams/WiringDiagrams.jl
+++ b/src/wiring_diagrams/WiringDiagrams.jl
@@ -3,6 +3,7 @@ module WiringDiagrams
 using Reexport
 
 include("Directed.jl")
+include("Undirected.jl")
 include("Algebraic.jl")
 include("Algorithms.jl")
 include("Expressions.jl")
@@ -11,6 +12,7 @@ include("GraphML.jl")
 include("JSON.jl")
 
 @reexport using .DirectedWiringDiagrams
+@reexport using .UndirectedWiringDiagrams
 @reexport using .AlgebraicWiringDiagrams
 @reexport using .WiringDiagramAlgorithms
 @reexport using .WiringDiagramExpressions

--- a/src/wiring_diagrams/WiringDiagrams.jl
+++ b/src/wiring_diagrams/WiringDiagrams.jl
@@ -3,8 +3,8 @@ module WiringDiagrams
 using Reexport
 
 include("Directed.jl")
-include("Undirected.jl")
 include("Algebraic.jl")
+include("Undirected.jl")
 include("Algorithms.jl")
 include("Expressions.jl")
 include("Serialization.jl")
@@ -12,8 +12,8 @@ include("GraphML.jl")
 include("JSON.jl")
 
 @reexport using .DirectedWiringDiagrams
-@reexport using .UndirectedWiringDiagrams
 @reexport using .AlgebraicWiringDiagrams
+@reexport using .UndirectedWiringDiagrams
 @reexport using .WiringDiagramAlgorithms
 @reexport using .WiringDiagramExpressions
 

--- a/src/wiring_diagrams/WiringDiagrams.jl
+++ b/src/wiring_diagrams/WiringDiagrams.jl
@@ -2,7 +2,7 @@ module WiringDiagrams
 
 using Reexport
 
-include("Core.jl")
+include("Directed.jl")
 include("Algebraic.jl")
 include("Algorithms.jl")
 include("Expressions.jl")
@@ -10,7 +10,7 @@ include("Serialization.jl")
 include("GraphML.jl")
 include("JSON.jl")
 
-@reexport using .WiringDiagramCore
+@reexport using .DirectedWiringDiagrams
 @reexport using .AlgebraicWiringDiagrams
 @reexport using .WiringDiagramAlgorithms
 @reexport using .WiringDiagramExpressions

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -64,7 +64,7 @@ const Dendrogram = CSetType(TheoryDendrogram, data=[:R], index=[:parent])
 d = Dendrogram(height=Float64)
 add_parts!(d, :X, 3, (height=0,))
 add_parts!(d, :X, 2, (height=[1,2],))
-for v in 1:3; set_subpart!(d, v, :parent, 4) end
+set_subpart!(d, 1:3, :parent, 4)
 set_subpart!(d, [4,5], :parent, 5)
 
 @test nparts(d, :X) == 5
@@ -75,5 +75,10 @@ set_subpart!(d, [4,5], :parent, 5)
 @test subpart(d, [1,2,3], :height)::Vector{Float64} == [0,0,0]
 @test subpart(d, 4, :height)::Float64 == 1
 @test subpart(d, :, :height) == [0,0,0,1,2]
+
+d2 = empty(d)
+copy_parts!(d2, d, :X, 5)
+@test nparts(d2, :X) == 1
+@test subpart(d2, 1, :height) == 2.0
 
 end

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -63,7 +63,7 @@ const Dendrogram = CSetType(TheoryDendrogram, data=[:R], index=[:parent])
 
 d = Dendrogram(height=Float64)
 add_parts!(d, :X, 3, (height=0,))
-add_parts!(d, :X, 2, (height=[1,2],))
+add_parts!(d, :X, 2, (height=[10,20],))
 set_subpart!(d, 1:3, :parent, 4)
 set_subpart!(d, [4,5], :parent, 5)
 
@@ -73,12 +73,13 @@ set_subpart!(d, [4,5], :parent, 5)
 @test subpart(d, :, :parent) == [4,4,4,5,5]
 @test incident(d, 4, :parent) == [1,2,3]
 @test subpart(d, [1,2,3], :height)::Vector{Float64} == [0,0,0]
-@test subpart(d, 4, :height)::Float64 == 1
-@test subpart(d, :, :height) == [0,0,0,1,2]
+@test subpart(d, 4, :height)::Float64 == 10
+@test subpart(d, :, :height) == [0,0,0,10,20]
 
 d2 = empty(d)
-copy_parts!(d2, d, :X, 5)
-@test nparts(d2, :X) == 1
-@test subpart(d2, 1, :height) == 2.0
+copy_parts!(d2, d, :X, [4,5])
+@test nparts(d2, :X) == 2
+@test subpart(d2, [1,2], :parent) == [2,2]
+@test subpart(d2, [1,2], :height) == [10,20]
 
 end

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -37,6 +37,9 @@ set_subpart!(dds, 1, :Φ, 1)
 
 @test_throws KeyError subpart(dds, 1, :badname)
 @test_throws KeyError set_subpart!(dds, 1, :badname, 1)
+@test get_subpart(dds, 1, :Φ, nothing) == 1
+@test get_subpart(dds, 1, :badname, nothing) == nothing
+@test get_subpart(() -> nothing, dds, 1, :badname) == nothing
 
 # Dendrograms
 #############

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -13,7 +13,11 @@ using Catlab.CategoricalAlgebra.CSets
   Φ::Hom(X,X)
 end
 
+const AbstractDDS = AbstractCSetType(TheoryDDS)
 const DDS = CSetType(TheoryDDS, index=[:Φ])
+@test AbstractDDS <: AbstractCSet
+@test DDS <: AbstractDDS
+@test DDS <: CSet
 
 dds = DDS()
 @test keys(dds.incident) == (:Φ,)

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -15,7 +15,7 @@ end
 
 const AbstractDDS = AbstractCSetType(TheoryDDS)
 const DDS = CSetType(TheoryDDS, index=[:Φ])
-@test AbstractDDS <: AbstractCSet
+@test AbstractDDS == AbstractCSet{(:X,),(:Φ,),(1,),(1,)}
 @test DDS <: AbstractDDS
 @test DDS <: CSet
 
@@ -56,7 +56,10 @@ set_subpart!(dds, 1, :Φ, 1)
   height::Hom(X,R)
 end
 
+const AbstractDendrogram = AbstractCSetType(TheoryDendrogram, data=[:R])
 const Dendrogram = CSetType(TheoryDendrogram, data=[:R], index=[:parent])
+@test AbstractDendrogram ==
+  AbstractCSet{(:X,),(:parent,),(1,),(1,),(:height,),(1,)}
 
 d = Dendrogram(height=Float64)
 add_parts!(d, :X, 3, (height=0,))

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -32,6 +32,7 @@ set_subpart!(dds, 1, :Φ, 1)
 
 @test add_part!(dds, :X, (Φ=1,)) == 2
 @test add_part!(dds, :X, (Φ=1,)) == 3
+@test subpart(dds, :Φ) == [1,1,1]
 @test subpart(dds, [2,3], :Φ) == [1,1]
 @test incident(dds, 1, :Φ) == [1,2,3]
 

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -35,11 +35,10 @@ set_subpart!(dds, 1, :Φ, 1)
 @test subpart(dds, [2,3], :Φ) == [1,1]
 @test incident(dds, 1, :Φ) == [1,2,3]
 
+@test has_subpart(dds, :Φ)
+@test !has_subpart(dds, :badname)
 @test_throws KeyError subpart(dds, 1, :badname)
 @test_throws KeyError set_subpart!(dds, 1, :badname, 1)
-@test get_subpart(dds, 1, :Φ, nothing) == 1
-@test get_subpart(dds, 1, :badname, nothing) == nothing
-@test get_subpart(() -> nothing, dds, 1, :badname) == nothing
 
 # Dendrograms
 #############
@@ -72,6 +71,7 @@ set_subpart!(d, [4,5], :parent, 5)
 @test subpart(d, 4, :parent) == 5
 @test subpart(d, :, :parent) == [4,4,4,5,5]
 @test incident(d, 4, :parent) == [1,2,3]
+@test has_subpart(d, :height)
 @test subpart(d, [1,2,3], :height)::Vector{Float64} == [0,0,0]
 @test subpart(d, 4, :height)::Float64 == 10
 @test subpart(d, :, :height) == [0,0,0,10,20]

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -35,6 +35,9 @@ set_subpart!(dds, 1, :Φ, 1)
 @test subpart(dds, [2,3], :Φ) == [1,1]
 @test incident(dds, 1, :Φ) == [1,2,3]
 
+@test_throws KeyError subpart(dds, 1, :badname)
+@test_throws KeyError set_subpart!(dds, 1, :badname, 1)
+
 # Dendrograms
 #############
 

--- a/test/graphics/GraphvizWiringDiagrams.jl
+++ b/test/graphics/GraphvizWiringDiagrams.jl
@@ -3,7 +3,7 @@ module TestGraphvizWiringDiagrams
 using Test
 import JSON
 
-using Catlab.WiringDiagrams, Catlab.Graphics
+using Catlab.Theories, Catlab.WiringDiagrams, Catlab.Graphics
 import Catlab.Graphics: Graphviz
 using Catlab.Graphics.WiringDiagramLayouts: position, normal
 

--- a/test/wiring_diagrams/Algorithms.jl
+++ b/test/wiring_diagrams/Algorithms.jl
@@ -1,7 +1,7 @@
 module TestWiringDiagramAlgorithms
 
 using Test
-using Catlab.WiringDiagrams
+using Catlab.Theories, Catlab.WiringDiagrams
 
 A, B, C, D = [ Ports([sym]) for sym in [:A, :B, :C, :D] ]
 I = munit(Ports)

--- a/test/wiring_diagrams/Directed.jl
+++ b/test/wiring_diagrams/Directed.jl
@@ -1,8 +1,8 @@
-module TestWiringDiagramCore
+module TestDirectedWiringDiagrams
 using Test
 
-using Catlab.WiringDiagrams.WiringDiagramCore
-import Catlab.WiringDiagrams.WiringDiagramCore: validate_ports
+using Catlab.WiringDiagrams.DirectedWiringDiagrams
+import Catlab.WiringDiagrams.DirectedWiringDiagrams: validate_ports
 
 # For testing purposes, check equality of port symbols.
 function validate_ports(source_port::Symbol, target_port::Symbol)

--- a/test/wiring_diagrams/GraphML.jl
+++ b/test/wiring_diagrams/GraphML.jl
@@ -1,8 +1,8 @@
 module TestGraphMLWiringDiagrams
-
 using Test
+
 using LightXML
-using Catlab.WiringDiagrams
+using Catlab.Theories, Catlab.WiringDiagrams
 
 # Round trip wiring diagrams with dictionary box and wire data.
 

--- a/test/wiring_diagrams/JSON.jl
+++ b/test/wiring_diagrams/JSON.jl
@@ -1,8 +1,8 @@
 module TestJSONWiringDiagrams
-
 using Test
+
 import JSON
-using Catlab.WiringDiagrams
+using Catlab.Theories, Catlab.WiringDiagrams
 
 # Round trip wiring diagrams with dictionary box and wire data.
 

--- a/test/wiring_diagrams/Undirected.jl
+++ b/test/wiring_diagrams/Undirected.jl
@@ -47,7 +47,7 @@ set_link!(d, 1:3, 1:3, outer=true)
 @test link(d, 1:3, outer=true) == [1,2,3]
 @test_throws ErrorException set_link!(d, 1, 2)
 
-# Box-relative interface for ports.
+# Interface for ports that is relative to their boxes.
 d_previous = d
 d = UndirectedWiringDiagram([:X,:Y,:Z])
 add_box!(d, [:X,:W]); add_box!(d, [:Y,:W]); add_box!(d, [:Z,:W])
@@ -57,5 +57,28 @@ add_wires!(d, (i,1) => (outer_box(d),i) for i in 1:3)
 add_wire!(d, (1,2) => (2,2))
 add_wire!(d, (2,2) => (3,2))
 @test d == d_previous
+
+# Operadic interface
+####################
+
+f = UndirectedWiringDiagram(3)
+add_box!(f, 2); add_box!(f, 2); add_box!(f, 2)
+add_links!(f, 4)
+set_link!(f, 1:6, [1,4,2,4,3,4])
+set_link!(f, 1:3, 1:3, outer=true)
+
+g = UndirectedWiringDiagram(2)
+add_box!(g, 1); add_box!(g, 1)
+add_links!(g, 2)
+set_link!(g, 1:2, 2:-1:1)
+set_link!(g, 1:2, 1:2, outer=true)
+
+h = UndirectedWiringDiagram(3)
+add_box!(h, 2); add_box!(h, 1); add_box!(h, 1); add_box!(h, 2)
+add_links!(h, 4)
+set_link!(h, 1:6, [1,4,4,2,3,4])
+set_link!(h, 1:3, 1:3, outer=true)
+@test ocompose(f,2,g) == h
+@test ocompose(ocompose(f,1,g),3,g) == ocompose(ocompose(f,2,g),1,g)
 
 end

--- a/test/wiring_diagrams/Undirected.jl
+++ b/test/wiring_diagrams/Undirected.jl
@@ -47,4 +47,15 @@ set_link!(d, 1:3, 1:3, outer=true)
 @test link(d, 1:3, outer=true) == [1,2,3]
 @test_throws ErrorException set_link!(d, 1, 2)
 
+# Box-relative interface for ports.
+d_previous = d
+d = UndirectedWiringDiagram([:X,:Y,:Z])
+add_box!(d, [:X,:W]); add_box!(d, [:Y,:W]); add_box!(d, [:Z,:W])
+@test port_type(d, (1,1)) == :X
+@test port_type(d, (2,1)) == :Y
+add_wires!(d, (i,1) => (outer_box(d),i) for i in 1:3)
+add_wire!(d, (1,2) => (2,2))
+add_wire!(d, (2,2) => (3,2))
+@test d == d_previous
+
 end

--- a/test/wiring_diagrams/Undirected.jl
+++ b/test/wiring_diagrams/Undirected.jl
@@ -1,0 +1,41 @@
+module TestUndirectedWiringDiagrams
+using Test
+
+using Catlab.WiringDiagrams.UndirectedWiringDiagrams
+
+# Imperative interface
+######################
+
+# Untyped wiring diagrams.
+d = UndirectedWiringDiagram(3)
+@test nboxes(d) == 0
+@test nlinks(d) == 0
+add_box!(d, 2); add_box!(d, 2); add_box!(d, 2)
+add_links!(d, 4)
+@test nboxes(d) == 3
+@test nlinks(d) == 4
+@test collect(boxes(d)) == collect(1:3)
+@test collect(links(d)) == collect(1:4)
+@test collect(ports(d)) == collect(1:6)
+@test collect(outer_ports(d)) == collect(1:3)
+@test ports.([d], boxes(d)) == [[1,2], [3,4], [5,6]]
+set_outer_link!(d, 1:3, 1:3)
+set_link!(d, [1,3,5], 1:3)
+set_link!(d, [2,4,6], 4)
+@test linked_ports(d, 1) == [1]
+@test linked_ports(d, 4) == [2,4,6]
+@test linked_outer_ports(d, 1) == [1]
+
+# Typed wiring diagrams.
+# TODO: Enforce type compatibility.
+d = UndirectedWiringDiagram([:X,:Y,:Z])
+add_box!(d, [:X,:W]); add_box!(d, [:Y,:W]); add_box!(d, [:Z,:W])
+add_links!(d, [:X,:Y,:Z,:W])
+set_outer_link!(d, 1:3, 1:3)
+set_link!(d, [1,3,5], 1:3)
+set_link!(d, [2,4,6], 4)
+@test linked_ports(d, 1) == [1]
+@test linked_ports(d, 4) == [2,4,6]
+@test linked_outer_ports(d, 1) == [1]
+
+end

--- a/test/wiring_diagrams/Undirected.jl
+++ b/test/wiring_diagrams/Undirected.jl
@@ -12,30 +12,35 @@ d = UndirectedWiringDiagram(3)
 @test nlinks(d) == 0
 add_box!(d, 2); add_box!(d, 2); add_box!(d, 2)
 add_links!(d, 4)
+@test box(d, 1) == 1
+@test box(d, 1:4) == [1,1,2,2]
 @test nboxes(d) == 3
 @test nlinks(d) == 4
 @test collect(boxes(d)) == collect(1:3)
 @test collect(links(d)) == collect(1:4)
 @test collect(ports(d)) == collect(1:6)
-@test collect(outer_ports(d)) == collect(1:3)
+@test collect(ports(d, outer=true)) == collect(1:3)
+@test ports(d, outer_box(d)) == [1,2,3]
 @test ports.([d], boxes(d)) == [[1,2], [3,4], [5,6]]
-set_outer_link!(d, 1:3, 1:3)
 set_link!(d, [1,3,5], 1:3)
 set_link!(d, [2,4,6], 4)
+set_link!(d, 1:3, 1:3, outer=true)
+@test link(d, 1) == 1
+@test link(d, 1, outer=true) == 1
+@test link(d, [2,4,6]) == [4,4,4]
 @test linked_ports(d, 1) == [1]
+@test linked_ports(d, 1, outer=true) == [1]
 @test linked_ports(d, 4) == [2,4,6]
-@test linked_outer_ports(d, 1) == [1]
 
 # Typed wiring diagrams.
 # TODO: Enforce type compatibility.
 d = UndirectedWiringDiagram([:X,:Y,:Z])
 add_box!(d, [:X,:W]); add_box!(d, [:Y,:W]); add_box!(d, [:Z,:W])
 add_links!(d, [:X,:Y,:Z,:W])
-set_outer_link!(d, 1:3, 1:3)
 set_link!(d, [1,3,5], 1:3)
 set_link!(d, [2,4,6], 4)
-@test linked_ports(d, 1) == [1]
-@test linked_ports(d, 4) == [2,4,6]
-@test linked_outer_ports(d, 1) == [1]
+set_link!(d, 1:3, 1:3, outer=true)
+@test link(d, 1:6) == [1,4,2,4,3,4]
+@test link(d, 1:3, outer=true) == [1,2,3]
 
 end

--- a/test/wiring_diagrams/Undirected.jl
+++ b/test/wiring_diagrams/Undirected.jl
@@ -33,14 +33,18 @@ set_link!(d, 1:3, 1:3, outer=true)
 @test linked_ports(d, 4) == [2,4,6]
 
 # Typed wiring diagrams.
-# TODO: Enforce type compatibility.
 d = UndirectedWiringDiagram([:X,:Y,:Z])
 add_box!(d, [:X,:W]); add_box!(d, [:Y,:W]); add_box!(d, [:Z,:W])
 add_links!(d, [:X,:Y,:Z,:W])
+@test port_type(d, 1) == :X
+@test port_type(d, [1,3,5]) == [:X,:Y,:Z]
+@test port_type(d, 3, outer=true) == :Z
+@test link_type(d, 3) == :Z
 set_link!(d, [1,3,5], 1:3)
 set_link!(d, [2,4,6], 4)
 set_link!(d, 1:3, 1:3, outer=true)
 @test link(d, 1:6) == [1,4,2,4,3,4]
 @test link(d, 1:3, outer=true) == [1,2,3]
+@test_throws ErrorException set_link!(d, 1, 2)
 
 end

--- a/test/wiring_diagrams/Undirected.jl
+++ b/test/wiring_diagrams/Undirected.jl
@@ -9,43 +9,43 @@ using Catlab.WiringDiagrams.UndirectedWiringDiagrams
 # Untyped wiring diagrams.
 d = UndirectedWiringDiagram(3)
 @test nboxes(d) == 0
-@test nlinks(d) == 0
+@test njunctions(d) == 0
 add_box!(d, 2); add_box!(d, 2); add_box!(d, 2)
-add_links!(d, 4)
+add_junctions!(d, 4)
 @test box(d, 1) == 1
 @test box(d, 1:4) == [1,1,2,2]
 @test nboxes(d) == 3
-@test nlinks(d) == 4
+@test njunctions(d) == 4
 @test collect(boxes(d)) == collect(1:3)
-@test collect(links(d)) == collect(1:4)
+@test collect(junctions(d)) == collect(1:4)
 @test collect(ports(d)) == collect(1:6)
 @test collect(ports(d, outer=true)) == collect(1:3)
 @test ports(d, outer_box(d)) == [1,2,3]
 @test ports.([d], boxes(d)) == [[1,2], [3,4], [5,6]]
-set_link!(d, [1,3,5], 1:3)
-set_link!(d, [2,4,6], 4)
-set_link!(d, 1:3, 1:3, outer=true)
-@test link(d, 1) == 1
-@test link(d, 1, outer=true) == 1
-@test link(d, [2,4,6]) == [4,4,4]
-@test linked_ports(d, 1) == [1]
-@test linked_ports(d, 1, outer=true) == [1]
-@test linked_ports(d, 4) == [2,4,6]
+set_junction!(d, [1,3,5], 1:3)
+set_junction!(d, [2,4,6], 4)
+set_junction!(d, 1:3, 1:3, outer=true)
+@test junction(d, 1) == 1
+@test junction(d, 1, outer=true) == 1
+@test junction(d, [2,4,6]) == [4,4,4]
+@test ports_with_junction(d, 1) == [1]
+@test ports_with_junction(d, 1, outer=true) == [1]
+@test ports_with_junction(d, 4) == [2,4,6]
 
 # Typed wiring diagrams.
 d = UndirectedWiringDiagram([:X,:Y,:Z])
 add_box!(d, [:X,:W]); add_box!(d, [:Y,:W]); add_box!(d, [:Z,:W])
-add_links!(d, [:X,:Y,:Z,:W])
+add_junctions!(d, [:X,:Y,:Z,:W])
 @test port_type(d, 1) == :X
 @test port_type(d, [1,3,5]) == [:X,:Y,:Z]
 @test port_type(d, 3, outer=true) == :Z
-@test link_type(d, 3) == :Z
-set_link!(d, [1,3,5], 1:3)
-set_link!(d, [2,4,6], 4)
-set_link!(d, 1:3, 1:3, outer=true)
-@test link(d, 1:6) == [1,4,2,4,3,4]
-@test link(d, 1:3, outer=true) == [1,2,3]
-@test_throws ErrorException set_link!(d, 1, 2)
+@test junction_type(d, 3) == :Z
+set_junction!(d, [1,3,5], 1:3)
+set_junction!(d, [2,4,6], 4)
+set_junction!(d, 1:3, 1:3, outer=true)
+@test junction(d, 1:6) == [1,4,2,4,3,4]
+@test junction(d, 1:3, outer=true) == [1,2,3]
+@test_throws ErrorException set_junction!(d, 1, 2)
 
 # Interface for ports that is relative to their boxes.
 d_previous = d
@@ -63,31 +63,31 @@ add_wire!(d, (2,2) => (3,2))
 
 f = UndirectedWiringDiagram(3)
 add_box!(f, 2); add_box!(f, 2); add_box!(f, 2)
-add_links!(f, 4)
-set_link!(f, [1,4,2,4,3,4])
-set_link!(f, 1:3, outer=true)
+add_junctions!(f, 4)
+set_junction!(f, [1,4,2,4,3,4])
+set_junction!(f, 1:3, outer=true)
 
 g1 = UndirectedWiringDiagram(2)
 add_box!(g1, 1); add_box!(g1, 1)
-add_links!(g1, 2)
-set_link!(g1, 1:2)
-set_link!(g1, 1:2, outer=true)
+add_junctions!(g1, 2)
+set_junction!(g1, 1:2)
+set_junction!(g1, 1:2, outer=true)
 g2 = copy(g1)
-set_link!(g2, 2:-1:1)
+set_junction!(g2, 2:-1:1)
 
 h = UndirectedWiringDiagram(3)
 add_box!(h, 2); add_box!(h, 1); add_box!(h, 1); add_box!(h, 2)
-add_links!(h, 4)
-set_link!(h, [1,4,4,2,3,4])
-set_link!(h, 1:3, outer=true)
+add_junctions!(h, 4)
+set_junction!(h, [1,4,4,2,3,4])
+set_junction!(h, 1:3, outer=true)
 @test ocompose(f,2,g2) == h
 @test ocompose(ocompose(f,1,g1),3,g2) == ocompose(ocompose(f,2,g2),1,g1)
 
 h = UndirectedWiringDiagram(3)
 for i in 1:6; add_box!(h, 1) end
-add_links!(h, 4)
-set_link!(h, [1,4,4,2,3,4])
-set_link!(h, 1:3, outer=true)
+add_junctions!(h, 4)
+set_junction!(h, [1,4,4,2,3,4])
+set_junction!(h, 1:3, outer=true)
 @test ocompose(f, [g1,g2,g1]) == h
 
 end

--- a/test/wiring_diagrams/Undirected.jl
+++ b/test/wiring_diagrams/Undirected.jl
@@ -67,18 +67,27 @@ add_links!(f, 4)
 set_link!(f, 1:6, [1,4,2,4,3,4])
 set_link!(f, 1:3, 1:3, outer=true)
 
-g = UndirectedWiringDiagram(2)
-add_box!(g, 1); add_box!(g, 1)
-add_links!(g, 2)
-set_link!(g, 1:2, 2:-1:1)
-set_link!(g, 1:2, 1:2, outer=true)
+g1 = UndirectedWiringDiagram(2)
+add_box!(g1, 1); add_box!(g1, 1)
+add_links!(g1, 2)
+set_link!(g1, 1:2, 1:2)
+set_link!(g1, 1:2, 1:2, outer=true)
+g2 = copy(g1)
+set_link!(g2, 1:2, 2:-1:1)
 
 h = UndirectedWiringDiagram(3)
 add_box!(h, 2); add_box!(h, 1); add_box!(h, 1); add_box!(h, 2)
 add_links!(h, 4)
-set_link!(h, 1:6, [1,4,4,2,3,4])
-set_link!(h, 1:3, 1:3, outer=true)
-@test ocompose(f,2,g) == h
-@test ocompose(ocompose(f,1,g),3,g) == ocompose(ocompose(f,2,g),1,g)
+set_link!(h, :, [1,4,4,2,3,4])
+set_link!(h, :, 1:3, outer=true)
+@test ocompose(f,2,g2) == h
+@test ocompose(ocompose(f,1,g1),3,g2) == ocompose(ocompose(f,2,g2),1,g1)
+
+h = UndirectedWiringDiagram(3)
+for i in 1:6; add_box!(h, 1) end
+add_links!(h, 4)
+set_link!(h, :, [1,4,4,2,3,4])
+set_link!(h, :, 1:3, outer=true)
+@test ocompose(f, [g1,g2,g1]) == h
 
 end

--- a/test/wiring_diagrams/Undirected.jl
+++ b/test/wiring_diagrams/Undirected.jl
@@ -64,30 +64,30 @@ add_wire!(d, (2,2) => (3,2))
 f = UndirectedWiringDiagram(3)
 add_box!(f, 2); add_box!(f, 2); add_box!(f, 2)
 add_links!(f, 4)
-set_link!(f, 1:6, [1,4,2,4,3,4])
-set_link!(f, 1:3, 1:3, outer=true)
+set_link!(f, [1,4,2,4,3,4])
+set_link!(f, 1:3, outer=true)
 
 g1 = UndirectedWiringDiagram(2)
 add_box!(g1, 1); add_box!(g1, 1)
 add_links!(g1, 2)
-set_link!(g1, 1:2, 1:2)
-set_link!(g1, 1:2, 1:2, outer=true)
+set_link!(g1, 1:2)
+set_link!(g1, 1:2, outer=true)
 g2 = copy(g1)
-set_link!(g2, 1:2, 2:-1:1)
+set_link!(g2, 2:-1:1)
 
 h = UndirectedWiringDiagram(3)
 add_box!(h, 2); add_box!(h, 1); add_box!(h, 1); add_box!(h, 2)
 add_links!(h, 4)
-set_link!(h, :, [1,4,4,2,3,4])
-set_link!(h, :, 1:3, outer=true)
+set_link!(h, [1,4,4,2,3,4])
+set_link!(h, 1:3, outer=true)
 @test ocompose(f,2,g2) == h
 @test ocompose(ocompose(f,1,g1),3,g2) == ocompose(ocompose(f,2,g2),1,g1)
 
 h = UndirectedWiringDiagram(3)
 for i in 1:6; add_box!(h, 1) end
 add_links!(h, 4)
-set_link!(h, :, [1,4,4,2,3,4])
-set_link!(h, :, 1:3, outer=true)
+set_link!(h, [1,4,4,2,3,4])
+set_link!(h, 1:3, outer=true)
 @test ocompose(f, [g1,g2,g1]) == h
 
 end

--- a/test/wiring_diagrams/WiringDiagrams.jl
+++ b/test/wiring_diagrams/WiringDiagrams.jl
@@ -1,7 +1,7 @@
 using Test
 
-@testset "Core" begin
-  include("Core.jl")
+@testset "Directed" begin
+  include("Directed.jl")
 end
 
 @testset "Algebraic" begin

--- a/test/wiring_diagrams/WiringDiagrams.jl
+++ b/test/wiring_diagrams/WiringDiagrams.jl
@@ -4,6 +4,10 @@ using Test
   include("Directed.jl")
 end
 
+@testset "Undirected" begin
+  include("Undirected.jl")
+end
+
 @testset "Algebraic" begin
   include("Algebraic.jl")
 end


### PR DESCRIPTION
This PR is a first cut at undirected wiring diagrams, implementing:
- data structures for typed and untyped wiring diagrams, based on C-sets
- the operad structure, namely functions for full and partial operadic composition, based on pushouts in `FinOrd`

The PR is interspersed with various tweaks and improvements to C-sets. The most notable is a function `copy_parts!` that allows a sub-C-set of one C-set to be copied into another.

Next on the list for UWDs is basic support for visualization, probably starting with Graphviz.