### PR TITLE
V0.7.4 Version Bump on Master

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 AutoHashEquals = "^0"
 Compat = "^1, ^2, ^3"
-Compose = "^0"
+Compose = "0.7 - 0"
 DataStructures = "^0"
 GeneralizedGenerated = "^0"
 JSON = "^0"

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Catlab"
 uuid = "134e5e36-593f-5add-ad60-77f754baafbe"
 license = "BSD2"
 authors = ["Evan Patterson <evan@epatters.org>"]
-version = "0.7.3"
+version = "0.7.4"
 
 [deps]
 AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"

--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 [compat]
 AutoHashEquals = "^0"
 Compat = "^1, ^2, ^3"
-Compose = "0.7 - 0"
+Compose = "0.7, 0.8, 0.9"
 DataStructures = "^0"
 GeneralizedGenerated = "^0"
 JSON = "^0"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -12,6 +12,12 @@ using Catlab,
 
 @info "Building Literate.jl docs"
 
+# XXX: Work around old LaTeX distribution in GitHub CI.
+if haskey(ENV, "GITHUB_ACTIONS")
+  import TikzPictures
+  TikzPictures.standaloneWorkaround(true)
+end
+
 # Set Literate.jl config if not being compiled on recognized service.
 config = Dict{String,String}()
 if !(haskey(ENV, "GITHUB_ACTIONS") || haskey(ENV, "GITLAB_CI"))


### PR DESCRIPTION
Version bump the master branch. Currently if you depend on Catlab v0.7.4+ and `]dev Catlab` you get a version issue.