### PR TITLE
Bounds check before assigning C-set subpart

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -320,8 +320,12 @@ set_subpart!(cset::CSet, name::Symbol, new_subpart) =
 @generated function _set_subpart!(cset::T, part::Int, ::Val{name}, subpart) where
     {name, obs,homs,doms,codoms,data,data_doms,indexed,data_indexed,
      T <: CSet{obs,homs,doms,codoms,data,data_doms,indexed,data_indexed}}
+  if name ∈ homs
+    codom = obs[codoms[findfirst(name .== homs)]]
+  end
   if name ∈ indexed
     quote
+      @assert 0 <= subpart <= cset.nparts.$codom
       old = cset.subparts.$name[part]
       cset.subparts.$name[part] = subpart
       if old > 0
@@ -332,7 +336,10 @@ set_subpart!(cset::CSet, name::Symbol, new_subpart) =
       end
     end
   elseif name ∈ homs
-    :(cset.subparts.$name[part] = subpart)
+    quote
+      @assert 0 <= subpart <= cset.nparts.$codom
+      cset.subparts.$name[part] = subpart
+    end
   elseif name ∈ data_indexed
     quote
       old = cset.data.$name[part]

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -2,7 +2,7 @@
 """
 module CSets
 export AbstractCSet, AbstractCSetType, CSet, CSetType,
-  nparts, subpart, has_subpart, incident,
+  nparts, has_part, subpart, has_subpart, incident,
   add_part!, add_parts!, copy_parts!, set_subpart!, set_subparts!
 
 using Compat
@@ -125,6 +125,17 @@ Base.empty(cset::T) where T <: CSet = T(map(eltype, cset.data))
 """
 nparts(cset::CSet, type::Symbol) = cset.nparts[type]
 
+""" Whether a C-set has a part with the given name.
+"""
+has_part(cset::CSet, type::Symbol) = _has_part(cset, Val(type))
+
+@generated _has_part(cset::CSet{obs}, ::Val{type}) where {obs,type} =
+  type ∈ obs
+
+has_part(cset::CSet, type::Symbol, part::Int) = 1 <= part <= nparts(cset, type)
+has_part(cset::CSet, type::Symbol, part::AbstractVector{Int}) =
+  let n=nparts(cset, type); [ 1 <= x <= n for x in part ] end
+
 """ Get subpart of part in C-set.
 
 Both single and vectorized access are supported.
@@ -148,7 +159,7 @@ end
 has_subpart(cset::CSet, name::Symbol) = _has_subpart(cset, Val(name))
 
 @generated function _has_subpart(cset::T, ::Val{name}) where
-    {name, obs,homs,doms,codoms,data, T<: CSet{obs,homs,doms,codoms,data}}
+    {name, obs,homs,doms,codoms,data, T <: CSet{obs,homs,doms,codoms,data}}
   name ∈ homs || name ∈ data
 end
 

--- a/src/categorical_algebra/Graphs.jl
+++ b/src/categorical_algebra/Graphs.jl
@@ -47,8 +47,8 @@ edges(g::AbstractCSet) = 1:ne(g)
 edges(g::AbstractCSet, src::Int, tgt::Int) =
   (e for e in incident(g, src, :src) if subpart(g, e, :tgt) == tgt)
 
-has_vertex(g::AbstractCSet, v::Int) = 1 <= v <= nv(g)
-has_edge(g::AbstractCSet, e::Int) = 1 <= e <= ne(g)
+has_vertex(g::AbstractCSet, v) = has_part(g, :V, v)
+has_edge(g::AbstractCSet, e) = has_part(g, :E, e)
 has_edge(g::AbstractCSet, src::Int, tgt::Int) = tgt ∈ outneighbors(g, src)
 
 add_vertex!(g::AbstractGraph) = add_part!(g, :V)

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -47,6 +47,11 @@ set_subpart!(dds, 1, :Φ, 1)
 @test_throws KeyError subpart(dds, 1, :nonsubpart)
 @test_throws KeyError set_subpart!(dds, 1, :nonsubpart, 1)
 
+# Error handling
+@test_throws AssertionError add_part!(dds, :X, Φ=5)
+@test subpart(dds, :Φ) == [1,1,1,0]
+@test incident(dds, 4, :Φ) == []
+
 # Dendrograms
 #############
 

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -36,10 +36,16 @@ set_subpart!(dds, 1, :Φ, 1)
 @test subpart(dds, [2,3], :Φ) == [1,1]
 @test incident(dds, 1, :Φ) == [1,2,3]
 
+@test has_part(dds, :X)
+@test !has_part(dds, :nonpart)
+@test has_part(dds, :X, 3)
+@test !has_part(dds, :X, 4)
+@test has_part(dds, :X, 1:5) == [true, true, true, false, false]
+
 @test has_subpart(dds, :Φ)
-@test !has_subpart(dds, :badname)
-@test_throws KeyError subpart(dds, 1, :badname)
-@test_throws KeyError set_subpart!(dds, 1, :badname, 1)
+@test !has_subpart(dds, :nonsubpart)
+@test_throws KeyError subpart(dds, 1, :nonsubpart)
+@test_throws KeyError set_subpart!(dds, 1, :nonsubpart, 1)
 
 # Dendrograms
 #############


### PR DESCRIPTION
The bare minimum fix for #199. It does *not* add support for rolling back C-set "transactions" but it does at least ensure that the internal state is consistent. For now, this is all I plan to do about this problem.

```julia
julia> using Catlab.CategoricalAlgebra.Graphs

julia> g = Graph();

julia> add_vertices!(g, 3)
1:3

julia> add_edge!(g, 1, 4)
ERROR: AssertionError: 0 <= subpart <= cset.nparts.V
[SNIP]

julia> src(g)
1-element Array{Int64,1}:
 1

julia> tgt(g)
1-element Array{Int64,1}:
 0
```