### PR TITLE
Missing type parameters in abstract type for ACSets

### DIFF
--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -76,6 +76,9 @@ end
 
 const AbstractDendrogram = AbstractACSetType(TheoryDendrogram)
 const Dendrogram = ACSetType(TheoryDendrogram, index=[:parent])
+@test Dendrogram <: AbstractDendrogram
+@test Dendrogram <: ACSet
+@test Dendrogram{Real} <: AbstractDendrogram{Real}
 
 d = Dendrogram{Int}()
 add_parts!(d, :X, 3, height=0)


### PR DESCRIPTION
I think this commit should restore the intended behavior, which tries to strike a balance between allowing subtyping where useful and having an informative abstract type.

@mehalter, can you confirm that this fixes the problem you reported today?