### PR TITLE
Undirected wiring diagrams as a hypergraph category

### DIFF
--- a/docs/src/apis/wiring_diagrams.md
+++ b/docs/src/apis/wiring_diagrams.md
@@ -4,7 +4,7 @@
 Modules = [
   WiringDiagrams.DirectedWiringDiagrams,
   WiringDiagrams.UndirectedWiringDiagrams,
-  WiringDiagrams.AlgebraicWiringDiagrams,
+  WiringDiagrams.MonoidalDirectedWiringDiagrams,
   WiringDiagrams.WiringDiagramAlgorithms,
   WiringDiagrams.WiringDiagramSerialization,
   WiringDiagrams.GraphMLWiringDiagrams,

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -5,7 +5,6 @@ export AbstractCSet, AbstractCSetType, CSet, CSetType,
   nparts, has_part, subpart, has_subpart, incident,
   add_part!, add_parts!, copy_parts!, set_subpart!, set_subparts!
 
-import Base: show
 using Compat
 using LabelledArrays, StaticArrays
 
@@ -118,6 +117,23 @@ function Base.copy(cset::T) where T <: CSet
 end
 
 Base.empty(cset::T) where T <: CSet = T(map(eltype, cset.data))
+
+function Base.show(io::IO, mime::MIME"text/plain",
+                   a::AbstractCSet{Ob,Hom,Dom,Codom,Data,DataDom}) where
+    {Ob,Hom,Dom,Codom,Data,DataDom}
+  println(io, "CSet")
+  for ob in Ob
+    println(io, "  $ob = 1:$(nparts(a,ob))")
+  end
+  for (i, hom) in enumerate(Hom)
+    println(io, "  $hom : $(Ob[Dom[i]]) → $(Ob[Codom[i]])")
+    println(io, "    $(subpart(a,hom))")
+  end
+  for (i, data) in enumerate(Data)
+    println(io, "  $data : $(Ob[DataDom[i]]) → $(eltype(subpart(a,data)))")
+    println(io, "    $(subpart(a,data))")
+  end
+end
 
 # C-set interface
 #################
@@ -421,22 +437,4 @@ function deletesorted!(a::AbstractVector, x)
   deleteat!(a, i)
 end
 
-# Useful Printing
-#################
-
-function show(io::IO, mime::MIME"text/plain", a::AbstractCSet{Ob,Hom,Dom,Codom,Data,DataDom}) where
-    {Ob,Hom,Dom,Codom,Data,DataDom}
-  println(io, "CSet")
-  for ob in Ob
-    println(io, "  $(string(ob)) = 1:$(nparts(a,ob))")
-  end
-  for i in 1:length(Hom)
-    println(io, "  $(string(Hom[i])) : $(string(Ob[Dom[i]])) -> $(string(Ob[Codom[i]]))")
-    println(io, "    $(subpart(a,Hom[i]))")
-  end
-  for i in 1:length(Data)
-    println(io, "  $(string(Data[i])) : $(string(Ob[DataDom[i]])) -> $(eltype(subpart(a,Data[i])))")
-    println(io, "    $(subpart(a,Data[i]))")
-  end
-end
 end

--- a/src/theories/Monoidal.jl
+++ b/src/theories/Monoidal.jl
@@ -10,7 +10,8 @@ export MonoidalCategory, otimes, munit, ⊗, collect, ndims,
   DaggerCategory, FreeDaggerCategory, dagger,
   DaggerSymmetricMonoidalCategory, FreeDaggerSymmetricMonoidalCategory,
   DaggerCompactCategory, FreeDaggerCompactCategory,
-  TracedMonoidalCategory, FreeTracedMonoidalCategory, trace
+  TracedMonoidalCategory, FreeTracedMonoidalCategory, trace,
+  HypergraphCategory
 
 import Base: collect, ndims
 
@@ -433,4 +434,22 @@ end
 function show_latex(io::IO, expr::HomExpr{:trace}; kw...)
   X, A, B, f = args(expr)
   print(io, "\\operatorname{Tr}_{$A,$B}^{$X} \\left($f\\right)")
+end
+
+# Hypergraph category
+#####################
+
+""" Theory of *hypergraph categories*
+
+Hypergraph categories are also known as "well-supported compact closed
+categories" and "spidered/dungeon categories", among other things.
+
+FIXME: Should also inherit `ClosedMonoidalCategory` and `DaggerCategory`, but
+multiple inheritance is not yet supported.
+"""
+@signature MonoidalCategoryWithBidiagonals(Ob,Hom) => HypergraphCategory(Ob,Hom) begin
+  # Self-dual compact closed category.
+  dunit(A::Ob)::(munit() → (A ⊗ A))
+  dcounit(A::Ob)::((A ⊗ A) → munit())
+  dagger(R::(A → B))::(B → A) ⊣ (A::Ob, B::Ob)
 end

--- a/src/theories/Monoidal.jl
+++ b/src/theories/Monoidal.jl
@@ -447,9 +447,14 @@ categories" and "spidered/dungeon categories", among other things.
 FIXME: Should also inherit `ClosedMonoidalCategory` and `DaggerCategory`, but
 multiple inheritance is not yet supported.
 """
-@signature MonoidalCategoryWithBidiagonals(Ob,Hom) => HypergraphCategory(Ob,Hom) begin
+@theory MonoidalCategoryWithBidiagonals(Ob,Hom) => HypergraphCategory(Ob,Hom) begin
   # Self-dual compact closed category.
   dunit(A::Ob)::(munit() → (A ⊗ A))
   dcounit(A::Ob)::((A ⊗ A) → munit())
-  dagger(R::(A → B))::(B → A) ⊣ (A::Ob, B::Ob)
+  dagger(f::(A → B))::(B → A) ⊣ (A::Ob, B::Ob)
+
+  dunit(A) == create(A) ⋅ mcopy(A) ⊣ (A::Ob)
+  dcounit(A) == mmerge(A) ⋅ delete(A) ⊣ (A::Ob)
+  (dagger(f) == (id(Y) ⊗ dunit(X)) ⋅ (id(Y) ⊗ f ⊗ id(X)) ⋅ (dcounit(Y) ⊗ id(X))
+   ⊣ (A::Ob, B::Ob, f::(A → B)))
 end

--- a/src/theories/MonoidalAdditive.jl
+++ b/src/theories/MonoidalAdditive.jl
@@ -3,7 +3,8 @@ export MonoidalCategoryAdditive, SymmetricMonoidalCategoryAdditive,
   MonoidalCategoryWithCodiagonals, CocartesianCategory, FreeCocartesianCategory,
   plus, zero, copair, coproj1, coproj2,
   MonoidalCategoryWithBidiagonalsAdditive, SemiadditiveCategory,
-  mcopy, delete, pair, proj1, proj2, Δ, ◊, +
+  mcopy, delete, pair, proj1, proj2, Δ, ◊, +,
+  HypergraphCategoryAdditive
 
 import Base: collect, ndims, +, zero
 
@@ -184,4 +185,30 @@ instead of multiplicatively.
   plus(A)⋅◊(A) == ◊(A) ⊕ ◊(A) ⊣ (A::Ob)
   zero(A)⋅Δ(A) == zero(A) ⊕ zero(A) ⊣ (A::Ob)
   zero(A)⋅◊(A) == id(mzero()) ⊣ (A::Ob)
+end
+
+# Hypergraph category
+#####################
+
+""" Theory of *hypergraph categories*, in additive notation
+
+Mathematically the same as [`HypergraphCategory`](@ref) but with different
+notation.
+"""
+@signature SymmetricMonoidalCategoryAdditive(Ob,Hom) =>
+    HypergraphCategoryAdditive(Ob,Hom) begin
+  # Supply of Frobenius monoids.
+  mcopy(A::Ob)::(A → (A ⊕ A))
+  @op (Δ) := mcopy
+  delete(A::Ob)::(A → mzero())
+  @op (◊) := delete
+  mmerge(A::Ob)::((A ⊕ A) → A)
+  @op (∇) := mmerge
+  create(A::Ob)::(mzero() → A)
+  @op (□) := create
+
+  # Self-dual compact closed category.
+  dunit(A::Ob)::(mzero() → (A ⊕ A))
+  dcounit(A::Ob)::((A ⊕ A) → mzero())
+  dagger(R::(A → B))::(B → A) ⊣ (A::Ob, B::Ob)
 end

--- a/src/theories/MonoidalAdditive.jl
+++ b/src/theories/MonoidalAdditive.jl
@@ -210,5 +210,5 @@ notation.
   # Self-dual compact closed category.
   dunit(A::Ob)::(mzero() → (A ⊕ A))
   dcounit(A::Ob)::((A ⊕ A) → mzero())
-  dagger(R::(A → B))::(B → A) ⊣ (A::Ob, B::Ob)
+  dagger(f::(A → B))::(B → A) ⊣ (A::Ob, B::Ob)
 end

--- a/src/theories/Relations.jl
+++ b/src/theories/Relations.jl
@@ -43,20 +43,11 @@ References:
 - Carboni & Walters, 1987, "Cartesian bicategories I", Sec. 5
 - Baez & Erbele, 2015, "Categories in control"
 """
-@signature MonoidalCategoryWithBidiagonalsAdditive(Ob,Hom) =>
+@signature HypergraphCategoryAdditive(Ob,Hom) =>
     AbelianBicategoryRelations(Ob,Hom) begin
-  # Self-dual compact closed category.
-  dunit(A::Ob)::(mzero() → (A ⊕ A))
-  dcounit(A::Ob)::((A ⊕ A) → mzero())
-  dagger(R::(A → B))::(B → A) ⊣ (A::Ob, B::Ob)
-
-  # Merging and creating (right adjoints of copying and deleting maps).
-  mmerge(A::Ob)::((A ⊕ A) → A)
-  @op (∇) := mmerge
-  create(A::Ob)::(mzero() → A)
-  @op (□) := create
-
-  # Co-addition and co-zero (right adjoints of addition and zero maps).
+  # Second supply of Frobenius monoids.
+  plus(A::Ob)::((A ⊕ A) → A)
+  zero(A::Ob)::(mzero() → A)
   coplus(A::Ob)::(A → (A ⊕ A))
   cozero(A::Ob)::(A → mzero())
 

--- a/src/theories/Relations.jl
+++ b/src/theories/Relations.jl
@@ -18,12 +18,7 @@ References:
 - Walters, 2009, blog post, "Categorical algebras of relations",
   http://rfcwalters.blogspot.com/2009/10/categorical-algebras-of-relations.html
 """
-@signature MonoidalCategoryWithBidiagonals(Ob,Hom) => BicategoryRelations(Ob,Hom) begin
-  # Self-dual dagger compact category.
-  dagger(R::(A → B))::(B → A) ⊣ (A::Ob, B::Ob)
-  dunit(A::Ob)::(munit() → (A ⊗ A))
-  dcounit(A::Ob)::((A ⊗ A) → munit())
-
+@signature HypergraphCategory(Ob,Hom) => BicategoryRelations(Ob,Hom) begin
   # Logical operations.
   meet(R::(A → B), S::(A → B))::(A → B) ⊣ (A::Ob, B::Ob)
   top(A::Ob, B::Ob)::(A → B)
@@ -50,10 +45,10 @@ References:
 """
 @signature MonoidalCategoryWithBidiagonalsAdditive(Ob,Hom) =>
     AbelianBicategoryRelations(Ob,Hom) begin
-  # Self-dual dagger compact category.
-  dagger(R::(A → B))::(B → A) ⊣ (A::Ob, B::Ob)
+  # Self-dual compact closed category.
   dunit(A::Ob)::(mzero() → (A ⊕ A))
   dcounit(A::Ob)::((A ⊕ A) → mzero())
+  dagger(R::(A → B))::(B → A) ⊣ (A::Ob, B::Ob)
 
   # Merging and creating (right adjoints of copying and deleting maps).
   mmerge(A::Ob)::((A ⊕ A) → A)

--- a/src/wiring_diagrams/Algebraic.jl
+++ b/src/wiring_diagrams/Algebraic.jl
@@ -1,12 +1,12 @@
-""" Wiring diagrams as a symmetric monoidal category and as an operad.
+""" Wiring diagrams as a symmetric monoidal category.
 
-This module provides a high-level functional and algebraic interface to wiring
-diagrams, building on the low-level imperative interface. It also defines data
-types and functions to represent diagonals, codiagonals, duals, caps, cups,
-daggers, and other structures in wiring diagrams.
+This module provides a high-level categorical interface to wiring diagrams,
+building on the low-level imperative interface and the operadic interface. It
+also defines data types and functions to represent diagonals, codiagonals,
+duals, caps, cups, daggers, and other gadgets in wiring diagrams.
 """
 module AlgebraicWiringDiagrams
-export Ports, Junction, PortOp, BoxOp, functor, ocompose, permute,
+export Ports, Junction, PortOp, BoxOp, functor, permute,
   implicit_mcopy, implicit_mmerge, junctioned_mcopy, junctioned_mmerge,
   junction_diagram, add_junctions, add_junctions!, rem_junctions, merge_junctions,
   junction_caps, junction_cups, junctioned_dunit, junctioned_dcounit
@@ -22,6 +22,7 @@ import ...Theories: dom, codom, id, compose, ⋅, ∘,
 import ...Syntax: functor, head
 using ..DirectedWiringDiagrams
 import ..DirectedWiringDiagrams: Box, WiringDiagram, input_ports, output_ports
+import ..UndirectedWiringDiagrams: add_junctions!
 
 # Categorical interface
 #######################
@@ -358,26 +359,6 @@ join(f::WiringDiagram{AbBiRel}, g::WiringDiagram{AbBiRel}) =
   compose(coplus(dom(f)), oplus(f,g), plus(codom(f)))
 top(A::Ports{AbBiRel}, B::Ports{AbBiRel}) = compose(delete(A), create(B))
 bottom(A::Ports{AbBiRel}, B::Ports{AbBiRel}) = compose(cozero(A), zero(B))
-
-# Operadic interface
-####################
-
-""" Operadic composition of wiring diagrams.
-
-This generic function has two different signatures, corresponding to the "full"
-and "partial" notions of operadic composition (Yau, 2018, *Operads of Wiring
-Diagrams*, Definitions 2.3 and 2.10).
-
-This operation is a simple wrapper around [`substitute`](@ref).
-"""
-function ocompose(f::WiringDiagram, gs::Vector{<:WiringDiagram})
-  @assert length(gs) == nboxes(f)
-  substitute(f, box_ids(f), gs)
-end
-function ocompose(f::WiringDiagram, i::Int, g::WiringDiagram)
-  @assert 1 <= i <= nboxes(f)
-  substitute(f, box_ids(f)[i], g)
-end
 
 # Junctions
 ###########

--- a/src/wiring_diagrams/Directed.jl
+++ b/src/wiring_diagrams/Directed.jl
@@ -481,7 +481,7 @@ end
 # Other constructors
 #-------------------
 
-""" A wiring diagram with a single box connected to its outer ports.
+""" Create wiring diagram with a single box connected to its outer ports.
 """
 function singleton_diagram(T::Type, box::AbstractBox)
   inputs, outputs = input_ports(box), output_ports(box)

--- a/src/wiring_diagrams/Directed.jl
+++ b/src/wiring_diagrams/Directed.jl
@@ -481,7 +481,7 @@ end
 # Other constructors
 #-------------------
 
-""" Create wiring diagram with a single box connected to its outer ports.
+""" Wiring diagram with a single box connected to the outer ports.
 """
 function singleton_diagram(T::Type, box::AbstractBox)
   inputs, outputs = input_ports(box), output_ports(box)

--- a/src/wiring_diagrams/Directed.jl
+++ b/src/wiring_diagrams/Directed.jl
@@ -23,7 +23,7 @@ export AbstractBox, Box, WiringDiagram, Wire, Port, PortKind,
   rem_wires!, port_value, validate_ports, is_permuted_equal,
   all_neighbors, neighbors, outneighbors, inneighbors, in_wires, out_wires,
   singleton_diagram, induced_subdiagram, encapsulated_subdiagram,
-  substitute, encapsulate
+  ocompose, substitute, encapsulate
 
 using Compat
 using AutoHashEquals
@@ -512,6 +512,26 @@ function induced_subdiagram(d::WiringDiagram{T}, vs::Vector{Int}) where T
   return sub
 end
 
+# Operadic interface
+####################
+
+""" Operadic composition of wiring diagrams.
+
+This generic function has two different signatures, corresponding to the "full"
+and "partial" notions of operadic composition (Yau, 2018, *Operads of Wiring
+Diagrams*, Definitions 2.3 and 2.10).
+
+This operation is a simple wrapper around [`substitute`](@ref).
+"""
+function ocompose(f::WiringDiagram, gs::Vector{<:WiringDiagram})
+  @assert length(gs) == nboxes(f)
+  substitute(f, box_ids(f), gs)
+end
+function ocompose(f::WiringDiagram, i::Int, g::WiringDiagram)
+  @assert 1 <= i <= nboxes(f)
+  substitute(f, box_ids(f)[i], g)
+end
+
 # Substitution
 ##############
 
@@ -520,8 +540,8 @@ end
 Performs one or more substitutions. When performing multiple substitutions, the
 substitutions are simultaneous.
 
-This operation implements the operadic composition of wiring diagrams
-(`ocompose`).
+This operation implements the operadic composition of wiring diagrams, see also
+[`ocompose`](@ref).
 """
 function substitute(d::WiringDiagram; kw...)
   substitute(d, filter(v -> box(d,v) isa WiringDiagram, box_ids(d)); kw...)
@@ -637,7 +657,8 @@ default_merge_wire_values(::Any, middle::Any, ::Any) = middle
 
 """ Encapsulate multiple boxes within a single sub-diagram.
 
-This operation is a (one-sided) inverse to subsitution (see `substitute`).
+This operation is a (one-sided) inverse to subsitution, see
+[`substitute`](@ref).
 """
 function encapsulate(d::WiringDiagram, vs::Vector{Int}; value=nothing, kw...)
   encapsulate(d, [vs]; values=[value], kw...)

--- a/src/wiring_diagrams/Directed.jl
+++ b/src/wiring_diagrams/Directed.jl
@@ -478,7 +478,8 @@ function out_wires(d::WiringDiagram, v::Int, port::Int)
   out_wires(d, Port(v, OutputPort, port))
 end
 
-# Other constructors.
+# Other constructors
+#-------------------
 
 """ A wiring diagram with a single box connected to its outer ports.
 """

--- a/src/wiring_diagrams/Expressions.jl
+++ b/src/wiring_diagrams/Expressions.jl
@@ -18,7 +18,7 @@ using LightGraphs
 using ...Syntax, ...Theories
 using ...Syntax: syntax_module
 using ...CategoricalAlgebra.Permutations
-using ..DirectedWiringDiagrams, ..AlgebraicWiringDiagrams
+using ..DirectedWiringDiagrams, ..MonoidalDirectedWiringDiagrams
 using ..WiringDiagramAlgorithms: crossing_minimization_by_sort
 
 # Expression -> Diagram

--- a/src/wiring_diagrams/MonoidalDirected.jl
+++ b/src/wiring_diagrams/MonoidalDirected.jl
@@ -5,7 +5,7 @@ building on the low-level imperative interface and the operadic interface. It
 also defines data types and functions to represent diagonals, codiagonals,
 duals, caps, cups, daggers, and other gadgets in wiring diagrams.
 """
-module AlgebraicWiringDiagrams
+module MonoidalDirectedWiringDiagrams
 export Ports, Junction, PortOp, BoxOp, functor, permute,
   implicit_mcopy, implicit_mmerge, junctioned_mcopy, junctioned_mmerge,
   junction_diagram, add_junctions, add_junctions!, rem_junctions, merge_junctions,

--- a/src/wiring_diagrams/MonoidalDirected.jl
+++ b/src/wiring_diagrams/MonoidalDirected.jl
@@ -65,8 +65,8 @@ WiringDiagram(value, inputs::Ports{T}, outputs::Ports{T}) where T =
 WiringDiagram(inputs::Ports{T}, outputs::Ports{T}) where T =
   WiringDiagram{T}(collect(inputs), collect(outputs))
 
-input_ports(::Type{Ports}, d::WiringDiagram{T}) where T = Ports{T}(input_ports(d))
-output_ports(::Type{Ports}, d::WiringDiagram{T}) where T = Ports{T}(output_ports(d))
+dom(d::WiringDiagram{T}) where T = Ports{T}(input_ports(d))
+codom(d::WiringDiagram{T}) where T = Ports{T}(output_ports(d))
 
 # Symmetric monoidal category
 #----------------------------
@@ -78,8 +78,7 @@ different ways, but wiring diagrams always form a symmetric monoidal category in
 the same way.
 """
 @instance SymmetricMonoidalCategory(Ports, WiringDiagram) begin
-  dom(f::WiringDiagram) = input_ports(Ports, f)
-  codom(f::WiringDiagram) = output_ports(Ports, f)
+  @import dom, codom
 
   function id(A::Ports)
     f = WiringDiagram(A, A)

--- a/src/wiring_diagrams/MonoidalDirected.jl
+++ b/src/wiring_diagrams/MonoidalDirected.jl
@@ -22,7 +22,7 @@ import ...Theories: dom, codom, id, compose, ⋅, ∘,
 import ...Syntax: functor, head
 using ..DirectedWiringDiagrams
 import ..DirectedWiringDiagrams: Box, WiringDiagram, input_ports, output_ports
-import ..UndirectedWiringDiagrams: add_junctions!
+import ..UndirectedWiringDiagrams: add_junctions!, junction_diagram
 
 # Categorical interface
 #######################

--- a/src/wiring_diagrams/MonoidalUndirected.jl
+++ b/src/wiring_diagrams/MonoidalUndirected.jl
@@ -1,19 +1,24 @@
 """ Undirected wiring diagrams as symmetric monoidal categories.
 """
 module MonoidalUndirectedWiringDiagrams
-export cospan_action
+export UndirectedWiringDiagramOb, UndirectedWiringDiagramHom, ObUWD, HomUWD,
+  cospan_action, dom_mask, codom_mask
 
-import ...Theories: otimes, ⊗
+using AutoHashEquals
+
+using ...GAT
+using ...Theories: HypergraphCategory
+import ...Theories: dom, codom, compose, id, ⋅, ∘, otimes, ⊗, munit, braid, σ,
+  mcopy, Δ, mmerge, ∇, delete, ◊, create, □, dunit, dcounit, dagger
 using ...CategoricalAlgebra.CSets: disjoint_union
 using ..UndirectedWiringDiagrams
+using ..UndirectedWiringDiagrams: TypedUndirectedWiringDiagram
+import ..UndirectedWiringDiagrams: singleton_diagram, junction_diagram
 
 const AbstractUWD = UndirectedWiringDiagram
 
 # Cospan algebra
 ################
-
-otimes(f::T, g::T) where T <: AbstractUWD = disjoint_union(f, g)
-⊗(f::T, g::T) where T <: AbstractUWD = otimes(f, g)
 
 """ Act on undirected wiring diagram with a cospan, as in a cospan algebra.
 
@@ -28,5 +33,134 @@ composition, on undirected wiring diagrams.
 function cospan_action(f::AbstractUWD, args...)
   ocompose(cospan_diagram(typeof(f), args...), 1, f)
 end
+
+function compose(f::UWD, g::UWD,
+                 f_codom::BitVector, g_dom::BitVector) where UWD <: AbstractUWD
+  f_dom, g_codom = .!f_codom, .!g_dom
+  k, ℓ, ℓ′, m = sum(f_dom), sum(f_codom), sum(g_dom), sum(g_codom)
+  @assert ℓ == ℓ′
+  f_inner, g_inner = zeros(Int, k+ℓ), zeros(Int, ℓ+m)
+  f_inner[f_dom] = 1:k; g_inner[g_codom] = k+ℓ .+ (1:m)
+  f_inner[f_codom] = g_inner[g_dom] = k .+ (1:ℓ)
+  inner, outer = [f_inner; g_inner], [1:k; k+ℓ .+ (1:m)]
+  junction_types = [ port_type(f, f_dom, outer=true);
+                     port_type(f, f_codom, outer=true);
+                     port_type(g, g_codom, outer=true) ]
+  cospan_action(f⊗g, inner, outer, junction_types)
+end
+
+otimes(f::UWD, g::UWD) where UWD <: AbstractUWD = disjoint_union(f, g)
+⊗(f::UWD, g::UWD) where UWD <: AbstractUWD = otimes(f, g)
+
+# Categorical interface
+#######################
+
+""" List of port types representing outer boundary of undirected wiring diagram.
+"""
+@auto_hash_equals struct UndirectedWiringDiagramOb{UWD<:AbstractUWD,T}
+  types::Vector{T}
+
+  UndirectedWiringDiagramOb{UWD}(types::Vector{T}) where {UWD<:AbstractUWD, T} =
+    new{UWD,T}(types)
+end
+const ObUWD = UndirectedWiringDiagramOb
+
+ObUWD(types::Vector) = ObUWD{TypedUndirectedWiringDiagram}(types)
+
+Base.length(A::ObUWD) = length(A.types)
+Base.cat(A::ObUWD{UWD}, B::ObUWD{UWD}) where UWD =
+  ObUWD{UWD}([A.types; B.types])
+
+""" Undirected wiring diagram with specified domain and codomain.
+
+The outer ports of the undirected wiring diagram are partitioned into domain and
+codomain by masks (bit vectors).
+"""
+@auto_hash_equals struct UndirectedWiringDiagramHom{UWD<:AbstractUWD}
+  diagram::UWD
+  dom::BitVector
+
+  function UndirectedWiringDiagramHom(diagram::UWD;
+      dom::Union{BitVector,Nothing}=nothing,
+      codom::Union{BitVector,Nothing}=nothing) where UWD <: AbstractUWD
+    if !(isnothing(dom) || isnothing(codom))
+      @assert codom == .!dom "Domain and codomain masks must form partition"
+    elseif !isnothing(codom)
+      dom = .!codom
+    elseif isnothing(dom)
+      error("Must supply at least one of domain and codomain masks")
+    end
+    length(dom) == length(ports(diagram, outer=true)) ||
+      error("Length of (co)domain masks must equal number of outer ports")
+    new{UWD}(diagram, dom)
+  end
+end
+const HomUWD = UndirectedWiringDiagramHom
+
+dom_mask(f::HomUWD) = f.dom
+codom_mask(f::HomUWD) = .!f.dom
+
+dom_ports(f::HomUWD) = ports(f.diagram, outer=true)[dom_mask(f)]
+codom_ports(f::HomUWD) = ports(f.diagram, outer=true)[codom_mask(f)]
+dom_port_types(f::HomUWD) = port_type(f.diagram, dom_ports(f), outer=true)
+codom_port_types(f::HomUWD) = port_type(f.diagram, codom_ports(f), outer=true)
+
+dom(f::HomUWD{UWD}) where UWD = ObUWD{UWD}(dom_port_types(f))
+codom(f::HomUWD{UWD}) where UWD = ObUWD{UWD}(codom_port_types(f))
+
+""" Undirected wiring diagrams as a hypergraph category.
+
+The objects are lists of port types and morphisms are undirected wiring diagrams
+whose outer ports are partitioned into domain and codomain.
+"""
+@instance HypergraphCategory(ObUWD, HomUWD) begin
+  @import dom, codom
+
+  function compose(f::HomUWD, g::HomUWD)
+    k, ℓ = sum(dom_mask(f)), sum(codom_mask(g))
+    HomUWD(compose(f.diagram, g.diagram, codom_mask(f), dom_mask(g)),
+           dom=(1:k+ℓ .<= k))
+  end
+  
+  otimes(A::ObUWD, B::ObUWD) = cat(A, B)
+  munit(::Type{ObUWD}) = ObUWD(Symbol[])
+
+  function otimes(f::HomUWD, g::HomUWD)
+    HomUWD(otimes(f.diagram, g.diagram), dom=[dom_mask(f); dom_mask(g)])
+  end
+
+  id(A::ObUWD) = let n = length(A)
+    HomUWD(junction_diagram(A, repeat(1:n, 2)), dom=[trues(n); falses(n)])
+  end
+  braid(A::ObUWD, B::ObUWD) = let m = length(A), n = length(B)
+    HomUWD(junction_diagram(A⊗B, [1:m+n; m+1:m+n; 1:m]),
+           dom=[trues(m+n); falses(m+n)])
+  end
+  mcopy(A::ObUWD) = let n = length(A)
+    HomUWD(junction_diagram(A, repeat(1:n, 3)), dom=[trues(n); falses(2n)])
+  end
+  mmerge(A::ObUWD) = let n = length(A)
+    HomUWD(junction_diagram(A, repeat(1:n, 3)), dom=[trues(2n); falses(n)])
+  end
+  delete(A::ObUWD) = let n = length(A)
+    HomUWD(junction_diagram(A, 1:n), dom=trues(n))
+  end
+  create(A::ObUWD) = let n = length(A)
+    HomUWD(junction_diagram(A, 1:n), dom=falses(n))
+  end
+  dunit(A::ObUWD) = let n = length(A)
+    HomUWD(junction_diagram(A, repeat(1:n, 2)), dom=falses(2n))
+  end
+  dcounit(A::ObUWD) = let n = length(A)
+    HomUWD(junction_diagram(A, repeat(1:n, 2)), dom=trues(2n))
+  end
+  dagger(f::HomUWD) = HomUWD(f.diagram, codom=dom_mask(f))
+end
+
+munit(::Type{ObUWD{UWD}}) where UWD = ObUWD{UWD}(Symbol[])
+munit(::Type{ObUWD{UWD,T}}) where {UWD,T} = ObUWD{UWD}(T[])
+
+singleton_diagram(A::ObUWD{UWD}) where UWD = singleton_diagram(UWD, A.types)
+junction_diagram(A::ObUWD{UWD}, f) where UWD = junction_diagram(UWD, f, A.types)
 
 end

--- a/src/wiring_diagrams/MonoidalUndirected.jl
+++ b/src/wiring_diagrams/MonoidalUndirected.jl
@@ -1,0 +1,32 @@
+""" Undirected wiring diagrams as symmetric monoidal categories.
+"""
+module MonoidalUndirectedWiringDiagrams
+export cospan_action
+
+import ...Theories: otimes, ⊗
+using ...CategoricalAlgebra.CSets: disjoint_union
+using ..UndirectedWiringDiagrams
+
+const AbstractUWD = UndirectedWiringDiagram
+
+# Cospan algebra
+################
+
+otimes(f::T, g::T) where T <: AbstractUWD = disjoint_union(f, g)
+⊗(f::T, g::T) where T <: AbstractUWD = otimes(f, g)
+
+""" Act on undirected wiring diagram with a cospan, as in a cospan algebra.
+
+A *cospan algebra* is a lax monoidal functor from a category of (typed) cospans
+(Cospan,⊕) to (Set,×) (Fong & Spivak, 2019, Hypergraph categories, §2.1: Cospans
+and cospan-algebras). Undirected wiring diagrams are a cospan algebra in
+essentially the same way that any hypergraph category is (Fong & Spivak, 2019,
+§4.1: Cospan-algebras and hypergraph categories are equivalent). In fact, we use
+this action to implement the hypergraph category structure, particularly
+composition, on undirected wiring diagrams.
+"""
+function cospan_action(f::AbstractUWD, args...)
+  ocompose(cospan_diagram(typeof(f), args...), 1, f)
+end
+
+end

--- a/src/wiring_diagrams/Undirected.jl
+++ b/src/wiring_diagrams/Undirected.jl
@@ -12,8 +12,7 @@ using ...CategoricalAlgebra.FinSets: FinFunction, pushout
 using ...Theories: FreeCategory, dom, codom, compose, ⋅, id
 
 import ..DirectedWiringDiagrams: box, boxes, nboxes, add_box!, add_wire!,
-  add_wires!, singleton_diagram
-import ..AlgebraicWiringDiagrams: add_junctions!, ocompose
+  add_wires!, singleton_diagram, ocompose
 
 # Data types
 ############

--- a/src/wiring_diagrams/Undirected.jl
+++ b/src/wiring_diagrams/Undirected.jl
@@ -203,18 +203,18 @@ this function generalizes [`singleton_diagram`](@ref).
 See also: [`junction_diagram`](@ref).
 """
 function cospan_diagram(::Type{T}, f::FinFunction{Int},
-                        f_outer::FinFunction{Int}, port_types=nothing;
+                        f_outer::FinFunction{Int}, junction_types=nothing;
                         data...) where T<:AbstractUWD
   @assert codom(f) == codom(f_outer)
-  if isnothing(port_types); port_types = length(codom(f)) end
-  cospan_diagram(T, collect(f), collect(f_outer), port_types; data...)
+  if isnothing(junction_types); junction_types = length(codom(f)) end
+  cospan_diagram(T, collect(f), collect(f_outer), junction_types; data...)
 end
 function cospan_diagram(::Type{T}, f::AbstractVector{Int},
-                        f_outer::AbstractVector{Int}, port_types;
+                        f_outer::AbstractVector{Int}, junction_types;
                         data...) where T<:AbstractUWD
-  d = empty_diagram(T, map_port_types(port_types, f_outer))
-  add_box!(d, map_port_types(port_types, f); data...)
-  add_junctions!(d, port_types)
+  d = empty_diagram(T, map_port_types(junction_types, f_outer))
+  add_box!(d, map_port_types(junction_types, f); data...)
+  add_junctions!(d, junction_types)
   set_junction!(d, f)
   set_junction!(d, f_outer, outer=true)
   return d
@@ -225,14 +225,14 @@ end
 See also: [`singleton_diagram`](@ref), [`cospan_diagram`](@ref).
 """
 function junction_diagram(::Type{T}, f::FinFunction{Int},
-                          port_types=nothing) where T<:AbstractUWD
-  if isnothing(port_types); port_types = length(codom(f)) end
-  junction_diagram(T, collect(f), port_types)
+                          junction_types=nothing) where T<:AbstractUWD
+  if isnothing(junction_types); junction_types = length(codom(f)) end
+  junction_diagram(T, collect(f), junction_types)
 end
 function junction_diagram(::Type{T}, f::AbstractVector{Int},
-                          port_types) where T<:AbstractUWD
-  d = empty_diagram(T, map_port_types(port_types, f))
-  add_junctions!(d, port_types)
+                          junction_types) where T<:AbstractUWD
+  d = empty_diagram(T, map_port_types(junction_types, f))
+  add_junctions!(d, junction_types)
   set_junction!(d, f, outer=true)
   return d
 end

--- a/src/wiring_diagrams/Undirected.jl
+++ b/src/wiring_diagrams/Undirected.jl
@@ -53,6 +53,8 @@ function UndirectedWiringDiagram(::Type{UWD},
   add_parts!(d, :OuterPort, nports)
   return d
 end
+UndirectedWiringDiagram(nports::Int; kw...) =
+  UndirectedWiringDiagram(UntypedUWD, nports; kw...)
 
 function UndirectedWiringDiagram(::Type{UWD},
     port_types::AbstractVector{T}; data_types...) where {UWD <: AbstractUWD, T}
@@ -61,13 +63,8 @@ function UndirectedWiringDiagram(::Type{UWD},
   add_parts!(d, :OuterPort, nports, outer_port_type=port_types)
   return d
 end
-
-function UndirectedWiringDiagram(port_types; data_types...)
-  UWD = UndirectedWiringDiagramType(typeof(port_types))
-  UndirectedWiringDiagram(UWD, port_types; data_types...)
-end
-UndirectedWiringDiagramType(::Type{Int}) = UntypedUWD
-UndirectedWiringDiagramType(::Type{<:AbstractVector}) = TypedUWD
+UndirectedWiringDiagram(port_types::AbstractVector; kw...) =
+  UndirectedWiringDiagram(TypedUWD, port_types; kw...)
 
 # Imperative interface
 ######################
@@ -181,10 +178,12 @@ function add_wires!(d::AbstractUWD, wires)
   end
 end
 
+# Other constructors
+#-------------------
+
 function singleton_diagram(::Type{T}, port_types; data...) where T<:AbstractUWD
-  UWD = T == UndirectedWiringDiagram ?
-    UndirectedWiringDiagramType(typeof(port_types)) : T
-  d = UndirectedWiringDiagram(UWD, port_types)
+  d = UndirectedWiringDiagram(
+    (T == AbstractUWD ? (port_types,) : (T, port_types))...)
   junctions = add_junctions!(d, port_types)
   add_box!(d, port_types; data...)
   set_junction!(d, junctions)

--- a/src/wiring_diagrams/WiringDiagrams.jl
+++ b/src/wiring_diagrams/WiringDiagrams.jl
@@ -3,8 +3,8 @@ module WiringDiagrams
 using Reexport
 
 include("Directed.jl")
-include("Algebraic.jl")
 include("Undirected.jl")
+include("Algebraic.jl")
 include("Algorithms.jl")
 include("Expressions.jl")
 include("Serialization.jl")
@@ -12,8 +12,8 @@ include("GraphML.jl")
 include("JSON.jl")
 
 @reexport using .DirectedWiringDiagrams
-@reexport using .AlgebraicWiringDiagrams
 @reexport using .UndirectedWiringDiagrams
+@reexport using .AlgebraicWiringDiagrams
 @reexport using .WiringDiagramAlgorithms
 @reexport using .WiringDiagramExpressions
 

--- a/src/wiring_diagrams/WiringDiagrams.jl
+++ b/src/wiring_diagrams/WiringDiagrams.jl
@@ -4,7 +4,7 @@ using Reexport
 
 include("Directed.jl")
 include("Undirected.jl")
-include("Algebraic.jl")
+include("MonoidalDirected.jl")
 include("Algorithms.jl")
 include("Expressions.jl")
 include("Serialization.jl")
@@ -13,7 +13,7 @@ include("JSON.jl")
 
 @reexport using .DirectedWiringDiagrams
 @reexport using .UndirectedWiringDiagrams
-@reexport using .AlgebraicWiringDiagrams
+@reexport using .MonoidalDirectedWiringDiagrams
 @reexport using .WiringDiagramAlgorithms
 @reexport using .WiringDiagramExpressions
 

--- a/src/wiring_diagrams/WiringDiagrams.jl
+++ b/src/wiring_diagrams/WiringDiagrams.jl
@@ -5,6 +5,7 @@ using Reexport
 include("Directed.jl")
 include("Undirected.jl")
 include("MonoidalDirected.jl")
+include("MonoidalUndirected.jl")
 include("Algorithms.jl")
 include("Expressions.jl")
 include("Serialization.jl")
@@ -14,6 +15,7 @@ include("JSON.jl")
 @reexport using .DirectedWiringDiagrams
 @reexport using .UndirectedWiringDiagrams
 @reexport using .MonoidalDirectedWiringDiagrams
+@reexport using .MonoidalUndirectedWiringDiagrams
 @reexport using .WiringDiagramAlgorithms
 @reexport using .WiringDiagramExpressions
 

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -94,6 +94,11 @@ copy_parts!(d2, d, :X, [4,5])
 @test subpart(d2, [1,2], :parent) == [2,2]
 @test subpart(d2, [1,2], :height) == [10,20]
 
+du = disjoint_union(d, d2)
+@test nparts(du, :X) == 7
+@test subpart(du, :parent) == [4,4,4,5,5,7,7]
+@test subpart(du, :height) == [0,0,0,10,20,10,20]
+
 # Labeled sets
 ##############
 

--- a/test/wiring_diagrams/MonoidalDirected.jl
+++ b/test/wiring_diagrams/MonoidalDirected.jl
@@ -1,4 +1,4 @@
-module TestAlgebraicWiringDiagrams
+module TestMonoidalDirectedWiringDiagrams
 using Test
 
 using Catlab.Theories, Catlab.WiringDiagrams
@@ -282,37 +282,6 @@ S = singleton_diagram(AbelianBicategoryRelations, Box(:S,[:A],[:B]))
 @test coplus(A) != mcopy(A)
 @test zero(A) != create(A)
 @test cozero(A) != delete(A)
-
-# Operadic interface
-####################
-
-f, g, h = map([:f, :g, :h]) do sym
-  (i::Int) -> singleton_diagram(Box(Symbol("$sym$i"), [:A], [:A]))
-end
-
-# Identity
-d = compose(f(1),f(2))
-@test ocompose(g(1), 1, d) == d
-@test ocompose(g(1), [d]) == d
-@test ocompose(d, [f(1),f(2)]) == d
-@test ocompose(d, 1, f(1)) == d
-@test ocompose(d, 2, f(2)) == d
-
-# Associativity
-@test ocompose(compose(f(1),f(2)), [
-  ocompose(compose(g(1),g(2)), [compose(h(1),h(2)), compose(h(3),h(4))]),
-  ocompose(compose(g(3),g(4)), [compose(h(5),h(6)), compose(h(7),h(8))])
-]) == ocompose(
-  ocompose(compose(f(1),f(2)), [compose(g(1),g(2)), compose(g(3),g(4))]),
-  [compose(h(1),h(2)), compose(h(3),h(4)), compose(h(5),h(6)), compose(h(7),h(8))]
-)
-@test ocompose(
-  ocompose(compose(f(1),f(2)), 1, compose(g(1),g(2))),
-  3, compose(g(3),g(4))
-) == ocompose(
-  ocompose(compose(f(1),f(2)), 2, compose(g(3),g(4))),
-  1, compose(g(1),g(2))
-)
 
 # Junctions
 ###########

--- a/test/wiring_diagrams/MonoidalUndirected.jl
+++ b/test/wiring_diagrams/MonoidalUndirected.jl
@@ -1,0 +1,53 @@
+module TestMonoidalUndirectedWiringDiagrams
+using Test
+
+using Catlab.Theories, Catlab.WiringDiagrams
+
+# Categorical interface
+#######################
+
+# Category
+#---------
+
+# Domains and codomains
+A, B = ObUWD([:A]), ObUWD([:B])
+f = HomUWD(singleton_diagram(A⊗B), dom=BitArray([1,0]))
+g = HomUWD(singleton_diagram(B⊗A), codom=BitArray([0,1]))
+@test dom(f) == A
+@test codom(f) == B
+@test dom(g) == B
+@test codom(g) == A
+
+# Composition and identities
+fg = compose(f,g)
+@test dom(fg) == A
+@test codom(fg) == A
+@test nboxes(fg.diagram) == 2
+@test njunctions(fg.diagram) == 3
+@test compose(id(dom(f)), f) == f
+@test compose(f, id(codom(f))) == f
+
+# Symmetric monoidal category
+#----------------------------
+
+# Monoidal products
+X, Y = ObUWD([:A,:B]), ObUWD([:C,:D])
+I = munit(ObUWD)
+@test otimes(A,B) == X
+@test otimes(X,I) == X
+@test otimes(I,X) == X
+@test dom(f⊗g) == A⊗B
+@test codom(f⊗g) == B⊗A
+
+# Braiding
+@test compose(braid(X,Y),braid(Y,X)) == id(otimes(X,Y))
+
+# Hypergraph category
+#--------------------
+
+@test compose(create(X), mcopy(X)) == dunit(X)
+@test compose(mmerge(X), delete(X)) == dcounit(X)
+# XXX: Not equal due to ordering of outer ports, but isomorphic.
+#@test (id(B)⊗dunit(A)) ⋅ (id(B)⊗f⊗id(A)) ⋅ (dcounit(B)⊗id(A)) == dagger(f)
+
+end

--- a/test/wiring_diagrams/Undirected.jl
+++ b/test/wiring_diagrams/Undirected.jl
@@ -82,6 +82,12 @@ add_box!(d, 2); add_junctions!(d, 1)
 set_junction!(d, [1,1]); set_junction!(d, 1, outer=true)
 @test cospan_diagram(UWD, FinFunction([1,1]), FinFunction([1])) == d
 
+# Diagrams from functions: junctions only.
+d = UndirectedWiringDiagram(4)
+add_junctions!(d, 3)
+set_junction!(d, [1,2,2,3], outer=true)
+@test junction_diagram(UWD, FinFunction([1,2,2,3])) == d
+
 # Operadic interface
 ####################
 

--- a/test/wiring_diagrams/Undirected.jl
+++ b/test/wiring_diagrams/Undirected.jl
@@ -1,7 +1,10 @@
 module TestUndirectedWiringDiagrams
 using Test
 
+using Catlab.CategoricalAlgebra.FinSets: FinFunction
 using Catlab.WiringDiagrams.UndirectedWiringDiagrams
+
+const UWD = UndirectedWiringDiagram
 
 # Imperative interface
 ######################
@@ -58,12 +61,26 @@ add_wire!(d, (1,2) => (2,2))
 add_wire!(d, (2,2) => (3,2))
 @test d == d_previous
 
+# Other constructors
+#-------------------
+
 # Singleton diagrams.
 d = UndirectedWiringDiagram([:X,:Y,:Z])
-add_junctions!(d, [:X,:Y,:Z])
 add_box!(d, [:X,:Y,:Z])
+add_junctions!(d, [:X,:Y,:Z])
 set_junction!(d, 1:3); set_junction!(d, 1:3, outer=true)
-@test singleton_diagram(UndirectedWiringDiagram, [:X,:Y,:Z]) == d
+@test singleton_diagram(UWD, [:X,:Y,:Z]) == d
+
+# Diagrams from cospans.
+@test cospan_diagram(UWD, FinFunction(1:3), FinFunction(1:3), [:X,:Y,:Z]) ==
+  singleton_diagram(UWD, [:X,:Y,:Z])
+@test cospan_diagram(UWD, FinFunction(1:3), FinFunction(1:3)) ==
+  singleton_diagram(UWD, 3)
+
+d = UndirectedWiringDiagram(1)
+add_box!(d, 2); add_junctions!(d, 1)
+set_junction!(d, [1,1]); set_junction!(d, 1, outer=true)
+@test cospan_diagram(UWD, FinFunction([1,1]), FinFunction([1])) == d
 
 # Operadic interface
 ####################

--- a/test/wiring_diagrams/WiringDiagrams.jl
+++ b/test/wiring_diagrams/WiringDiagrams.jl
@@ -1,10 +1,7 @@
 using Test
 
-@testset "Directed" begin
+@testset "Core" begin
   include("Directed.jl")
-end
-
-@testset "Undirected" begin
   include("Undirected.jl")
 end
 
@@ -20,10 +17,7 @@ end
   include("Expressions.jl")
 end
 
-@testset "GraphML" begin
+@testset "Serialization" begin
   include("GraphML.jl")
-end
-
-@testset "JSON" begin
   include("JSON.jl")
 end

--- a/test/wiring_diagrams/WiringDiagrams.jl
+++ b/test/wiring_diagrams/WiringDiagrams.jl
@@ -5,8 +5,8 @@ using Test
   include("Undirected.jl")
 end
 
-@testset "Algebraic" begin
-  include("Algebraic.jl")
+@testset "Monoidal" begin
+  include("MonoidalDirected.jl")
 end
 
 @testset "Algorithms" begin

--- a/test/wiring_diagrams/WiringDiagrams.jl
+++ b/test/wiring_diagrams/WiringDiagrams.jl
@@ -7,6 +7,7 @@ end
 
 @testset "Monoidal" begin
   include("MonoidalDirected.jl")
+  include("MonoidalUndirected.jl")
 end
 
 @testset "Algorithms" begin


### PR DESCRIPTION
Resolves #216 and goes most of the way toward #218:

- Adds constructors `junction_diagram` and `cospan_diagram` for UWDs with zero or one boxes
- Implements UWDs as a cospan algebra (see Fong & Spivak, 2019, "Hypergraph categories")
- Uses the foregoing to implement UWDs as a hypergraph category (properly speaking, UWDs whose outer ports have been partitioned into domain and codomain)