### PR TITLE
BUG: _file=missing causes error in @warn

### DIFF
--- a/src/core/GAT.jl
+++ b/src/core/GAT.jl
@@ -204,7 +204,7 @@ end
 
 function parse_theory_binding(expr::Expr)::TheoryBinding
   @warn "Using Haskell-style theory declaration with parentheses is deprecated," *
-    " use Julia-style with curly braces." _file=missing _line=missing
+    " use Julia-style with curly braces."
   @match expr begin
     Expr(:call, name::Symbol, params...) => TheoryBinding(name, params)
     _ => throw(ParseError("Ill-formed theory binding $expr"))

--- a/src/core/Syntax.jl
+++ b/src/core/Syntax.jl
@@ -107,7 +107,7 @@ macro syntax(syntax_head, mod_name, body=nothing)
   syntax_name, base_types = @match syntax_head begin
     Expr(:call, name::Symbol, args...) => begin
       @warn "Using Haskell-style theory declaration with parentheses is deprecated," *
-        " use Julia-style with curly braces." _file=missing _line=missing
+        " use Julia-style with curly braces."
       (name, args)
     end
     Expr(:curly, name::Symbol, args...) => (name, args)


### PR DESCRIPTION
The deprecation warning on the old syntax errors when run; this fixes the error.