### PR TITLE
Restore original unit tests for C-sets

### DIFF
--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -2,44 +2,149 @@ module TestCSets
 using Test
 
 using Catlab: @present
-using Catlab.Theories
+using Catlab.Theories: FreeSchema, CatDescType, SchemaType
 using Catlab.CategoricalAlgebra.CSets
 
-@present TheoryDecGraph(FreeSchema) begin
-  V::Ob
-  E::Ob
+# Discrete dynamical systems
+############################
 
-  src::Hom(E,V)
-  tgt::Hom(E,V)
- 
-  X::Data
-
-  vdec::Attr(V,X)
-  edec::Attr(E,X)
+@present TheoryDDS(FreeSchema) begin
+  X::Ob
+  Φ::Hom(X,X)
 end
 
-const AbstractDecGraph{T} = AbstractACSet{SchemaType(TheoryDecGraph)...,Tuple{T}}
+const AbstractDDS = AbstractCSet{CatDescType(TheoryDDS)}
+const DDS = CSet{CatDescType(TheoryDDS), (:Φ,)}
+@test DDS <: AbstractDDS
+@test DDS <: CSet
 
-const DecGraph{T} = ACSet{SchemaType(TheoryDecGraph)...,Tuple{T},(:src,:tgt,:vdec)}
+dds = DDS()
+@test keys(dds.indices) == (:Φ,)
+@test nparts(dds, :X) == 0
+@test add_part!(dds, :X, Φ=0) == 1 # FIXME: Shouldn't need Φ=0
+@test nparts(dds, :X) == 1
+@test incident(dds, 1, :Φ) == []
 
-g = DecGraph{Symbol}()
+set_subpart!(dds, 1, :Φ, 1)
+@test subpart(dds, 1, :Φ) == 1
+@test incident(dds, 1, :Φ) == [1]
 
-@test add_parts!(g,:V,vdec=[:a,:b,:d]) == 1:3
+@test add_part!(dds, :X, Φ=1) == 2
+@test add_part!(dds, :X, Φ=1) == 3
+@test subpart(dds, :Φ) == [1,1,1]
+@test subpart(dds, [2,3], :Φ) == [1,1]
+@test incident(dds, 1, :Φ) == [1,2,3]
 
-@test subpart(g,:vdec) == [:a,:b,:d]
+@test has_part(dds, :X)
+@test !has_part(dds, :nonpart)
+@test has_part(dds, :X, 3)
+@test !has_part(dds, :X, 4)
+@test has_part(dds, :X, 1:5) == [true, true, true, false, false]
 
-@test subpart(g,2,:vdec) == :b
+@test has_subpart(dds, :Φ)
+@test !has_subpart(dds, :nonsubpart)
+@test_throws KeyError subpart(dds, 1, :nonsubpart)
+@test_throws KeyError set_subpart!(dds, 1, :nonsubpart, 1)
 
-@test incident(g,:a,:vdec) == [1]
+# Error handling
+@test_throws ErrorException add_part!(dds, :X, Φ=5)
+@test_skip subpart(dds, :Φ) == [1,1,1,0]
+@test_skip incident(dds, 4, :Φ) == []
 
-@test add_parts!(g,:E,src=[1,2],tgt=[2,3],edec=[:f,:g]) == 1:2
+# Dendrograms
+#############
 
-@test incident(g,3,:tgt) == [2]
+# Strictly speaking, this data structure is not a single dendrogram but a forest
+# of dendrograms (whose roots are the elements fixed under the `parent` map) and
+# in order to be valid dendrograms, the `height` map must satisfy
+# `compose(parent, height) ≥ height` pointwise.
 
-set_subpart!(g,2,:tgt,2)
+@present TheoryDendrogram(FreeSchema) begin
+  X::Ob
+  R::Data
+  parent::Hom(X,X)
+  height::Attr(X,R)
+end
 
-@test incident(g,3,:tgt) == []
+const AbstractDendrogram{T} =
+  AbstractACSet{SchemaType(TheoryDendrogram)..., Tuple{T}}
+const Dendrogram{T} =
+  ACSet{SchemaType(TheoryDendrogram)..., Tuple{T}, (:parent,)}
 
