### PR TITLE
Version Bump on Master

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Catlab"
 uuid = "134e5e36-593f-5add-ad60-77f754baafbe"
 license = "MIT"
 authors = ["Evan Patterson <evan@epatters.org>"]
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"


### PR DESCRIPTION
Version bump the master branch. Currently if you depend on Catlab v0.7.4+ and `]dev Catlab` you get a version issue.