### PR TITLE
Limits of C-sets

### DIFF
--- a/src/categorical_algebra/CSetMorphisms.jl
+++ b/src/categorical_algebra/CSetMorphisms.jl
@@ -101,9 +101,7 @@ force(α::ACSetTransformation) =
   dom(α::ACSetTransformation) = α.dom
   codom(α::ACSetTransformation) = α.codom
 
-  function id(X::ACSet)
-    ACSetTransformation(map(t -> id(FinSet(length(t))), X.tables), X, X)
-  end
+  id(X::ACSet) = ACSetTransformation(map(id, finsets(X)), X, X)
 
   function compose(α::ACSetTransformation, β::ACSetTransformation)
     # Question: Should we incur cost of checking that codom(β) == dom(α)?
@@ -111,6 +109,8 @@ force(α::ACSetTransformation) =
                         dom(α), codom(β))
   end
 end
+
+finsets(X::ACSet) = map(table -> FinSet(length(table)), X.tables)
 
 # Limits and colimits
 #####################
@@ -141,9 +141,9 @@ end
 unpack_diagram(diagram::DiscreteDiagram{<:AbstractCSet}) =
   map(DiscreteDiagram, unpack_finsets(ob(diagram)))
 unpack_diagram(span::Multispan{<:AbstractCSet}) =
-  map(Multispan, unpack_finsets(apex(span)), unpack_components(legs(span)))
+  map(Multispan, finsets(apex(span)), unpack_components(legs(span)))
 unpack_diagram(cospan::Multicospan{<:AbstractCSet}) =
-  map(Multicospan, unpack_finsets(base(cospan)), unpack_components(legs(cospan)))
+  map(Multicospan, finsets(base(cospan)), unpack_components(legs(cospan)))
 unpack_diagram(para::ParallelMorphisms{<:AbstractCSet}) =
   map(ParallelMorphisms, unpack_components(hom(para)))
 
@@ -166,9 +166,13 @@ function pack_components(fs::NamedTuple{Ob}, doms, codoms) where Ob
   map(ACSetTransformation, components, doms, codoms)
 end
 
-# TODO: Document.
+""" Objects in diagram that will have explicit legs in limit cone.
+
+Encodes common conventions such as, when taking a pullback of a cospan, not
+including a leg for the base since it can be computed from the other legs.
+"""
 cone_objects(diagram) = ob(diagram)
-cone_objects(span::Multispan) = map(codom, legs(span))
+cone_objects(cospan::Multicospan) = map(dom, legs(cospan))
 cone_objects(para::ParallelMorphisms) = SVector(dom(para))
 
 end

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -225,7 +225,7 @@ end
 
 """ Number of parts of given type in a C-set.
 """
-nparts(acs::ACSet, type::Symbol) = length(acs.tables[type])
+nparts(acs::ACSet, type) = length(acs.tables[type])
 
 """ Whether a C-set has a part with the given name.
 """

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -8,7 +8,7 @@ using Compat: only
 using AutoHashEquals
 using DataStructures: IntDisjointSets, union!, find_root
 import FunctionWrappers: FunctionWrapper
-using StaticArrays: StaticVector, SVector, @SVector
+using StaticArrays: SVector, @SVector
 
 using ...GAT
 using ...Theories: Category
@@ -129,7 +129,7 @@ compose_impl(f::FinFunctionVector, g::FinFunctionVector) = g.func[f.func]
 # Limits
 ########
 
-function product(Xs::StaticVector{0,<:FinSet{Int}})
+function product(Xs::EmptyDiagram{<:FinSet{Int}})
   Limit(Xs, Multispan(FinSet(1), @SVector FinFunction{Int}[]))
 end
 
@@ -137,7 +137,7 @@ function factorize(lim::Terminal{<:FinSet{Int}}, X::FinSet{Int})
   FinFunction(ones(Int, length(X)))
 end
 
-function product(Xs::StaticVector{2,<:FinSet{Int}})
+function product(Xs::ObjectPair{<:FinSet{Int}})
   m, n = length.(Xs)
   indices = CartesianIndices((m, n))
   π1 = FinFunction(i -> indices[i][1], m*n, m)
@@ -152,7 +152,7 @@ function factorize(lim::BinaryProduct{<:FinSet{Int}}, fs::Span{<:FinSet{Int}})
   FinFunction(i -> indices[f(i),g(i)], apex(fs), ob(lim))
 end
 
-function product(Xs::AbstractVector{<:FinSet{Int}})
+function product(Xs::DiscreteDiagram{<:FinSet{Int}})
   ns = length.(Xs)
   indices = CartesianIndices(Tuple(ns))
   n = prod(ns)
@@ -197,7 +197,7 @@ end
 # Colimits
 ##########
 
-function coproduct(Xs::StaticVector{0,<:FinSet{Int}})
+function coproduct(Xs::EmptyDiagram{<:FinSet{Int}})
   Colimit(Xs, Multicospan(FinSet(0), @SVector FinFunction{Int}[]))
 end
 
@@ -205,7 +205,7 @@ function factorize(colim::Initial{<:FinSet{Int}}, X::FinSet{Int})
   FinFunction(Int[], X)
 end
 
-function coproduct(Xs::StaticVector{2,<:FinSet{Int}})
+function coproduct(Xs::ObjectPair{<:FinSet{Int}})
   m, n = length.(Xs)
   ι1 = FinFunction(1:m, m, m+n)
   ι2 = FinFunction(m+1:m+n, n, m+n)