-@test incident(g,2,:tgt) == [1,2]
+d = Dendrogram{Int}()
+# add_parts!(d, :X, 3, height=0)
+# add_parts!(d, :X, 2, height=[10,20])
+# FIXME: Broadcasting style should work.
+# add_parts!(d, :X, 3, height=[0,0,0], parent=[0,0,0])
+# add_parts!(d, :X, 2, height=[10,20], parent=[0,0])
+# FIXME: Order of keyword arguments should not matter.
+add_parts!(d, :X, 3, parent=[0,0,0], height=[0,0,0])
+add_parts!(d, :X, 2, parent=[0,0], height=[10,20])
+set_subpart!(d, 1:3, :parent, 4)
+set_subpart!(d, [4,5], :parent, 5)
+
+@test nparts(d, :X) == 5
+@test subpart(d, [1,2,3], :parent) == [4,4,4]
+@test subpart(d, 4, :parent) == 5
+@test subpart(d, :, :parent) == [4,4,4,5,5]
+@test incident(d, 4, :parent) == [1,2,3]
+@test has_subpart(d, :height)
+@test subpart(d, [1,2,3], :height) == [0,0,0]
+@test subpart(d, 4, :height) == 10
+@test subpart(d, :, :height) == [0,0,0,10,20]
+
+d2 = empty(d)
+copy_parts!(d2, d, :X, [4,5])
+@test nparts(d2, :X) == 2
+@test subpart(d2, [1,2], :parent) == [2,2]
+@test subpart(d2, [1,2], :height) == [10,20]
+
+du = disjoint_union(d, d2)
+@test nparts(du, :X) == 7
+@test subpart(du, :parent) == [4,4,4,5,5,7,7]
+@test subpart(du, :height) == [0,0,0,10,20,10,20]
+
+# Labeled sets
+##############
+
+# The simplest example of a C-set with a data attribute, to test data indexing.
+
+@present TheoryLabeledSet(FreeSchema) begin
+  X::Ob
+  Label::Data
+  label::Attr(X,Label)
+end
+
+const IndexedLabeledSet{T} =
+  ACSet{SchemaType(TheoryLabeledSet)..., Tuple{T}, (:label,)}
+
+lset = IndexedLabeledSet{Symbol}()
+@test keys(lset.indices) == (:label,)
+add_parts!(lset, :X, 2, label=[:foo, :bar])
+@test subpart(lset, :, :label) == [:foo, :bar]
+@test incident(lset, :foo, :label) == [1]
+@test isempty(incident(lset, :nonkey, :label))
+
+add_part!(lset, :X, label=:foo)
+@test incident(lset, :foo, :label) == [1,3]
+#set_subpart!(lset, 1, :label, :baz) # FIXME: @generated error.
+@test_skip subpart(lset, 1, :label) == :baz
+@test_skip incident(lset, [:foo,:baz], :label) == [[3],[1]]
+
+# TODO: Unique indexing temporarily not supported.
+# const UniqueIndexedLabeledSet = ...
+
+# lset = UniqueIndexedLabeledSet{Symbol}()
+# @test keys(lset.data_indices) == (:label,)
+# add_parts!(lset, :X, 2, label=[:foo, :bar])
+# @test subpart(lset, :, :label) == [:foo, :bar]
+# @test incident(lset, :foo, :label) == 1
+# @test incident(lset, [:foo,:bar], :label) == [1,2]
+# @test incident(lset, :nonkey, :label) == nothing
+
+# set_subpart!(lset, 1, :label, :baz)
+# @test subpart(lset, 1, :label) == :baz
+# @test incident(lset, :baz, :label) == 1
+# @test_throws ErrorException set_subpart!(lset, 1, :label, :bar)
 
 end


### PR DESCRIPTION
The tests were lost in the C-sets refactor (#219). I'm restoring them since they provide good coverage. This has exposed a few issues that should be resolved in follow-up PRs.