### PR TITLE
Use standard names for FinSet and FinRel

### DIFF
--- a/src/wiring_diagrams/Undirected.jl
+++ b/src/wiring_diagrams/Undirected.jl
@@ -8,7 +8,7 @@ export UndirectedWiringDiagram, outer_box, box, junction, nboxes, njunctions,
 
 using ...CategoricalAlgebra.CSets, ...Present
 using ...CategoricalAlgebra.ShapeDiagrams: Span
-using ...CategoricalAlgebra.FinSets: FinSetFunction, pushout
+using ...CategoricalAlgebra.FinSets: FinFunction, pushout
 using ...Theories: FreeCategory, dom, codom, compose, ⋅, id
 
 import ..DirectedWiringDiagrams: box, boxes, nboxes, add_box!, add_wire!,
@@ -204,11 +204,11 @@ function ocompose(f::AbstractUWD, gs::AbstractVector{<:AbstractUWD})
     copy_boxes!(h, g, boxes(g))
   end
 
-  f_junction = FinSetFunction(
+  f_junction = FinFunction(
     flat(junction(f, ports(f, i)) for i in boxes(f)), njunctions(f))
   # FIXME: Should use coproduct as monoidal product.
   gs_offset = [0; cumsum(njunctions.(gs))]
-  gs_outer = FinSetFunction(
+  gs_outer = FinFunction(
     flat(junction(g, outer=true) .+ n for (g,n) in zip(gs, gs_offset[1:end-1])),
     gs_offset[end])
   cospan = pushout(Span(f_junction, gs_outer))
@@ -219,9 +219,9 @@ function ocompose(f::AbstractUWD, gs::AbstractVector{<:AbstractUWD})
                  [junction_type(f); flat(junction_type(g) for g in gs)])
   end
 
-  f_outer = FinSetFunction(junction(f, outer=true), njunctions(f))
+  f_outer = FinFunction(junction(f, outer=true), njunctions(f))
   # FIXME: Again, should use coproduct.
-  gs_junction = FinSetFunction(
+  gs_junction = FinFunction(
     flat(junction(g) .+ n for (g,n) in zip(gs, gs_offset[1:end-1])),
     gs_offset[end])
   set_junction!(h, collect(f_outer ⋅ f_inc), outer=true)
@@ -237,8 +237,8 @@ function ocompose(f::AbstractUWD, i::Int, g::AbstractUWD)
   copy_boxes!(h, g, boxes(g))
   copy_boxes!(h, f, (i+1):nboxes(f))
 
-  f_i = FinSetFunction(junction(f, ports(f, i)), njunctions(f))
-  g_outer = FinSetFunction(junction(g, outer=true), njunctions(g))
+  f_i = FinFunction(junction(f, ports(f, i)), njunctions(f))
+  g_outer = FinFunction(junction(g, outer=true), njunctions(g))
   cospan = pushout(Span(f_i, g_outer))
   f_inc, g_inc = cospan.left, cospan.right
   junctions = add_junctions!(h, length(codom(f_inc)))
@@ -247,11 +247,11 @@ function ocompose(f::AbstractUWD, i::Int, g::AbstractUWD)
                  [junction_type(f); junction_type(g)])
   end
 
-  f_outer = FinSetFunction(junction(f, outer=true), njunctions(f))
-  f_start = FinSetFunction(junction(f, flat(ports(f, 1:(i-1)))), njunctions(f))
-  g_junction = FinSetFunction(junction(g), njunctions(g))
-  f_end = FinSetFunction(
-    junction(f, flat(ports(f, (i+1):nboxes(f)))), njunctions(f))
+  f_outer = FinFunction(junction(f, outer=true), njunctions(f))
+  f_start = FinFunction(junction(f, flat(ports(f, 1:(i-1)))), njunctions(f))
+  g_junction = FinFunction(junction(g), njunctions(g))
+  f_end = FinFunction(junction(f, flat(ports(f, (i+1):nboxes(f)))),
+                      njunctions(f))
   set_junction!(h, collect(f_outer ⋅ f_inc), outer=true)
   set_junction!(h, [
     collect(f_start ⋅ f_inc);

--- a/src/wiring_diagrams/Undirected.jl
+++ b/src/wiring_diagrams/Undirected.jl
@@ -8,7 +8,7 @@ export UndirectedWiringDiagram, outer_box, box, junction, nboxes, njunctions,
 
 using ...CategoricalAlgebra.CSets, ...Present
 using ...CategoricalAlgebra.ShapeDiagrams: Span
-using ...CategoricalAlgebra.FinSets: FinOrdFunction, pushout
+using ...CategoricalAlgebra.FinSets: FinSetFunction, pushout
 using ...Theories: FreeCategory, dom, codom, compose, ⋅, id
 
 import ..DirectedWiringDiagrams: box, boxes, nboxes, add_box!, add_wire!,
@@ -204,24 +204,24 @@ function ocompose(f::AbstractUWD, gs::AbstractVector{<:AbstractUWD})
     copy_boxes!(h, g, boxes(g))
   end
 
-  f_junction = FinOrdFunction(
+  f_junction = FinSetFunction(
     flat(junction(f, ports(f, i)) for i in boxes(f)), njunctions(f))
   # FIXME: Should use coproduct as monoidal product.
   gs_offset = [0; cumsum(njunctions.(gs))]
-  gs_outer = FinOrdFunction(
+  gs_outer = FinSetFunction(
     flat(junction(g, outer=true) .+ n for (g,n) in zip(gs, gs_offset[1:end-1])),
     gs_offset[end])
   cospan = pushout(Span(f_junction, gs_outer))
   f_inc, g_inc = cospan.left, cospan.right
-  junctions = add_junctions!(h, codom(f_inc).n)
+  junctions = add_junctions!(h, length(codom(f_inc)))
   if has_subpart(h, :junction_type)
     set_subpart!(h, [collect(f_inc); collect(g_inc)], :junction_type,
                  [junction_type(f); flat(junction_type(g) for g in gs)])
   end
 
-  f_outer = FinOrdFunction(junction(f, outer=true), njunctions(f))
+  f_outer = FinSetFunction(junction(f, outer=true), njunctions(f))
   # FIXME: Again, should use coproduct.
-  gs_junction = FinOrdFunction(
+  gs_junction = FinSetFunction(
     flat(junction(g) .+ n for (g,n) in zip(gs, gs_offset[1:end-1])),
     gs_offset[end])
   set_junction!(h, collect(f_outer ⋅ f_inc), outer=true)
@@ -237,20 +237,20 @@ function ocompose(f::AbstractUWD, i::Int, g::AbstractUWD)
   copy_boxes!(h, g, boxes(g))
   copy_boxes!(h, f, (i+1):nboxes(f))
 
-  f_i = FinOrdFunction(junction(f, ports(f, i)), njunctions(f))
-  g_outer = FinOrdFunction(junction(g, outer=true), njunctions(g))
+  f_i = FinSetFunction(junction(f, ports(f, i)), njunctions(f))
+  g_outer = FinSetFunction(junction(g, outer=true), njunctions(g))
   cospan = pushout(Span(f_i, g_outer))
   f_inc, g_inc = cospan.left, cospan.right
-  junctions = add_junctions!(h, codom(f_inc).n)
+  junctions = add_junctions!(h, length(codom(f_inc)))
   if has_subpart(h, :junction_type)
     set_subpart!(h, [collect(f_inc); collect(g_inc)], :junction_type,
                  [junction_type(f); junction_type(g)])
   end
 
-  f_outer = FinOrdFunction(junction(f, outer=true), njunctions(f))
-  f_start = FinOrdFunction(junction(f, flat(ports(f, 1:(i-1)))), njunctions(f))
-  g_junction = FinOrdFunction(junction(g), njunctions(g))
-  f_end = FinOrdFunction(
+  f_outer = FinSetFunction(junction(f, outer=true), njunctions(f))
+  f_start = FinSetFunction(junction(f, flat(ports(f, 1:(i-1)))), njunctions(f))
+  g_junction = FinSetFunction(junction(g), njunctions(g))
+  f_end = FinSetFunction(
     junction(f, flat(ports(f, (i+1):nboxes(f)))), njunctions(f))
   set_junction!(h, collect(f_outer ⋅ f_inc), outer=true)
   set_junction!(h, [

--- a/test/categorical_algebra/FinRelations.jl
+++ b/test/categorical_algebra/FinRelations.jl
@@ -7,21 +7,22 @@ using Catlab.CategoricalAlgebra.Matrices: MatrixDom
 # Category of finite ordinals and relations
 ###########################################
 
-R = FinOrdRelation(Matrix{BoolRig}([true false true; false true false]))
-@test dom(R) == FinOrdRelOb(3)
-@test codom(R) == FinOrdRelOb(2)
+R = FinRelation(Matrix{BoolRig}([true false true; false true false]))
+@test dom(R) == FinRel(3)
+@test codom(R) == FinRel(2)
 
 # Evaluation.
 @test map(R, [1,3], [1,2]) == [true, false]
-@test map(id(FinOrdRelOb(3)), [1,1], [1,2]) == [true, false]
-@test map(FinOrdRelation((x,y) -> 2x == y, 3, 6), [1,1], [2,1]) == [true, false]
+@test map(id(FinRel(3)), [1,1], [1,2]) == [true, false]
+@test map(FinRelation((x,y) -> 2x == y, 3, 6), [1,1], [2,1]) == [true, false]
 
 # Compatibility of function and matrix representations.
-R = FinOrdRelation((x,y) -> x == y || x == 2y || x == 3y, 10, 5)
-S = FinOrdRelation((x,y) -> (x+y) % 2 == 0, 5, 10)
+R = FinRelation((x,y) -> x == y || x == 2y || x == 3y, 10, 5)
+S = FinRelation((x,y) -> (x+y) % 2 == 0, 5, 10)
 A, B = dom(R), dom(S)
+m, n = length(A), length(B)
 R_mat, S_mat = force(R), force(S)
-A_mat, B_mat = MatrixDom{Matrix{BoolRig}}(A.n), MatrixDom{Matrix{BoolRig}}(B.n)
+A_mat, B_mat = MatrixDom{Matrix{BoolRig}}(m), MatrixDom{Matrix{BoolRig}}(n)
 
 @test force(R ⋅ S) == R_mat ⋅ S_mat
 @test force(R ⋅ id(codom(R))) == R_mat
@@ -29,22 +30,22 @@ A_mat, B_mat = MatrixDom{Matrix{BoolRig}}(A.n), MatrixDom{Matrix{BoolRig}}(B.n)
 @test force(dagger(R)) == dagger(R_mat)
 
 @test force(R ⊗ S) == R_mat ⊗ S_mat
-@test force(braid(A, B)) == FinOrdRelation(braid(A_mat, B_mat))
+@test force(braid(A, B)) == FinRelation(braid(A_mat, B_mat))
 
 @test force(R ⊕ S) == R_mat ⊕ S_mat
-@test force(swap(A, B)) == FinOrdRelation(swap(A_mat, B_mat))
+@test force(swap(A, B)) == FinRelation(swap(A_mat, B_mat))
 
-S = FinOrdRelation((x,y) -> (x+y) % 2 == 0, 10, 5)
+S = FinRelation((x,y) -> (x+y) % 2 == 0, 10, 5)
 S_mat = force(S)
 @test force(meet(R, S)) == meet(R_mat, S_mat)
 @test force(join(R, S)) == join(R_mat, S_mat)
 @test force(mcopy(dom(R))⋅(R⊗S)⋅mmerge(codom(R))) == meet(R_mat, S_mat)
 @test force(coplus(dom(R))⋅(R⊕S)⋅plus(codom(R))) == join(R_mat, S_mat)
 
-@test force(top(A, B)) == FinOrdRelation(ones(BoolRig, B.n, A.n))
-@test force(bottom(A, B)) == FinOrdRelation(zeros(BoolRig, B.n, A.n))
-@test force(delete(A)⋅create(B)) == FinOrdRelation(ones(BoolRig, B.n, A.n))
-@test force(cozero(A)⋅zero(B)) == FinOrdRelation(zeros(BoolRig, B.n, A.n))
+@test force(top(A, B)) == FinRelation(ones(BoolRig, n, m))
+@test force(bottom(A, B)) == FinRelation(zeros(BoolRig, n, m))
+@test force(delete(A)⋅create(B)) == FinRelation(ones(BoolRig, n, m))
+@test force(cozero(A)⋅zero(B)) == FinRelation(zeros(BoolRig, n, m))
 
 @test force(pair(R, S)) == pair(R_mat, S_mat)
 @test force(copair(R, S)) == copair(R_mat, S_mat)

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -7,20 +7,20 @@ using Catlab.CategoricalAlgebra.ShapeDiagrams, Catlab.CategoricalAlgebra.FinSets
 # Category of finite ordinals
 #############################
 
-f = FinSetFunction([1,3,4], 5)
-g = FinSetFunction([1,1,2,2,3], 3)
-h = FinSetFunction([3,1,2], 3)
+f = FinFunction([1,3,4], 5)
+g = FinFunction([1,1,2,2,3], 3)
+h = FinFunction([3,1,2], 3)
 
 # Evaluation.
 @test map(f, 1:3) == [1,3,4]
 @test map(id(FinSet(3)), 1:3) == [1,2,3]
-@test map(FinSetFunction(x -> (x % 3) + 1, 3, 3), 1:3) == [2,3,1]
+@test map(FinFunction(x -> (x % 3) + 1, 3, 3), 1:3) == [2,3,1]
 
 # Composition and identities.
 @test dom(f) == FinSet(3)
 @test codom(f) == FinSet(5)
-@test compose(f,g) == FinSetFunction([1,2,2], 3)
-@test compose(g,h) == FinSetFunction([3,3,1,1,2], 3)
+@test compose(f,g) == FinFunction([1,2,2], 3)
+@test compose(g,h) == FinFunction([3,3,1,1,2], 3)
 @test compose(compose(f,g),h) == compose(f,compose(g,h))
 @test force(compose(id(dom(f)),f)) == f
 @test force(compose(f,id(codom(f)))) == f
@@ -34,49 +34,49 @@ h = FinSetFunction([3,1,2], 3)
 # Binary Product.
 span = product(FinSet(2), FinSet(3))
 @test apex(span) == FinSet(6)
-@test force(left(span)) == FinSetFunction([1,2,1,2,1,2])
-@test force(right(span)) == FinSetFunction([1,1,2,2,3,3])
+@test force(left(span)) == FinFunction([1,2,1,2,1,2])
+@test force(right(span)) == FinFunction([1,1,2,2,3,3])
 
 # N-ary Product.
 cone = product([FinSet(2), FinSet(3)])
 @test apex(cone) == FinSet(6)
-@test force(leg(cone,1)) == FinSetFunction([1,2,1,2,1,2])
-@test force(leg(cone,2)) == FinSetFunction([1,1,2,2,3,3])
+@test force(leg(cone,1)) == FinFunction([1,2,1,2,1,2])
+@test force(leg(cone,2)) == FinFunction([1,1,2,2,3,3])
 @test apex(product(FinSet{Int}[])) == FinSet(1)
 
 # Equalizer.
-f, g = FinSetFunction([1,2,3]), FinSetFunction([3,2,1])
-@test equalizer(f,g) == FinSetFunction([2], 3)
-@test equalizer([f,g]) == FinSetFunction([2], 3)
+f, g = FinFunction([1,2,3]), FinFunction([3,2,1])
+@test equalizer(f,g) == FinFunction([2], 3)
+@test equalizer([f,g]) == FinFunction([2], 3)
 
 # Equalizer in case of identical functions.
-f = FinSetFunction([4,2,3,1], 5)
+f = FinFunction([4,2,3,1], 5)
 @test equalizer(f,f) == force(id(FinSet(4)))
 @test equalizer([f,f]) == force(id(FinSet(4)))
 
 # Equalizer matching nothing.
-f, g = id(FinSet(5)), FinSetFunction([2,3,4,5,1], 5)
-@test equalizer(f,g) == FinSetFunction(Int[], 5)
-@test equalizer([f,g]) == FinSetFunction(Int[], 5)
+f, g = id(FinSet(5)), FinFunction([2,3,4,5,1], 5)
+@test equalizer(f,g) == FinFunction(Int[], 5)
+@test equalizer([f,g]) == FinFunction(Int[], 5)
 
 # Pullback.
-span = pullback(Cospan(FinSetFunction([1,1,3,2],4), FinSetFunction([1,1,4,2],4)))
+span = pullback(Cospan(FinFunction([1,1,3,2],4), FinFunction([1,1,4,2],4)))
 @test apex(span) == FinSet(5)
-@test force(left(span)) == FinSetFunction([1,2,1,2,4], 4)
-@test force(right(span)) == FinSetFunction([1,1,2,2,4], 4)
+@test force(left(span)) == FinFunction([1,2,1,2,4], 4)
+@test force(right(span)) == FinFunction([1,1,2,2,4], 4)
 
 # Pullback from a singleton set: the degenerate case of a product.
-span = pullback(Cospan(FinSetFunction([1,1]), FinSetFunction([1,1,1])))
+span = pullback(Cospan(FinFunction([1,1]), FinFunction([1,1,1])))
 @test apex(span) == FinSet(6)
-@test force(left(span)) == FinSetFunction([1,2,1,2,1,2])
-@test force(right(span)) == FinSetFunction([1,1,2,2,3,3])
+@test force(left(span)) == FinFunction([1,2,1,2,1,2])
+@test force(right(span)) == FinFunction([1,1,2,2,3,3])
 
 # Pullback using generic limit interface
-f,g = FinSetFunction([1,1,3,2],4), FinSetFunction([1,1,4,2],4)
+f,g = FinFunction([1,1,3,2],4), FinFunction([1,1,4,2],4)
 cone = limit(Diagram([FinSet(4),FinSet(4),FinSet(4)], [(1,3,f),(2,3,g)]))
 @test apex(cone) == FinSet(5)
-@test force(leg(cone,1)) == FinSetFunction([1,2,1,2,4],4)
-@test force(leg(cone,2)) == FinSetFunction([1,1,2,2,4],4)
+@test force(leg(cone,1)) == FinFunction([1,2,1,2,4],4)
+@test force(leg(cone,2)) == FinFunction([1,1,2,2,4],4)
 
 # Colimits
 ##########
@@ -87,46 +87,46 @@ cone = limit(Diagram([FinSet(4),FinSet(4),FinSet(4)], [(1,3,f),(2,3,g)]))
 # Binary Coproduct.
 cospan = coproduct(FinSet(2), FinSet(3))
 @test base(cospan) == FinSet(5)
-@test left(cospan) == FinSetFunction([1,2], 5)
-@test right(cospan) == FinSetFunction([3,4,5], 5)
+@test left(cospan) == FinFunction([1,2], 5)
+@test right(cospan) == FinFunction([3,4,5], 5)
 
 # N-ary Coproduct.
 cocone = coproduct([FinSet(2), FinSet(3)])
 @test base(cocone) == FinSet(5)
-@test leg(cocone,1) == FinSetFunction([1,2], 5)
-@test leg(cocone,2) == FinSetFunction([3,4,5], 5)
+@test leg(cocone,1) == FinFunction([1,2], 5)
+@test leg(cocone,2) == FinFunction([3,4,5], 5)
 @test base(coproduct(FinSet{Int}[])) == FinSet(0)
 
 # Coequalizer from a singleton set.
-f, g = FinSetFunction([1], 3), FinSetFunction([3], 3)
-@test coequalizer(f,g) == FinSetFunction([1,2,1], 2)
-@test coequalizer([f,g]) == FinSetFunction([1,2,1], 2)
+f, g = FinFunction([1], 3), FinFunction([3], 3)
+@test coequalizer(f,g) == FinFunction([1,2,1], 2)
+@test coequalizer([f,g]) == FinFunction([1,2,1], 2)
 
 # Coequalizer in case of identical functions.
-f = FinSetFunction([4,2,3,1], 5)
+f = FinFunction([4,2,3,1], 5)
 @test coequalizer(f,f) == force(id(FinSet(5)))
 @test coequalizer([f,f]) == force(id(FinSet(5)))
 
 # Coequalizer identifying everything.
-f, g = id(FinSet(5)), FinSetFunction([2,3,4,5,1], 5)
-@test coequalizer(f,g) == FinSetFunction(repeat([1],5))
-@test coequalizer([f,g]) == FinSetFunction(repeat([1],5))
+f, g = id(FinSet(5)), FinFunction([2,3,4,5,1], 5)
+@test coequalizer(f,g) == FinFunction(repeat([1],5))
+@test coequalizer([f,g]) == FinFunction(repeat([1],5))
 
 # Pushout from the empty set: the degenerate case of the coproduct.
-f, g = FinSetFunction(Int[], 2), FinSetFunction(Int[], 3)
+f, g = FinFunction(Int[], 2), FinFunction(Int[], 3)
 cospan = pushout(Span(f,g))
 @test base(cospan) == FinSet(5)
-@test left(cospan) == FinSetFunction([1,2], 5)
-@test right(cospan) == FinSetFunction([3,4,5], 5)
+@test left(cospan) == FinFunction([1,2], 5)
+@test right(cospan) == FinFunction([3,4,5], 5)
 
 # Pushout from a singleton set.
-f, g = FinSetFunction([1], 2), FinSetFunction([2], 3)
+f, g = FinFunction([1], 2), FinFunction([2], 3)
 cospan = pushout(Span(f,g))
 @test base(cospan) == FinSet(4)
 h, k = left(cospan), right(cospan)
 @test compose(f,h) == compose(g,k)
-@test h == FinSetFunction([1,2], 4)
-@test k == FinSetFunction([3,1,4], 4)
+@test h == FinFunction([1,2], 4)
+@test k == FinFunction([3,1,4], 4)
 
 # Same thing with generic colimit interface
 diag = Diagram([FinSet(1),FinSet(2),FinSet(3)],[(1,2,f), (1,3,g)])
@@ -134,17 +134,17 @@ cocone = colimit(diag)
 @test base(cocone) == FinSet(4)
 h, k = leg(cocone,2), leg(cocone,3)
 @test compose(f,h) == compose(g,k)
-@test h == FinSetFunction([1,2], 4)
-@test k == FinSetFunction([3,1,4], 4)
+@test h == FinFunction([1,2], 4)
+@test k == FinFunction([3,1,4], 4)
 
 # Pushout from a two-element set, with non-injective legs.
-f, g = FinSetFunction([1,1], 2), FinSetFunction([1,2], 2)
+f, g = FinFunction([1,1], 2), FinFunction([1,2], 2)
 cospan = pushout(Span(f,g))
 @test base(cospan) == FinSet(2)
 h, k = left(cospan), right(cospan)
 @test compose(f,h) == compose(g,k)
-@test h == FinSetFunction([1,2], 2)
-@test k == FinSetFunction([1,1], 2)
+@test h == FinFunction([1,2], 2)
+@test k == FinFunction([1,1], 2)
 
 # Same thing with generic colimit interface
 diag = Diagram([FinSet(2),FinSet(2),FinSet(2)],[(1,2,f),(1,3,g)])
@@ -152,7 +152,7 @@ cocone = colimit(diag)
 @test base(cocone) == FinSet(2)
 h,k = leg(cocone,2), leg(cocone,3)
 @test compose(f,h) == compose(g,k)
-@test h == FinSetFunction([1,2], 2)
-@test k == FinSetFunction([1,1], 2)
+@test h == FinFunction([1,2], 2)
+@test k == FinFunction([1,1], 2)
 
 end

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -7,20 +7,20 @@ using Catlab.CategoricalAlgebra.ShapeDiagrams, Catlab.CategoricalAlgebra.FinSets
 # Category of finite ordinals
 #############################
 
-f = FinOrdFunction([1,3,4], 5)
-g = FinOrdFunction([1,1,2,2,3], 3)
-h = FinOrdFunction([3,1,2], 3)
+f = FinSetFunction([1,3,4], 5)
+g = FinSetFunction([1,1,2,2,3], 3)
+h = FinSetFunction([3,1,2], 3)
 
 # Evaluation.
 @test map(f, 1:3) == [1,3,4]
-@test map(id(FinOrd(3)), 1:3) == [1,2,3]
-@test map(FinOrdFunction(x -> (x % 3) + 1, 3, 3), 1:3) == [2,3,1]
+@test map(id(FinSet(3)), 1:3) == [1,2,3]
+@test map(FinSetFunction(x -> (x % 3) + 1, 3, 3), 1:3) == [2,3,1]
 
 # Composition and identities.
-@test dom(f) == FinOrd(3)
-@test codom(f) == FinOrd(5)
-@test compose(f,g) == FinOrdFunction([1,2,2], 3)
-@test compose(g,h) == FinOrdFunction([3,3,1,1,2], 3)
+@test dom(f) == FinSet(3)
+@test codom(f) == FinSet(5)
+@test compose(f,g) == FinSetFunction([1,2,2], 3)
+@test compose(g,h) == FinSetFunction([3,3,1,1,2], 3)
 @test compose(compose(f,g),h) == compose(f,compose(g,h))
 @test force(compose(id(dom(f)),f)) == f
 @test force(compose(f,id(codom(f)))) == f
@@ -29,130 +29,130 @@ h = FinOrdFunction([3,1,2], 3)
 ########
 
 # Terminal object.
-@test terminal(FinOrd) == FinOrd(1)
+@test terminal(FinSet{Int}) == FinSet(1)
 
 # Binary Product.
-span = product(FinOrd(2), FinOrd(3))
-@test apex(span) == FinOrd(6)
-@test force(left(span)) == FinOrdFunction([1,2,1,2,1,2])
-@test force(right(span)) == FinOrdFunction([1,1,2,2,3,3])
+span = product(FinSet(2), FinSet(3))
+@test apex(span) == FinSet(6)
+@test force(left(span)) == FinSetFunction([1,2,1,2,1,2])
+@test force(right(span)) == FinSetFunction([1,1,2,2,3,3])
 
 # N-ary Product.
-cone = product([FinOrd(2), FinOrd(3)])
-@test apex(cone) == FinOrd(6)
-@test force(leg(cone,1)) == FinOrdFunction([1,2,1,2,1,2])
-@test force(leg(cone,2)) == FinOrdFunction([1,1,2,2,3,3])
-@test apex(product(FinOrd[])) == FinOrd(1)
+cone = product([FinSet(2), FinSet(3)])
+@test apex(cone) == FinSet(6)
+@test force(leg(cone,1)) == FinSetFunction([1,2,1,2,1,2])
+@test force(leg(cone,2)) == FinSetFunction([1,1,2,2,3,3])
+@test apex(product(FinSet{Int}[])) == FinSet(1)
 
 # Equalizer.
-f, g = FinOrdFunction([1,2,3]), FinOrdFunction([3,2,1])
-@test equalizer(f,g) == FinOrdFunction([2], 3)
-@test equalizer([f,g]) == FinOrdFunction([2], 3)
+f, g = FinSetFunction([1,2,3]), FinSetFunction([3,2,1])
+@test equalizer(f,g) == FinSetFunction([2], 3)
+@test equalizer([f,g]) == FinSetFunction([2], 3)
 
 # Equalizer in case of identical functions.
-f = FinOrdFunction([4,2,3,1], 5)
-@test equalizer(f,f) == force(id(FinOrd(4)))
-@test equalizer([f,f]) == force(id(FinOrd(4)))
+f = FinSetFunction([4,2,3,1], 5)
+@test equalizer(f,f) == force(id(FinSet(4)))
+@test equalizer([f,f]) == force(id(FinSet(4)))
 
 # Equalizer matching nothing.
-f, g = id(FinOrd(5)), FinOrdFunction([2,3,4,5,1], 5)
-@test equalizer(f,g) == FinOrdFunction(Int[], 5)
-@test equalizer([f,g]) == FinOrdFunction(Int[], 5)
+f, g = id(FinSet(5)), FinSetFunction([2,3,4,5,1], 5)
+@test equalizer(f,g) == FinSetFunction(Int[], 5)
+@test equalizer([f,g]) == FinSetFunction(Int[], 5)
 
 # Pullback.
-span = pullback(Cospan(FinOrdFunction([1,1,3,2],4), FinOrdFunction([1,1,4,2],4)))
-@test apex(span) == FinOrd(5)
-@test force(left(span)) == FinOrdFunction([1,2,1,2,4], 4)
-@test force(right(span)) == FinOrdFunction([1,1,2,2,4], 4)
+span = pullback(Cospan(FinSetFunction([1,1,3,2],4), FinSetFunction([1,1,4,2],4)))
+@test apex(span) == FinSet(5)
+@test force(left(span)) == FinSetFunction([1,2,1,2,4], 4)
+@test force(right(span)) == FinSetFunction([1,1,2,2,4], 4)
 
 # Pullback from a singleton set: the degenerate case of a product.
-span = pullback(Cospan(FinOrdFunction([1,1]), FinOrdFunction([1,1,1])))
-@test apex(span) == FinOrd(6)
-@test force(left(span)) == FinOrdFunction([1,2,1,2,1,2])
-@test force(right(span)) == FinOrdFunction([1,1,2,2,3,3])
+span = pullback(Cospan(FinSetFunction([1,1]), FinSetFunction([1,1,1])))
+@test apex(span) == FinSet(6)
+@test force(left(span)) == FinSetFunction([1,2,1,2,1,2])
+@test force(right(span)) == FinSetFunction([1,1,2,2,3,3])
 
 # Pullback using generic limit interface
-f,g = FinOrdFunction([1,1,3,2],4), FinOrdFunction([1,1,4,2],4)
-cone = limit(Diagram([FinOrd(4),FinOrd(4),FinOrd(4)], [(1,3,f),(2,3,g)]))
-@test apex(cone) == FinOrd(5)
-@test force(leg(cone,1)) == FinOrdFunction([1,2,1,2,4],4)
-@test force(leg(cone,2)) == FinOrdFunction([1,1,2,2,4],4)
+f,g = FinSetFunction([1,1,3,2],4), FinSetFunction([1,1,4,2],4)
+cone = limit(Diagram([FinSet(4),FinSet(4),FinSet(4)], [(1,3,f),(2,3,g)]))
+@test apex(cone) == FinSet(5)
+@test force(leg(cone,1)) == FinSetFunction([1,2,1,2,4],4)
+@test force(leg(cone,2)) == FinSetFunction([1,1,2,2,4],4)
 
 # Colimits
 ##########
 
 # Initial object.
-@test initial(FinOrd) == FinOrd(0)
+@test initial(FinSet{Int}) == FinSet(0)
 
 # Binary Coproduct.
-cospan = coproduct(FinOrd(2), FinOrd(3))
-@test base(cospan) == FinOrd(5)
-@test left(cospan) == FinOrdFunction([1,2], 5)
-@test right(cospan) == FinOrdFunction([3,4,5], 5)
+cospan = coproduct(FinSet(2), FinSet(3))
+@test base(cospan) == FinSet(5)
+@test left(cospan) == FinSetFunction([1,2], 5)
+@test right(cospan) == FinSetFunction([3,4,5], 5)
 
 # N-ary Coproduct.
-cocone = coproduct([FinOrd(2), FinOrd(3)])
-@test base(cocone) == FinOrd(5)
-@test leg(cocone,1) == FinOrdFunction([1,2], 5)
-@test leg(cocone,2) == FinOrdFunction([3,4,5], 5)
-@test base(coproduct(FinOrd[])) == FinOrd(0)
+cocone = coproduct([FinSet(2), FinSet(3)])
+@test base(cocone) == FinSet(5)
+@test leg(cocone,1) == FinSetFunction([1,2], 5)
+@test leg(cocone,2) == FinSetFunction([3,4,5], 5)
+@test base(coproduct(FinSet{Int}[])) == FinSet(0)
 
 # Coequalizer from a singleton set.
-f, g = FinOrdFunction([1], 3), FinOrdFunction([3], 3)
-@test coequalizer(f,g) == FinOrdFunction([1,2,1], 2)
-@test coequalizer([f,g]) == FinOrdFunction([1,2,1], 2)
+f, g = FinSetFunction([1], 3), FinSetFunction([3], 3)
+@test coequalizer(f,g) == FinSetFunction([1,2,1], 2)
+@test coequalizer([f,g]) == FinSetFunction([1,2,1], 2)
 
 # Coequalizer in case of identical functions.
-f = FinOrdFunction([4,2,3,1], 5)
-@test coequalizer(f,f) == force(id(FinOrd(5)))
-@test coequalizer([f,f]) == force(id(FinOrd(5)))
+f = FinSetFunction([4,2,3,1], 5)
+@test coequalizer(f,f) == force(id(FinSet(5)))
+@test coequalizer([f,f]) == force(id(FinSet(5)))
 
 # Coequalizer identifying everything.
-f, g = id(FinOrd(5)), FinOrdFunction([2,3,4,5,1], 5)
-@test coequalizer(f,g) == FinOrdFunction(repeat([1],5))
-@test coequalizer([f,g]) == FinOrdFunction(repeat([1],5))
+f, g = id(FinSet(5)), FinSetFunction([2,3,4,5,1], 5)
+@test coequalizer(f,g) == FinSetFunction(repeat([1],5))
+@test coequalizer([f,g]) == FinSetFunction(repeat([1],5))
 
 # Pushout from the empty set: the degenerate case of the coproduct.
-f, g = FinOrdFunction(Int[], 2), FinOrdFunction(Int[], 3)
+f, g = FinSetFunction(Int[], 2), FinSetFunction(Int[], 3)
 cospan = pushout(Span(f,g))
-@test base(cospan) == FinOrd(5)
-@test left(cospan) == FinOrdFunction([1,2], 5)
-@test right(cospan) == FinOrdFunction([3,4,5], 5)
+@test base(cospan) == FinSet(5)
+@test left(cospan) == FinSetFunction([1,2], 5)
+@test right(cospan) == FinSetFunction([3,4,5], 5)
 
 # Pushout from a singleton set.
-f, g = FinOrdFunction([1], 2), FinOrdFunction([2], 3)
+f, g = FinSetFunction([1], 2), FinSetFunction([2], 3)
 cospan = pushout(Span(f,g))
-@test base(cospan) == FinOrd(4)
+@test base(cospan) == FinSet(4)
 h, k = left(cospan), right(cospan)
 @test compose(f,h) == compose(g,k)
-@test h == FinOrdFunction([1,2], 4)
-@test k == FinOrdFunction([3,1,4], 4)
+@test h == FinSetFunction([1,2], 4)
+@test k == FinSetFunction([3,1,4], 4)
 
 # Same thing with generic colimit interface
-diag = Diagram([FinOrd(1),FinOrd(2),FinOrd(3)],[(1,2,f), (1,3,g)])
+diag = Diagram([FinSet(1),FinSet(2),FinSet(3)],[(1,2,f), (1,3,g)])
 cocone = colimit(diag)
-@test base(cocone) == FinOrd(4)
+@test base(cocone) == FinSet(4)
 h, k = leg(cocone,2), leg(cocone,3)
 @test compose(f,h) == compose(g,k)
-@test h == FinOrdFunction([1,2], 4)
-@test k == FinOrdFunction([3,1,4], 4)
+@test h == FinSetFunction([1,2], 4)
+@test k == FinSetFunction([3,1,4], 4)
 
 # Pushout from a two-element set, with non-injective legs.
-f, g = FinOrdFunction([1,1], 2), FinOrdFunction([1,2], 2)
+f, g = FinSetFunction([1,1], 2), FinSetFunction([1,2], 2)
 cospan = pushout(Span(f,g))
-@test base(cospan) == FinOrd(2)
+@test base(cospan) == FinSet(2)
 h, k = left(cospan), right(cospan)
 @test compose(f,h) == compose(g,k)
-@test h == FinOrdFunction([1,2], 2)
-@test k == FinOrdFunction([1,1], 2)
+@test h == FinSetFunction([1,2], 2)
+@test k == FinSetFunction([1,1], 2)
 
 # Same thing with generic colimit interface
-diag = Diagram([FinOrd(2),FinOrd(2),FinOrd(2)],[(1,2,f),(1,3,g)])
+diag = Diagram([FinSet(2),FinSet(2),FinSet(2)],[(1,2,f),(1,3,g)])
 cocone = colimit(diag)
-@test base(cocone) == FinOrd(2)
+@test base(cocone) == FinSet(2)
 h,k = leg(cocone,2), leg(cocone,3)
 @test compose(f,h) == compose(g,k)
-@test h == FinOrdFunction([1,2], 2)
-@test k == FinOrdFunction([1,1], 2)
+@test h == FinSetFunction([1,2], 2)
+@test k == FinSetFunction([1,1], 2)
 
 end


### PR DESCRIPTION
Resolves #215 and follows up #184/#197. In summary:

- `FinOrd` and `FinOrdFunction` are renamed to `FinSet` and `FinFunction`
- `FinOrdRelOb` and `FinOrdRelation` are renamed to `FinRel` and `FinRelation`
- The abstract type `FinFunction` has concrete subtypes `FinFunctionCallable` and `FinFunctionVector` and `FinRelation` has subtypes `FinRelationCallable` and `FinRelationMatrix`. The concrete types are exported but should rarely be needed in user code, which can use the constructors for `FinFunction` and `FinRelation`
- Type parameters are used to distinguished the usual categories from their skeleta. So, `FinSet{Int}` is the skeleton of **FinSet** and `FinSet{<:AbstractSet}` is **FinSet**. Currently, only the former is implemented but the latter could be straightforwardly implemented [along these lines](https://www.philipzucker.com/computational-category-theory-in-python-i-dictionaries-for-finset/).

I really hope this is the last time we need to rewrite this interface, so if you have concerns, speak now or forever hold your peace :)