@@ -218,7 +218,7 @@ function factorize(colim::BinaryCoproduct{<:FinSet{Int}},
   FinFunction(vcat(collect(f), collect(g)), ob(colim), base(fs))
 end
 
-function coproduct(Xs::AbstractVector{<:FinSet{Int}})
+function coproduct(Xs::DiscreteDiagram{<:FinSet{Int}})
   ns = length.(Xs)
   n = sum(ns)
   offsets = [0,cumsum(ns)...]

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -187,6 +187,8 @@ function universal(lim::Equalizer{<:FinSet{Int}},
   FinFunction(Int[only(searchsorted(ι, i)) for i in collect(h)], length(ι))
 end
 
+limit(cospan::Multicospan{<:FinSet{Int}}) = composite_pullback(cospan)
+
 function limit(d::FreeDiagram{<:FinSet{Int}})
   p = product(ob(d))
   n, leg = length(ob(p)), legs(p)
@@ -278,6 +280,8 @@ function universal(coeq::Coequalizer{<:FinSet{Int}},
   end
   FinFunction(q, codom(h))
 end
+
+colimit(span::Multispan{<:FinSet{Int}}) = composite_pushout(span)
 
 function colimit(d::FreeDiagram{<:FinSet{Int}})
   coprod = coproduct(ob(d))

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -14,8 +14,7 @@ using ...GAT
 using ...Theories: Category
 import ...Theories: dom, codom, id, compose, ⋅, ∘
 using ..FreeDiagrams, ..Limits
-import ..Limits: terminal, product, equalizer, pullback, limit,
-  initial, coproduct, coequalizer, pushout, colimit, factorize
+import ..Limits: limit, colimit, factorize
 
 # Category of finite sets
 #########################
@@ -129,7 +128,7 @@ compose_impl(f::FinFunctionVector, g::FinFunctionVector) = g.func[f.func]
 # Limits
 ########
 
-function product(Xs::EmptyDiagram{<:FinSet{Int}})
+function limit(Xs::EmptyDiagram{<:FinSet{Int}})
   Limit(Xs, Multispan(FinSet(1), @SVector FinFunction{Int}[]))
 end
 
@@ -137,7 +136,7 @@ function factorize(lim::Terminal{<:FinSet{Int}}, X::FinSet{Int})
   FinFunction(ones(Int, length(X)))
 end
 
-function product(Xs::ObjectPair{<:FinSet{Int}})
+function limit(Xs::ObjectPair{<:FinSet{Int}})
   m, n = length.(Xs)
   indices = CartesianIndices((m, n))
   π1 = FinFunction(i -> indices[i][1], m*n, m)
@@ -152,7 +151,7 @@ function factorize(lim::BinaryProduct{<:FinSet{Int}}, fs::Span{<:FinSet{Int}})
   FinFunction(i -> indices[f(i),g(i)], apex(fs), ob(lim))
 end
 
-function product(Xs::DiscreteDiagram{<:FinSet{Int}})
+function limit(Xs::DiscreteDiagram{<:FinSet{Int}})
   ns = length.(Xs)
   indices = CartesianIndices(Tuple(ns))
   n = prod(ns)
@@ -166,14 +165,14 @@ function factorize(lim::Product{<:FinSet{Int}}, fs::Multispan{<:FinSet})
   FinFunction(i -> indices[(f(i) for f in fs)...], apex(fs), ob(lim))
 end
 
-function equalizer(pair::ParallelPair{<:FinSet{Int}})
+function limit(pair::ParallelPair{<:FinSet{Int}})
   f, g = pair
   m = length(dom(pair))
   eq = FinFunction(filter(i -> f(i) == g(i), 1:m), m)
   Limit(pair, Multispan(SVector(eq)))
 end
 
-function equalizer(para::ParallelMorphisms{<:FinSet{Int}})
+function limit(para::ParallelMorphisms{<:FinSet{Int}})
   @assert !isempty(para)
   f1, frest = para[1], para[2:end]
   m = length(dom(para))
@@ -197,7 +196,7 @@ end
 # Colimits
 ##########
 
-function coproduct(Xs::EmptyDiagram{<:FinSet{Int}})
+function colimit(Xs::EmptyDiagram{<:FinSet{Int}})
   Colimit(Xs, Multicospan(FinSet(0), @SVector FinFunction{Int}[]))
 end
 
@@ -205,7 +204,7 @@ function factorize(colim::Initial{<:FinSet{Int}}, X::FinSet{Int})
   FinFunction(Int[], X)
 end
 
-function coproduct(Xs::ObjectPair{<:FinSet{Int}})
+function colimit(Xs::ObjectPair{<:FinSet{Int}})
   m, n = length.(Xs)
   ι1 = FinFunction(1:m, m, m+n)
   ι2 = FinFunction(m+1:m+n, n, m+n)
@@ -218,7 +217,7 @@ function factorize(colim::BinaryCoproduct{<:FinSet{Int}},
   FinFunction(vcat(collect(f), collect(g)), ob(colim), base(fs))
 end
 
-function coproduct(Xs::DiscreteDiagram{<:FinSet{Int}})
+function colimit(Xs::DiscreteDiagram{<:FinSet{Int}})
   ns = length.(Xs)
   n = sum(ns)
   offsets = [0,cumsum(ns)...]
@@ -232,7 +231,7 @@ function factorize(colim::Coproduct{<:FinSet{Int}},
               ob(colim), base(fs))
 end
 
-function coequalizer(pair::ParallelPair{<:FinSet{Int}})
+function colimit(pair::ParallelPair{<:FinSet{Int}})
   f, g = pair
   m, n = length(dom(pair)), length(codom(pair))
   sets = IntDisjointSets(n)
@@ -245,7 +244,7 @@ function coequalizer(pair::ParallelPair{<:FinSet{Int}})
   Colimit(pair, Multicospan(SVector(coeq)))
 end
 
-function coequalizer(para::ParallelMorphisms{<:FinSet{Int}})
+function colimit(para::ParallelMorphisms{<:FinSet{Int}})
   @assert !isempty(para)
   f1, frest = para[1], para[2:end]
   m, n = length(dom(para)), length(codom(para))

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -168,7 +168,7 @@ function limit(pair::ParallelPair{<:FinSet{Int}})
   f, g = pair
   m = length(dom(pair))
   eq = FinFunction(filter(i -> f(i) == g(i), 1:m), m)
-  Limit(pair, SMultispan{1}(eq))
+  Limit(pair, SMultispan(eq))
 end
 
 function limit(para::ParallelMorphisms{<:FinSet{Int}})
@@ -176,7 +176,7 @@ function limit(para::ParallelMorphisms{<:FinSet{Int}})
   f1, frest = para[1], para[2:end]
   m = length(dom(para))
   eq = FinFunction(filter(i -> all(f1(i) == f(i) for f in frest), 1:m), m)
-  Limit(para, SMultispan{1}(eq))
+  Limit(para, SMultispan(eq))
 end
 
 function factorize(lim::Equalizer{<:FinSet{Int}}, h::FinFunction{Int})
@@ -240,7 +240,7 @@ function colimit(pair::ParallelPair{<:FinSet{Int}})
   h = [ find_root(sets, i) for i in 1:n ]
   roots = unique!(sort(h))
   coeq = FinFunction([ searchsortedfirst(roots, r) for r in h], length(roots))
-  Colimit(pair, SMulticospan{1}(coeq))
+  Colimit(pair, SMulticospan(coeq))
 end
 
 function colimit(para::ParallelMorphisms{<:FinSet{Int}})
@@ -256,7 +256,7 @@ function colimit(para::ParallelMorphisms{<:FinSet{Int}})
   h = [ find_root(sets, i) for i in 1:n ]
   roots = unique!(sort(h))
   coeq = FinFunction([ searchsortedfirst(roots, r) for r in h ], length(roots))
-  Colimit(para, SMulticospan{1}(coeq))
+  Colimit(para, SMulticospan(coeq))
 end
 
 function factorize(coeq::Coequalizer{<:FinSet{Int}}, h::FinFunction{Int})

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -8,7 +8,6 @@ using Compat: only
 using AutoHashEquals
 using DataStructures: IntDisjointSets, union!, find_root
 import FunctionWrappers: FunctionWrapper
-using StaticArrays: SVector, @SVector
 
 using ...GAT
 using ...Theories: Category
@@ -129,7 +128,7 @@ compose_impl(f::FinFunctionVector, g::FinFunctionVector) = g.func[f.func]
 ########
 
 function limit(Xs::EmptyDiagram{<:FinSet{Int}})
-  Limit(Xs, Multispan(FinSet(1), @SVector FinFunction{Int}[]))
+  Limit(Xs, SMultispan{0}(FinSet(1)))
 end
 
 function factorize(lim::Terminal{<:FinSet{Int}}, X::FinSet{Int})
@@ -169,7 +168,7 @@ function limit(pair::ParallelPair{<:FinSet{Int}})
   f, g = pair
   m = length(dom(pair))
   eq = FinFunction(filter(i -> f(i) == g(i), 1:m), m)
-  Limit(pair, Multispan(SVector(eq)))
+  Limit(pair, SMultispan{1}(eq))
 end
 
 function limit(para::ParallelMorphisms{<:FinSet{Int}})
@@ -177,7 +176,7 @@ function limit(para::ParallelMorphisms{<:FinSet{Int}})
   f1, frest = para[1], para[2:end]
   m = length(dom(para))
   eq = FinFunction(filter(i -> all(f1(i) == f(i) for f in frest), 1:m), m)
-  Limit(para, Multispan(SVector(eq)))
+  Limit(para, SMultispan{1}(eq))
 end
 
 function factorize(lim::Equalizer{<:FinSet{Int}}, h::FinFunction{Int})
@@ -197,7 +196,7 @@ end
 ##########
 
 function colimit(Xs::EmptyDiagram{<:FinSet{Int}})
-  Colimit(Xs, Multicospan(FinSet(0), @SVector FinFunction{Int}[]))
+  Colimit(Xs, SMulticospan{0}(FinSet(0)))
 end
 
 function factorize(colim::Initial{<:FinSet{Int}}, X::FinSet{Int})
@@ -241,7 +240,7 @@ function colimit(pair::ParallelPair{<:FinSet{Int}})
   h = [ find_root(sets, i) for i in 1:n ]
   roots = unique!(sort(h))
   coeq = FinFunction([ searchsortedfirst(roots, r) for r in h], length(roots))
-  Colimit(pair, Multicospan(SVector(coeq)))
+  Colimit(pair, SMulticospan{1}(coeq))
 end
 
 function colimit(para::ParallelMorphisms{<:FinSet{Int}})
@@ -257,7 +256,7 @@ function colimit(para::ParallelMorphisms{<:FinSet{Int}})
   h = [ find_root(sets, i) for i in 1:n ]
   roots = unique!(sort(h))
   coeq = FinFunction([ searchsortedfirst(roots, r) for r in h ], length(roots))
-  Colimit(para, Multicospan(SVector(coeq)))
+  Colimit(para, SMulticospan{1}(coeq))
 end
 
 function factorize(coeq::Coequalizer{<:FinSet{Int}}, h::FinFunction{Int})

--- a/src/categorical_algebra/FreeDiagrams.jl
+++ b/src/categorical_algebra/FreeDiagrams.jl
@@ -64,26 +64,22 @@ shape is a pushout.
 end
 
 function Multispan(legs::AbstractVector)
-  @assert !isempty(legs) && allequal(dom.(legs))
+  !isempty(legs) || error("Empty list of legs but no base given")
+  allequal(dom.(legs)) || error("Legs $legs do not have common domain")
   Multispan(dom(first(legs)), legs)
 end
 
 const SMultispan{N,Ob} = Multispan{Ob,<:StaticVector{N}}
 
+SMultispan(legs...) = Multispan(SVector(legs...))
+SMultispan{N}(legs::Vararg{T,N}) where {T,N} = Multispan(SVector(legs...))
 SMultispan{0}(apex) = Multispan(apex, SVector{0,Any}())
-SMultispan{1}(leg) = Multispan(dom(leg), SVector(leg))
 
 """ Span of morphims in a category.
 
 A common special case of [`Multispan`](@ref). See also [`Cospan`](@ref).
 """
-const Span{Ob} = Multispan{Ob,<:StaticVector{2}}
-
-function Span(left, right)
-  dom(left) == dom(right) ||
-    error("Domains of legs of span do not match: $left vs $right")
-  Multispan(dom(left), SVector(left, right))
-end
+const Span{Ob} = SMultispan{2,Ob}
 
 apex(span::Multispan) = span.apex
 legs(span::Multispan) = span.legs
@@ -106,26 +102,22 @@ legs different than two. A limit of this shape is a pullback.
 end
 
 function Multicospan(legs::AbstractVector)
-  @assert !isempty(legs) && allequal(codom.(legs))
+  !isempty(legs) || error("Empty list of legs but no base given")
+  allequal(codom.(legs)) || error("Legs $legs do not have common codomain")
   Multicospan(codom(first(legs)), legs)
 end
 
 const SMulticospan{N,Ob} = Multicospan{Ob,<:StaticVector{N}}
 
+SMulticospan(legs...) = Multicospan(SVector(legs...))
+SMulticospan{N}(legs::Vararg{T,N}) where {T,N} = Multicospan(SVector(legs...))
 SMulticospan{0}(base) = Multicospan(base, SVector{0,Any}())
-SMulticospan{1}(leg) = Multicospan(codom(leg), SVector(leg))
 
 """ Cospan of morphisms in a category.
 
 A common special case of [`Multicospan`](@ref). See also [`Span`](@ref).
 """
 const Cospan{Ob} = SMulticospan{2,Ob}
-
-function Cospan(left, right)
-  codom(left) == codom(right) ||
-    error("Codomains of legs of cospan do not match: $left vs $right")
-  Multicospan(codom(left), SVector(left, right))
-end
 
 base(cospan::Multicospan) = cospan.base
 legs(cospan::Multicospan) = cospan.legs

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -98,52 +98,69 @@ coproj1(colim::Union{BinaryCoproduct,BinaryPushout}) = first(legs(colim))
 coproj2(colim::Union{BinaryCoproduct,BinaryPushout}) = last(legs(colim))
 proj(coeq::Coequalizer) = only(legs(coeq))
 
-# Generic functions
-###################
+# Generic limits and colimits
+#############################
 
 """ Limit of a diagram.
+
+To define limits in a category with objects `Ob`, override the method
+`limit(::FreeDiagram{Ob})` for general limits or `limit(::D)` with suitable type
+`D <: FixedShapeFreeDiagram{Ob}` for limits of specific shape, such as products
+or equalizers.
+
+See also: [`colimit`](@ref)
 """
 function limit end
 
 """ Colimit of a diagram.
+
+To define colimits in a category with objects `Ob`, override the method
+`colimit(::FreeDiagram{Ob})` for general colimits or `colimit(::D)` with
+suitable type `D <: FixedShapeFreeDiagram{Ob}` for colimits of specific shape,
+such as coproducts or coequalizers.
+
+See also: [`limit`](@ref)
 """
 function colimit end
 
-terminal(T::Type) = product(EmptyDiagram{T}())
-initial(T::Type) = coproduct(EmptyDiagram{T}())
+# Specific limits and colimits
+##############################
+
+terminal(T::Type) = limit(EmptyDiagram{T}())
+initial(T::Type) = colimit(EmptyDiagram{T}())
 
 delete(lim::Terminal, A) = factorize(lim, A)
 create(colim::Initial, A) = factorize(colim, A)
 
 """ Product of a pair of objects.
 """
-product(A, B) = product(ObjectPair(A, B))
-product(As::AbstractVector) = product(DiscreteDiagram(As))
+product(A, B) = limit(ObjectPair(A, B))
+product(As::AbstractVector) = limit(DiscreteDiagram(As))
 
 """ Coproduct of a pair of objects.
 """
-coproduct(A, B) = coproduct(ObjectPair(A, B))
-coproduct(As::AbstractVector) = coproduct(DiscreteDiagram(As))
+coproduct(A, B) = colimit(ObjectPair(A, B))
+coproduct(As::AbstractVector) = colimit(DiscreteDiagram(As))
 
 """ Equalizer of a pair of morphisms with common domain and codomain.
 """
-equalizer(f, g) = equalizer(ParallelPair(f, g))
-equalizer(fs::AbstractVector) = equalizer(ParallelMorphisms(fs))
+equalizer(f, g) = limit(ParallelPair(f, g))
+equalizer(fs::AbstractVector) = limit(ParallelMorphisms(fs))
 
 """ Coequalizer of a pair of morphisms with common domain and codomain.
 """
-coequalizer(f, g) = coequalizer(ParallelPair(f, g))
-coequalizer(fs::AbstractVector) = coequalizer(ParallelMorphisms(fs))
+coequalizer(f, g) = colimit(ParallelPair(f, g))
+coequalizer(fs::AbstractVector) = colimit(ParallelMorphisms(fs))
 
 """ Pullback of a pair of morphisms with common codomain.
 """
-pullback(f, g) = pullback(Cospan(f, g))
-pullback(fs::AbstractVector) = pullback(Multicospan(fs))
+pullback(f, g) = limit(Cospan(f, g))
+pullback(fs::AbstractVector) = limit(Multicospan(fs))
 
 """ Pushout of a pair of morphisms with common domain.
 """
-pushout(f, g) = pushout(Span(f, g))
-pushout(fs::AbstractVector) = pushout(Multispan(fs))
+pushout(f, g) = colimit(Span(f, g))
+pushout(fs::AbstractVector) = colimit(Multispan(fs))
 
 """ Pairing of morphisms: universal property of products/pullbacks.
 """
@@ -179,11 +196,11 @@ struct CompositePullback{Ob, Diagram<:Multicospan{Ob}, Cone<:Multispan{Ob},
   eq::Eq
 end
 
-""" Pullback of a cospan.
+""" Default implementation of the pullback of a cospan.
 
-The default implementation computes the pullback from products and equalizers.
+Computes the pullback from products and equalizers.
 """
-function pullback(cospan::Cospan)
+function limit(cospan::Cospan)
   f, g = cospan
   (π1, π2) = prod = product(dom(f), dom(g))
   (ι,) = eq = equalizer(π1⋅f, π2⋅g)
@@ -206,12 +223,11 @@ struct CompositePushout{Ob, Diagram<:Multispan{Ob}, Cocone<:Multicospan{Ob},
   coeq::Coeq
 end
 
-""" Pushout of a span.
+""" Default implementation of the pushout of a span.
 
-The default implementation computes the pushout from coproducts and
-coequalizers.
+Computes the pushout from coproducts and coequalizers.
 """
-function pushout(span::Span)
+function colimit(span::Span)
   f, g = span
   (ι1, ι2) = coprod = coproduct(codom(f), codom(g))
   (π,) = coeq = coequalizer(f⋅ι1, g⋅ι2)

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -126,43 +126,85 @@ function colimit end
 # Specific limits and colimits
 ##############################
 
+""" Terminal object.
+
+To implement for a type `T`, define the method `limit(::EmptyDiagram{T})`.
+"""
 terminal(T::Type) = limit(EmptyDiagram{T}())
+
+""" Initial object.
+
+To implement for a type `T`, define the method `colimit(::EmptyDiagram{T})`.
+"""
 initial(T::Type) = colimit(EmptyDiagram{T}())
 
+""" Universal morphism into a terminal object.
+
+To implement for a type `T`, define the method `factorize(::Terminal{T}, ::T)`.
+"""
 delete(lim::Terminal, A) = factorize(lim, A)
+
+""" Universal morphism out of an initial object.
+
+To implement for a type `T`, define the method `factorize(::Initial{T}, ::T)`.
+"""
 create(colim::Initial, A) = factorize(colim, A)
 
-""" Product of a pair of objects.
+""" Product of objects.
+
+To implement for a type `T`, define the method `limit(::ObjectPair{T})` and/or
+`limit(::DiscreteDiagram{T})`.
 """
 product(A, B) = limit(ObjectPair(A, B))
 product(As::AbstractVector) = limit(DiscreteDiagram(As))
 
-""" Coproduct of a pair of objects.
+""" Coproduct of objects.
+
+To implement for a type `T`, define the method `colimit(::ObjectPair{T})` and/or
+`colimit(::DiscreteDiagram{T})`.
 """
 coproduct(A, B) = colimit(ObjectPair(A, B))
 coproduct(As::AbstractVector) = colimit(DiscreteDiagram(As))
 
-""" Equalizer of a pair of morphisms with common domain and codomain.
+""" Equalizer of morphisms with common domain and codomain.
+
+To implement for a type `T`, define the method `limit(::ParallelPair{T})` and/or
+`limit(::ParallelMorphisms{T})`.
 """
 equalizer(f, g) = limit(ParallelPair(f, g))
 equalizer(fs::AbstractVector) = limit(ParallelMorphisms(fs))
 
-""" Coequalizer of a pair of morphisms with common domain and codomain.
+""" Coequalizer of morphisms with common domain and codomain.
+
+To implement for a type `T`, define the method `colimit(::ParallelPair{T})` or
+`colimit(::ParallelMorphisms{T})`.
 """
 coequalizer(f, g) = colimit(ParallelPair(f, g))
 coequalizer(fs::AbstractVector) = colimit(ParallelMorphisms(fs))
 
 """ Pullback of a pair of morphisms with common codomain.
+
+To implement for a type `T`, define the method `limit(::Cospan{T})` and/or
+`limit(::Multicospan{T})` or, if you have already implemented products and
+equalizers, rely on the default implementation.
 """
 pullback(f, g) = limit(Cospan(f, g))
 pullback(fs::AbstractVector) = limit(Multicospan(fs))
 
 """ Pushout of a pair of morphisms with common domain.
+
+To implement for a type `T`, define the method `colimit(::Span{T})` and/or
+`colimit(::Multispan{T})` or, if you have already implemented coproducts and
+coequalizers, rely on the default implementation.
 """
 pushout(f, g) = colimit(Span(f, g))
 pushout(fs::AbstractVector) = colimit(Multispan(fs))
 
 """ Pairing of morphisms: universal property of products/pullbacks.
+
+To implement for products of type `T`, define the method
+`factorize(::BinaryProduct{T}, ::Span{T})` and/or
+`factorize(::Product{T}, ::Multispan{T})` and similarly for pullbacks.
 """
 pair(lim::Union{BinaryProduct,BinaryPullback}, f, g) =
   factorize(lim, Span(f, g))
@@ -170,6 +212,10 @@ pair(lim::Union{Product,Pullback}, fs::AbstractVector) =
   factorize(lim, Multispan(fs))
 
 """ Copairing of morphisms: universal property of coproducts/pushouts.
+
+To implement for coproducts of type `T`, define the method
+`factorize(::BinaryCoproduct{T}, ::Cospan{T})` and/or
+`factorize(::Coproduct{T}, ::Multicospan{T})` and similarly for pushouts.
 """
 copair(colim::Union{BinaryCoproduct,BinaryPushout}, f, g) =
   factorize(colim, Cospan(f, g))

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -7,7 +7,8 @@ export AbstractLimit, AbstractColimit, Limit, Colimit,
   BinaryProduct, Product, product, proj1, proj2, pair,
   BinaryPullback, Pullback, BinaryEqualizer, Equalizer, pullback, incl,
   BinaryCoproduct, Coproduct, coproduct, coproj1, coproj2, copair,
-  BinaryPushout, Pushout, BinaryCoequalizer, Coequalizer, pushout, proj
+  BinaryPushout, Pushout, BinaryCoequalizer, Coequalizer, pushout, proj,
+  composite_pullback, composite_pushout
 
 using Compat: only
 
@@ -98,8 +99,8 @@ coproj1(colim::Union{BinaryCoproduct,BinaryPushout}) = first(legs(colim))
 coproj2(colim::Union{BinaryCoproduct,BinaryPushout}) = last(legs(colim))
 proj(coeq::Coequalizer) = only(legs(coeq))
 
-# Generic limits and colimits
-#############################
+# Generic (co)limits
+####################
 
 """ Limit of a diagram.
 
@@ -132,8 +133,8 @@ See also: [`limit`](@ref), [`colimit`](@ref).
 """
 function universal end
 
-# Specific limits and colimits
-##############################
+# Specific (co)limits
+#####################
 
 """ Terminal object.
 
@@ -242,8 +243,8 @@ define the method `universal(::Coequalizer{T}, ::SMulticospan{1,T})`.
 factorize(lim::Equalizer, h) = universal(lim, SMultispan(h))
 factorize(colim::Coequalizer, h) = universal(colim, SMulticospan(h))
 
-# Default implementations
-#########################
+# Composite (co)limits
+######################
 
 """ Pullback formed as composite of product and equalizer.
 
@@ -262,16 +263,15 @@ struct CompositePullback{Ob, Diagram<:Multicospan{Ob}, Cone<:Multispan{Ob},
   eq::Eq
 end
 
-""" Default implementation of the pullback of a cospan.
-
-Computes the pullback from products and equalizers.
+""" Compute pullback as composite of product and equalizer.
 """
-function limit(cospan::Cospan)
+function composite_pullback(cospan::Cospan)
   f, g = cospan
   (π1, π2) = prod = product(dom(f), dom(g))
   (ι,) = eq = equalizer(π1⋅f, π2⋅g)
   CompositePullback(cospan, Span(ι⋅π1, ι⋅π2), prod, eq)
 end
+composite_pullback(f, g) = composite_pullback(Cospan(f, g))
 
 function universal(lim::CompositePullback, cone::Multispan)
   factorize(lim.eq, universal(lim.prod, cone))
@@ -289,16 +289,15 @@ struct CompositePushout{Ob, Diagram<:Multispan{Ob}, Cocone<:Multicospan{Ob},
   coeq::Coeq
 end
 
-""" Default implementation of the pushout of a span.
-
-Computes the pushout from coproducts and coequalizers.
+""" Compute pushout as composite of coproduct and coequalizer.
 """
-function colimit(span::Span)
+function composite_pushout(span::Span)
   f, g = span
   (ι1, ι2) = coprod = coproduct(codom(f), codom(g))
   (π,) = coeq = coequalizer(f⋅ι1, g⋅ι2)
   CompositePushout(span, Cospan(ι1⋅π, ι2⋅π), coprod, coeq)
 end
+composite_pushout(f, g) = composite_pushout(Span(f, g))
 
 function universal(lim::CompositePushout, cone::Multicospan)
   factorize(lim.coeq, universal(lim.coprod, cone))

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -12,7 +12,6 @@ export AbstractLimit, AbstractColimit, Limit, Colimit,
 using Compat: only
 
 using AutoHashEquals
-using StaticArrays: StaticVector, SVector, @SVector
 
 using ...Theories
 import ...Theories: ob, terminal, product, proj1, proj2, equalizer, incl,
@@ -48,9 +47,9 @@ Base.length(lim::AbstractLimit) = length(cone(lim))
   cone::Cone
 end
 
-const Terminal{Ob} = AbstractLimit{Ob,<:StaticVector{0}}
-const BinaryProduct{Ob} = AbstractLimit{Ob,<:StaticVector{2}}
-const Product{Ob} = AbstractLimit{Ob,<:AbstractVector}
+const Terminal{Ob} = AbstractLimit{Ob,<:EmptyDiagram}
+const BinaryProduct{Ob} = AbstractLimit{Ob,<:ObjectPair}
+const Product{Ob} = AbstractLimit{Ob,<:DiscreteDiagram}
 const BinaryPullback{Ob} = AbstractLimit{Ob,<:Cospan}
 const Pullback{Ob} = AbstractLimit{Ob,<:Multicospan}
 const BinaryEqualizer{Ob} = AbstractLimit{Ob,<:ParallelPair}
@@ -87,9 +86,9 @@ Base.length(colim::AbstractColimit) = length(cocone(colim))
   cocone::Cocone
 end
 
-const Initial{Ob} = AbstractColimit{Ob,<:StaticVector{0}}
-const BinaryCoproduct{Ob} = AbstractColimit{Ob,<:StaticVector{2}}
-const Coproduct{Ob} = AbstractColimit{Ob,<:AbstractVector}
+const Initial{Ob} = AbstractColimit{Ob,<:EmptyDiagram}
+const BinaryCoproduct{Ob} = AbstractColimit{Ob,<:ObjectPair}
+const Coproduct{Ob} = AbstractColimit{Ob,<:DiscreteDiagram}
 const BinaryPushout{Ob} = AbstractColimit{Ob,<:Span}
 const Pushout{Ob} = AbstractColimit{Ob,<:Multispan}
 const BinaryCoequalizer{Ob} = AbstractColimit{Ob,<:ParallelPair}
@@ -110,19 +109,21 @@ function limit end
 """
 function colimit end
 
-terminal(T::Type) = product(@SVector T[])
-initial(T::Type) = coproduct(@SVector T[])
+terminal(T::Type) = product(EmptyDiagram{T}())
+initial(T::Type) = coproduct(EmptyDiagram{T}())
 
 delete(lim::Terminal, A) = factorize(lim, A)
 create(colim::Initial, A) = factorize(colim, A)
 
 """ Product of a pair of objects.
 """
-product(A, B) = product(SVector(A, B))
+product(A, B) = product(ObjectPair(A, B))
+product(As::AbstractVector) = product(DiscreteDiagram(As))
 
 """ Coproduct of a pair of objects.
 """
-coproduct(A, B) = coproduct(SVector(A, B))
+coproduct(A, B) = coproduct(ObjectPair(A, B))
+coproduct(As::AbstractVector) = coproduct(DiscreteDiagram(As))
 
 """ Equalizer of a pair of morphisms with common domain and codomain.
 """

--- a/test/categorical_algebra/CSetMorphisms.jl
+++ b/test/categorical_algebra/CSetMorphisms.jl
@@ -37,6 +37,43 @@ add_edges!(h, [1,2], [2,1])
 @test force(compose(id(g), α)) == α
 @test force(compose(α, id(h))) == α
 
+# Limits
+#-------
+
+# Terminal object in Graph: the self-loop.
+term = Graph(1)
+add_edge!(term, 1, 1)
+@test ob(terminal(Graph)) == term
+
+# Products in Graph: unitality.
+lim = product(g, term)
+@test ob(lim) == g
+@test force(proj1(lim)) == force(id(g))
+@test force(proj2(lim)) ==
+  CSetTransformation((V=fill(1,4), E=fill(1,3)), g, term)
+
+# Product in Graph: two directed intervals (Reyes et al 2004, p. 48).
+I = Graph(2)
+add_edge!(I, 1, 2)
+prod = ob(product(I, I))
+@test nv(prod) == 4
+@test ne(prod) == 1
+@test src(prod) != tgt(prod)
+
+# Product in Graph: deleting edges by multiplying by an isolated vertex.
+g0 = ob(product(g, Graph(1)))
+@test nv(g0) == nv(g)
+@test ne(g0) == 0
+
+# Product in Graph: copying edges by multiplying by the double self-loop.
+cycle2 = Graph(1)
+add_edges!(cycle2, [1,1], [1,1])
+g2 = ob(product(g, cycle2))
+@test nv(g2) == nv(g)
+@test ne(g2) == 2*ne(g)
+@test src(g2) == repeat(src(g), 2)
+@test tgt(g2) == repeat(tgt(g), 2)
+
 # Attributed C-set morphisms
 ############################
 

--- a/test/categorical_algebra/CSetMorphisms.jl
+++ b/test/categorical_algebra/CSetMorphisms.jl
@@ -61,6 +61,8 @@ prod = ob(product(I, I))
 @test src(prod) != tgt(prod)
 
 # Product in Graph: deleting edges by multiplying by an isolated vertex.
+g = Graph(4)
+add_edges!(g, [1,2,3], [2,3,4])
 g0 = ob(product(g, Graph(1)))
 @test nv(g0) == nv(g)
 @test ne(g0) == 0
@@ -73,6 +75,35 @@ g2 = ob(product(g, cycle2))
 @test ne(g2) == 2*ne(g)
 @test src(g2) == repeat(src(g), 2)
 @test tgt(g2) == repeat(tgt(g), 2)
+
+# Equalizer in Graph from (Reyes et al 2004, p. 50).
+g, h = Graph(2), Graph(2)
+add_edges!(g, [1,2], [2,1])
+add_edges!(h, [1,2,2], [2,1,1])
+ϕ = CSetTransformation((V=[1,2], E=[1,2]), g, h)
+ψ = CSetTransformation((V=[1,2], E=[1,3]), g, h)
+@test is_natural(ϕ) && is_natural(ψ)
+eq = equalizer(ϕ, ψ)
+@test ob(eq) == I
+@test force(incl(eq)[:V]) == FinFunction([1,2])
+@test force(incl(eq)[:E]) == FinFunction([1], 2)
+
+# Pullback in Graph from (Reyes et al 2004, p. 53).
+# This test exposes an error in the text: using their notation, there should be
+# a second edge between the vertices (1,3) and (1,4).
+g0, g1, g2 = Graph(2), Graph(3), Graph(2)
+add_edges!(g0, [1,1,2], [1,2,2])
+add_edges!(g1, [1,2,3], [2,3,3])
+add_edges!(g2, [1,2,2], [1,2,2])
+ϕ = CSetTransformation((V=[1,2,2], E=[2,3,3]), g1, g0)
+ψ = CSetTransformation((V=[1,2], E=[1,3,3]), g2, g0)
+@test is_natural(ϕ) && is_natural(ψ)
+lim = pullback(ϕ, ψ)
+@test nv(ob(lim)) == 3
+@test sort!(collect(zip(src(ob(lim)), tgt(ob(lim))))) ==
+  [(2,3), (2,3), (3,3), (3,3)]
+@test is_natural(proj1(lim))
+@test is_natural(proj2(lim))
 
 # Attributed C-set morphisms
 ############################

--- a/test/categorical_algebra/FreeDiagrams.jl
+++ b/test/categorical_algebra/FreeDiagrams.jl
@@ -19,6 +19,25 @@ diagram = FreeDiagram([A,B,C], [(1,3,f),(2,3,g),(1,2,h)])
 # Diagrams of fixed shape
 #########################
 
+# Empty diagrams.
+@test isempty(EmptyDiagram{FreeCategory.Ob}())
+
+# Object pairs.
+pair = ObjectPair(A,B)
+@test length(pair) == 2
+@test first(pair) == A
+@test last(pair) == B
+
+# Discrete diagrams.
+discrete = DiscreteDiagram([A,B,C])
+@test length(discrete) == 3
+A′, B′, C′ = discrete
+@test [A′,B′,C′] == collect(discrete)
+
+diagram = FreeDiagram(discrete)
+@test ob(diagram) == [A,B,C]
+@test isempty(hom(diagram))
+
 # Spans.
 f, g = Hom(:f, C, A), Hom(:g, C, B)
 span = Span(f,g)

--- a/test/categorical_algebra/FreeDiagrams.jl
+++ b/test/categorical_algebra/FreeDiagrams.jl
@@ -31,8 +31,7 @@ pair = ObjectPair(A,B)
 # Discrete diagrams.
 discrete = DiscreteDiagram([A,B,C])
 @test length(discrete) == 3
-A′, B′, C′ = discrete
-@test [A′,B′,C′] == collect(discrete)
+@test ob(discrete) == [A,B,C]
 
 diagram = FreeDiagram(discrete)
 @test ob(diagram) == [A,B,C]
@@ -94,6 +93,7 @@ f, g, h = Hom(:f, A, B), Hom(:g, A, B), Hom(:h, A, B)
 para = ParallelMorphisms([f,g,h])
 @test dom(para) == A
 @test codom(para) == B
+@test hom(para) == [f,g,h]
 
 diagram = FreeDiagram(para)
 @test ob(diagram) == [A,B]

--- a/test/categorical_algebra/FreeDiagrams.jl
+++ b/test/categorical_algebra/FreeDiagrams.jl
@@ -46,7 +46,7 @@ span = Span(f,g)
 @test right(span) == g
 
 f = Hom(:f, A, B)
-@test_throws Exception Span(f,g)
+@test_throws ErrorException Span(f,g)
 
 # Multispans.
 f, g, h = Hom(:f, C, A), Hom(:g, C, B), Hom(:h, C, A)
@@ -67,6 +67,9 @@ cospan = Cospan(f,g)
 @test legs(cospan) == [f,g]
 @test left(cospan) == f
 @test right(cospan) == g
+
+f = Hom(:f, A ,B)
+@test_throws ErrorException Cospan(f,g)
 
 # Multicospans.
 f, g, h = Hom(:f, A, C), Hom(:g, B, C), Hom(:h, A, C)

--- a/test/categorical_algebra/Limits.jl
+++ b/test/categorical_algebra/Limits.jl
@@ -6,7 +6,6 @@ FinSet.
 module TestLimits
 using Test
 
-using StaticArrays
 using Catlab.Theories, Catlab.CategoricalAlgebra
 
 A, B, C = Ob(FreeCategory, :A, :B, :C)
@@ -16,13 +15,13 @@ A, B, C = Ob(FreeCategory, :A, :B, :C)
 
 # Products.
 f, g = Hom(:f, C, A), Hom(:g, C, B)
-lim = Limit(SVector(A,B), Span(f,g))
+lim = Limit(ObjectPair(A,B), Span(f,g))
 @test lim isa BinaryProduct
 @test ob(lim) == C
 @test apex(lim) == C
 @test legs(lim) == [f,g]
 
-lim = Limit([A,B], Span(f,g))
+lim = Limit(DiscreteDiagram([A,B]), Span(f,g))
 @test lim isa Product
 
 # Colimits
@@ -30,13 +29,13 @@ lim = Limit([A,B], Span(f,g))
 
 # Coproducts.
 f, g = Hom(:f, A, C), Hom(:g, B, C)
-colim = Colimit(SVector(A,B), Cospan(f,g))
+colim = Colimit(ObjectPair(A,B), Cospan(f,g))
 @test colim isa BinaryCoproduct
 @test ob(colim) == C
 @test base(colim) == C
 @test legs(colim) == [f,g]
 
-colim = Colimit([A,B], Cospan(f,g))
+colim = Colimit(DiscreteDiagram([A,B]), Cospan(f,g))
 @test colim isa Coproduct
 
 end


### PR DESCRIPTION
Implements limits of C-sets without attributes, building on both #269 and #270. The algorithm for colimits is dual, so implementing it will be a copy-paste. However, writing the tests will take longer, so I'll leave colimits for next time.

This PR also refactors the interface for (co)limits and universal properties to be consistent across all diagram shapes. As a result, any limit of C-sets can be reduced to a limit in FinSet in a simple and generic way.