### PR TITLE
Allow TagBot to build documentation

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -9,3 +9,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
According to the Documenter.jl docs
https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#GitHub-Actions 
This should allow the TagBot to build the documentation for tags and therefore for the stable versions. This should close #241.

