### PR TITLE
Don't restrict to `DataType` in C-set attributes

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -157,7 +157,7 @@ end
 
 function make_tables(::Type{CD}, AD::Type{<:AttrDesc{CD}},
                      Ts::Type{<:Tuple}) where {CD}
-  cols = NamedTuple{CD.ob}(Tuple{Symbol,DataType}[] for ob in CD.ob)
+  cols = NamedTuple{CD.ob}(Tuple{Symbol,Type}[] for ob in CD.ob)
   for hom in CD.hom
     push!(cols[dom(CD,hom)], (hom, Int))
   end


### PR DESCRIPTION
Using `DataType` instead of `Type` prevents `UnionAll`s from being used as attribute types, which should be allowed. In Julia you rarely want to restrict to `DataType`.