### PR TITLE
Double Category of Squares

### DIFF
--- a/src/categorical_algebra/CategoricalAlgebra.jl
+++ b/src/categorical_algebra/CategoricalAlgebra.jl
@@ -11,10 +11,12 @@ include("Permutations.jl")
 include("PredicatedSets.jl")
 include("CSets.jl")
 include("StructuredCospans.jl")
+include("Squares.jl")
 
 @reexport using .FreeDiagrams
 @reexport using .Limits
 @reexport using .CSets
 @reexport using .StructuredCospans
+@reexport using .Squares
 
 end

--- a/src/categorical_algebra/FreeDiagrams.jl
+++ b/src/categorical_algebra/FreeDiagrams.jl
@@ -12,13 +12,13 @@ export AbstractFreeDiagram, FreeDiagram, FixedShapeFreeDiagram, DiscreteDiagram,
   ob, hom, dom, codom, apex, legs, feet, left, right,
   nv, ne, src, tgt, vertices, edges, has_vertex, has_edge,
   add_vertex!, add_vertices!, add_edge!, add_edges!,
-  SquareDiagram, hcompose, vcompose
+  SquareDiagram, top, bottom
 
 using AutoHashEquals
 using StaticArrays: StaticVector, SVector, @SVector
 
 using ...Present, ...Theories, ...CSetDataStructures, ...Graphs
-import ...Theories: ob, hom, dom, codom, ⋅, top, bottom, left, right
+import ...Theories: ob, hom, dom, codom, top, bottom, left, right
 using ...Graphs.BasicGraphs: TheoryGraph
 
 # Diagrams of fixed shape
@@ -178,8 +178,8 @@ Base.lastindex(para::ParallelMorphisms) = lastindex(para.homs)
 
 allequal(xs::AbstractVector) = all(isequal(x, xs[1]) for x in xs[2:end])
 
-# SquareDiagrams form a Double category
-#######################################
+# Commutative squares
+#####################
 
 """    SquareDiagram(top, bottom, left, right)
 
@@ -218,52 +218,6 @@ top(sq::SquareDiagram) = sq.sides[1]
 bottom(sq::SquareDiagram) = sq.sides[2]
 left(sq::SquareDiagram) = sq.sides[3]
 right(sq::SquareDiagram) = sq.sides[4]
-
-
-"""    hcompose(s₁, s₂)
-
-compose two squares horizontally as shown below:
-    1   -f->   3  -g->   5
-    |          |         |
-    |          |         |
-    v          v         v
-    2  -f'->   4  -g'->  6
-"""
-function hcompose(s₁::SquareDiagram, s₂::SquareDiagram)
-    @assert ob(s₁)[3] == ob(s₂)[1]
-    @assert ob(s₁)[4] == ob(s₂)[2]
-    @assert right(s₁) == left(s₂)
-
-    f = top(s₁)
-    f′= bottom(s₁)
-    g = top(s₂)
-    g′= bottom(s₂)
-    return SquareDiagram(f⋅g, f′⋅g′, left(s₁), right(s₂))
-end
-"""    vcompose(s₁, s₂)
-
-compose two squares vertically as shown below:
-    1   -->  3
-    |        |
-    |        |
-    v        v
-    2  -->   4
-    |        |
-    |        |
-    v        v
-    5  -->   6
-"""
-function vcompose(s₁::SquareDiagram, s₂::SquareDiagram)
-    @assert ob(s₁)[2] == ob(s₂)[1]
-    @assert ob(s₁)[4] == ob(s₂)[3]
-    @assert bottom(s₁) == top(s₂)
-
-    f = left(s₁)
-    f′= right(s₁)
-    g = left(s₂)
-    g′= right(s₂)
-    return SquareDiagram(top(s₁), bottom(s₂), f⋅g, f′⋅g′)
-end
 
 # General diagrams
 ##################

--- a/src/categorical_algebra/Squares.jl
+++ b/src/categorical_algebra/Squares.jl
@@ -32,8 +32,8 @@ import ..FinSets: compose_impl, FinSet, FinFunction
 
   id2(A::FinSet) = SquareDiagram(idH(A), idH(A), idV(A), idV(A))
   # FIXME: how do you distinguish between vertical and horizontal if they are the same type?
-  id2(f::FinFunction) = SquareDiagram(f, f, idV(A), idV(A))
-  id2(f::FinFunction) = SquareDiagram(idH(A), idH(A), f, f)
+  id2V(f::FinFunction) = SquareDiagram(f, f, idV(A), idV(A))
+  id2H(f::FinFunction) = SquareDiagram(idH(A), idH(A), f, f)
 
   composeH(α::SquareDiagram, β::SquareDiagram) = hcompose(α, β)
   composeV(α::SquareDiagram, β::SquareDiagram) = vcompose(α, β)

--- a/src/categorical_algebra/Squares.jl
+++ b/src/categorical_algebra/Squares.jl
@@ -1,0 +1,43 @@
+""" Arrow Category as a Double Category of Squares
+
+In every category C, you can construct Sq(C) as a 
+[double category](https://ncatlab.org/nlab/show/double+category) 
+of commutative squares. This module uses SquareDiagrams to implement
+this construction.
+"""
+module Squares
+
+using AutoHashEquals
+# using ...Present
+using ...GAT
+using ...Theories: DoubleCategory
+import ...Theories: ob, hom, dom, codom, compose, ⋅, ⋆, HomV, HomH, composeH, composeV, id
+using ..FreeDiagrams
+import ..FinSets: compose_impl, FinSet, FinFunction
+
+@instance DoubleCategory{FinSet, FinFunction, FinFunction, SquareDiagram} begin
+  @import dom, codom, top, bottom, left, right, ⋅
+  idH(A::FinSet) = FinFunction(identity, A, A)
+  idV(A::FinSet) = FinFunction(identity, A, A)
+
+  function composeH(f::FinFunction, g::FinFunction)
+    @assert codom(f) == dom(g)
+    FinFunction(compose_impl(f,g), dom(f), codom(g))
+  end
+
+  function composeV(f::FinFunction, g::FinFunction)
+    @assert codom(f) == dom(g)
+    FinFunction(compose_impl(f,g), dom(f), codom(g))
+  end
+
+  id2(A::FinSet) = SquareDiagram(idH(A), idH(A), idV(A), idV(A))
+  # FIXME: how do you distinguish between vertical and horizontal if they are the same type?
+  id2(f::FinFunction) = SquareDiagram(f, f, idV(A), idV(A))
+  id2(f::FinFunction) = SquareDiagram(idH(A), idH(A), f, f)
+
+  composeH(α::SquareDiagram, β::SquareDiagram) = hcompose(α, β)
+  composeV(α::SquareDiagram, β::SquareDiagram) = vcompose(α, β)
+  
+end
+
+end

--- a/src/categorical_algebra/Squares.jl
+++ b/src/categorical_algebra/Squares.jl
@@ -8,28 +8,20 @@ this construction.
 module Squares
 
 using AutoHashEquals
-# using ...Present
+
 using ...GAT
 using ...Theories: DoubleCategory
 import ...Theories: ob, hom, dom, codom, compose, ⋅, ⋆, HomV, HomH,
                     composeH, composeV, id, idH, idV, id2, id2H, id2V
-using ..FreeDiagrams
-import ..FinSets: compose_impl, FinSet, FinFunction
+using ..FreeDiagrams, ..FinSets
 
 @instance DoubleCategory{FinSet, FinFunction, FinFunction, SquareDiagram} begin
   @import dom, codom, top, bottom, left, right, ⋅
   idH(A::FinSet) = FinFunction(identity, A, A)
   idV(A::FinSet) = FinFunction(identity, A, A)
 
-  function composeH(f::FinFunction, g::FinFunction)
-    @assert codom(f) == dom(g)
-    FinFunction(compose_impl(f,g), dom(f), codom(g))
-  end
-
-  function composeV(f::FinFunction, g::FinFunction)
-    @assert codom(f) == dom(g)
-    FinFunction(compose_impl(f,g), dom(f), codom(g))
-  end
+  composeH(f::FinFunction, g::FinFunction) = compose(f,g)
+  composeV(f::FinFunction, g::FinFunction) = compose(f,g)
 
   id2(A::FinSet) = SquareDiagram(idH(A), idH(A), idV(A), idV(A))
   # FIXME: how do you distinguish between vertical and horizontal if they are the same type?

--- a/src/categorical_algebra/Squares.jl
+++ b/src/categorical_algebra/Squares.jl
@@ -28,9 +28,51 @@ using ..FreeDiagrams, ..FinSets
   id2V(f::FinFunction) = SquareDiagram(f, f, idV(A), idV(A))
   id2H(f::FinFunction) = SquareDiagram(idH(A), idH(A), f, f)
 
-  composeH(α::SquareDiagram, β::SquareDiagram) = hcompose(α, β)
-  composeV(α::SquareDiagram, β::SquareDiagram) = vcompose(α, β)
+  """    composeH(s₁, s₂)
 
+  compose two squares horizontally as shown below:
+      1   -f->   3  -g->   5
+      |          |         |
+      |          |         |
+      v          v         v
+      2  -f'->   4  -g'->  6
+   """
+  function composeH(s₁::SquareDiagram, s₂::SquareDiagram)
+    @assert ob(s₁)[3] == ob(s₂)[1]
+    @assert ob(s₁)[4] == ob(s₂)[2]
+    @assert right(s₁) == left(s₂)
+
+    f = top(s₁)
+    f′= bottom(s₁)
+    g = top(s₂)
+    g′= bottom(s₂)
+    return SquareDiagram(f⋅g, f′⋅g′, left(s₁), right(s₂))
+  end
+
+  """    composeV(s₁, s₂)
+
+  compose two squares vertically as shown below:
+      1   -->  3
+      |        |
+      |        |
+      v        v
+      2  -->   4
+      |        |
+      |        |
+      v        v
+      5  -->   6
+  """
+  function composeV(s₁::SquareDiagram, s₂::SquareDiagram)
+    @assert ob(s₁)[2] == ob(s₂)[1]
+    @assert ob(s₁)[4] == ob(s₂)[3]
+    @assert bottom(s₁) == top(s₂)
+
+    f = left(s₁)
+    f′= right(s₁)
+    g = left(s₂)
+    g′= right(s₂)
+    return SquareDiagram(top(s₁), bottom(s₂), f⋅g, f′⋅g′)
+  end
 end
 
 end

--- a/src/categorical_algebra/Squares.jl
+++ b/src/categorical_algebra/Squares.jl
@@ -1,7 +1,7 @@
 """ Arrow Category as a Double Category of Squares
 
-In every category C, you can construct Sq(C) as a 
-[double category](https://ncatlab.org/nlab/show/double+category) 
+In every category C, you can construct Sq(C) as a
+[double category](https://ncatlab.org/nlab/show/double+category)
 of commutative squares. This module uses SquareDiagrams to implement
 this construction.
 """
@@ -11,7 +11,8 @@ using AutoHashEquals
 # using ...Present
 using ...GAT
 using ...Theories: DoubleCategory
-import ...Theories: ob, hom, dom, codom, compose, ⋅, ⋆, HomV, HomH, composeH, composeV, id
+import ...Theories: ob, hom, dom, codom, compose, ⋅, ⋆, HomV, HomH,
+                    composeH, composeV, id, idH, idV, id2, id2H, id2V
 using ..FreeDiagrams
 import ..FinSets: compose_impl, FinSet, FinFunction
 
@@ -37,7 +38,7 @@ import ..FinSets: compose_impl, FinSet, FinFunction
 
   composeH(α::SquareDiagram, β::SquareDiagram) = hcompose(α, β)
   composeV(α::SquareDiagram, β::SquareDiagram) = vcompose(α, β)
-  
+
 end
 
 end

--- a/src/core/GAT.jl
+++ b/src/core/GAT.jl
@@ -276,7 +276,8 @@ most one type constructor with a given name.
 """
 function get_type(theory::Theory, name::Symbol)::TypeConstructor
   indices = findall(cons -> cons.name == name, theory.types)
-  length(indices) == 1 || error("Malformed GAT definition type constructors cannot be overloaded $name")
+  length(indices) < 1 && error("Malformed GAT definition type constructor for $name is missing")
+  length(indices) > 1 && error("Malformed GAT definition type constructor for $name cannot be overloaded")
   theory.types[indices[1]]
 end
 function has_type(theory::Theory, name::Symbol)::Bool

--- a/src/core/GAT.jl
+++ b/src/core/GAT.jl
@@ -276,7 +276,7 @@ most one type constructor with a given name.
 """
 function get_type(theory::Theory, name::Symbol)::TypeConstructor
   indices = findall(cons -> cons.name == name, theory.types)
-  @assert length(indices) == 1
+  length(indices) == 1 || error("Malformed GAT definition type constructors cannot be overloaded $name")
   theory.types[indices[1]]
 end
 function has_type(theory::Theory, name::Symbol)::Bool

--- a/src/theories/Category.jl
+++ b/src/theories/Category.jl
@@ -1,6 +1,6 @@
 export Category, FreeCategory, Ob, Hom, dom, codom, id, compose, ⋅,
   Category2, FreeCategory2, Hom2, compose2, 
-  DoubleCategory, HomH, HomV, composeH, composeV, FreeDoubleCategory
+  DoubleCategory, HomH, HomV, idH, idV, composeH, composeV, FreeDoubleCategory
 
 import Base: show
 
@@ -170,12 +170,12 @@ end
   # identity two cell on 1 object
   id2(X::Ob)::Hom2(X→X, X→X, X↓X, X↓X)          ⊣ (X::Ob)
   id2(X) == id2(idH(X), idH(X), idV(X), idV(X)) ⊣ (X::Ob)
-  # identity two cell from a HomH
-  id2(f::(X→Y))::Hom2(X→Y, X→Y, X↓X, Y↓Y) ⊣ (X::Ob, Y::Ob)
-  id2(f) == Hom2(f, f, idV(X), idV(Y))    ⊣ (X::Ob, Y::Ob, f::(X→Y))
-  # identity two cell from a HomV
-  id2(f::(X↓Y))::Hom2(X→X, Y→Y, X↓Y, X↓Y) ⊣ (X::Ob, Y::Ob)
-  id2(f) == Hom2(idH(X), idH(Y), f, f)    ⊣ (X::Ob, Y::Ob, f::(X→Y))
+  # identity two cell for vertical composition
+  id2V(f::(X→Y))::Hom2(X→Y, X→Y, X↓X, Y↓Y) ⊣ (X::Ob, Y::Ob)
+  id2V(f) == Hom2(f, f, idV(X), idV(Y))    ⊣ (X::Ob, Y::Ob, f::(X→Y))
+  # identity two cell for horizontal composition
+  id2H(f::(X↓Y))::Hom2(X→X, Y→Y, X↓Y, X↓Y) ⊣ (X::Ob, Y::Ob)
+  id2H(f) == Hom2(idH(X), idH(Y), f, f)    ⊣ (X::Ob, Y::Ob, f::(X→Y))
 
   # Vertical composition of 2-cells
   composeV(

--- a/src/theories/Category.jl
+++ b/src/theories/Category.jl
@@ -1,6 +1,6 @@
 export Category, FreeCategory, Ob, Hom, dom, codom, id, compose, ⋅,
   Category2, FreeCategory2, Hom2, compose2, 
-  DoubleCategory, HomH, HomV, composeH, composeV
+  DoubleCategory, HomH, HomV, composeH, composeV, FreeDoubleCategory
 
 import Base: show
 
@@ -180,18 +180,18 @@ end
   # Vertical composition of 2-cells
   composeV(
     α::Hom2(t,b,l,r),
-    β::Hom2(t2,b2,l2,r2)
-  )::Hom2(A→B, C→D, A↓C, B↓D)  ⊣ (A::Ob, B::Ob, X::Ob, Y::Ob, C::Ob, D::Ob,
+    β::Hom2(b,b2,l2,r2)
+  )::Hom2(t, b2, l⋅l2, r⋅r2)  ⊣ (A::Ob, B::Ob, X::Ob, Y::Ob, C::Ob, D::Ob,
                                   t::(A→B), b::(X→Y), l::(A↓X), r::(B↓Y),
-                                  t2::(X→Y), b2::(C→D), l2::(X↓C), r2::(Y↓D))
+                                           b2::(C→D), l2::(X↓C), r2::(Y↓D))
 
   # Horizontal composition of 2-cells
   composeH(
     α::Hom2(t,b,l,r),
-    β::Hom2(t2,b2,l2,r2)
-  )::Hom2(A→C, B→D, A↓B, C↓D)  ⊣ (A::Ob, B::Ob, X::Ob, Y::Ob, C::Ob, D::Ob,
+    β::Hom2(t2,b2,r,r2)
+  )::Hom2(t⋅t2, b⋅b2, l, r2)  ⊣ (A::Ob, B::Ob, X::Ob, Y::Ob, C::Ob, D::Ob,
                                   t::(A→X), b::(B→Y), l::(A↓B), r::(X↓Y),
-                                  t2::(X→C), b2::(Y→D), l2::(X↓Y), r2::(C↓D))
+                                  t2::(X→C), b2::(Y→D), r2::(C↓D))
 end
 
 # Convenience constructors
@@ -208,8 +208,8 @@ Checks domains of morphisms but not 2-morphisms.
 @syntax FreeDoubleCategory{ObExpr,HomVExpr, HomHExpr,Hom2Expr} DoubleCategory begin
   compose(f::HomV, g::HomV) = associate(new(f,g; strict=true))
   compose(f::HomH, g::HomH) = associate(new(f,g; strict=true))
-  # composeH(α::Hom2, β::Hom2) = associate(new(α,β))
-  # composeV(α::Hom2, β::Hom2) = associate(new(α,β))
+  composeH(α::Hom2, β::Hom2) = associate(new(α,β))
+  composeV(α::Hom2, β::Hom2) = associate(new(α,β))
 end
 
 function show_unicode(io::IO, expr::Hom2Expr{:composeH}; kw...)

--- a/src/theories/Category.jl
+++ b/src/theories/Category.jl
@@ -146,7 +146,8 @@ end
     (→) := HomH
     (↓) := HomV
     (⇒) := Hom2
-    (⋅) := compose
+    (⋅) := composeH
+    (⋆) := composeV
   end
 
   idH(A::Ob)::(A → A) ⊣ (A::Ob)
@@ -178,15 +179,19 @@ end
 
   # Vertical composition of 2-cells
   composeV(
-    α::Hom(A→B, X→Y, A↓X, B↓Y),
-    β::Hom(X→Y, C→D, X↓C, Y↓D)
-  )::Hom2(A→B, C→D, A↓C, B↓D)  ⊣ (A::Ob, B::Ob, X::Ob, Y::Ob, C::Ob, D::Ob)
+    α::Hom2(t,b,l,r),
+    β::Hom2(t2,b2,l2,r2)
+  )::Hom2(A→B, C→D, A↓C, B↓D)  ⊣ (A::Ob, B::Ob, X::Ob, Y::Ob, C::Ob, D::Ob,
+                                  t::(A→B), b::(X→Y), l::(A↓X), r::(B↓Y),
+                                  t2::(X→Y), b2::(C→D), l2::(X↓C), r2::(Y↓D))
 
   # Horizontal composition of 2-cells
   composeH(
-    α::Hom(A→X, B→Y, A↓B, X↓Y),
-    β::Hom(X→C, Y→D, X↓Y, C↓D)
-  )::Hom2(A→C, B→D, A↓B, C↓D)  ⊣ (A::Ob, B::Ob, X::Ob, Y::Ob, C::Ob, D::Ob)
+    α::Hom2(t,b,l,r),
+    β::Hom2(t2,b2,l2,r2)
+  )::Hom2(A→C, B→D, A↓B, C↓D)  ⊣ (A::Ob, B::Ob, X::Ob, Y::Ob, C::Ob, D::Ob,
+                                  t::(A→X), b::(B→Y), l::(A↓B), r::(X↓Y),
+                                  t2::(X→C), b2::(Y→D), l2::(X↓Y), r2::(C↓D))
 end
 
 # Convenience constructors
@@ -207,16 +212,16 @@ Checks domains of morphisms but not 2-morphisms.
   # composeV(α::Hom2, β::Hom2) = associate(new(α,β))
 end
 
-function show_unicode(io::IO, expr::Hom2Expr{:compose}; kw...)
+function show_unicode(io::IO, expr::Hom2Expr{:composeH}; kw...)
   Syntax.show_unicode_infix(io, expr, "⋅"; kw...)
 end
-function show_unicode(io::IO, expr::Hom2Expr{:compose2}; kw...)
+function show_unicode(io::IO, expr::Hom2Expr{:composeV}; kw...)
   Syntax.show_unicode_infix(io, expr, "*"; kw...)
 end
 
-function show_latex(io::IO, expr::Hom2Expr{:compose}; kw...)
+function show_latex(io::IO, expr::Hom2Expr{:composeH}; kw...)
   Syntax.show_latex_infix(io, expr, "\\cdot"; kw...)
 end
-function show_latex(io::IO, expr::Hom2Expr{:compose2}; kw...)
-  Syntax.show_latex_infix(io, expr, "*"; kw...)
+function show_latex(io::IO, expr::Hom2Expr{:composeV}; kw...)
+  Syntax.show_latex_infix(io, expr, "\\star"; kw...)
 end

--- a/src/theories/Category.jl
+++ b/src/theories/Category.jl
@@ -123,10 +123,8 @@ function show_latex(io::IO, expr::Hom2Expr{:compose2}; kw...)
   Syntax.show_latex_infix(io, expr, "*"; kw...)
 end
 
-
-###########
-# Double Category
-###########
+# Double category
+#################
 
 """ Theory of (strict) *double categories*
 """
@@ -168,30 +166,27 @@ end
   idV(A) ⋅ f == f ⊣ (A::Ob, B::Ob, f::(A ↓ B))
 
   # identity two cell on 1 object
-  id2(X::Ob)::Hom2(X→X, X→X, X↓X, X↓X)          ⊣ (X::Ob)
-  id2(X) == id2(idH(X), idH(X), idV(X), idV(X)) ⊣ (X::Ob)
+  id2(X::Ob)::Hom2(idH(X), idH(X), idV(X), idV(X)) ⊣ (X::Ob)
   # identity two cell for vertical composition
-  id2V(f::(X→Y))::Hom2(X→Y, X→Y, X↓X, Y↓Y) ⊣ (X::Ob, Y::Ob)
-  id2V(f) == Hom2(f, f, idV(X), idV(Y))    ⊣ (X::Ob, Y::Ob, f::(X→Y))
+  id2V(f::(X→Y))::Hom2(f, f, idV(X), idV(Y)) ⊣ (X::Ob, Y::Ob)
   # identity two cell for horizontal composition
-  id2H(f::(X↓Y))::Hom2(X→X, Y→Y, X↓Y, X↓Y) ⊣ (X::Ob, Y::Ob)
-  id2H(f) == Hom2(idH(X), idH(Y), f, f)    ⊣ (X::Ob, Y::Ob, f::(X→Y))
+  id2H(f::(X↓Y))::Hom2(idH(X), idH(Y), f, f) ⊣ (X::Ob, Y::Ob)
 
   # Vertical composition of 2-cells
   composeV(
     α::Hom2(t,b,l,r),
     β::Hom2(b,b2,l2,r2)
   )::Hom2(t, b2, l⋅l2, r⋅r2)  ⊣ (A::Ob, B::Ob, X::Ob, Y::Ob, C::Ob, D::Ob,
-                                  t::(A→B), b::(X→Y), l::(A↓X), r::(B↓Y),
-                                           b2::(C→D), l2::(X↓C), r2::(Y↓D))
+                                 t::(A→B), b::(X→Y), l::(A↓X), r::(B↓Y),
+                                 b2::(C→D), l2::(X↓C), r2::(Y↓D))
 
   # Horizontal composition of 2-cells
   composeH(
     α::Hom2(t,b,l,r),
     β::Hom2(t2,b2,r,r2)
   )::Hom2(t⋅t2, b⋅b2, l, r2)  ⊣ (A::Ob, B::Ob, X::Ob, Y::Ob, C::Ob, D::Ob,
-                                  t::(A→X), b::(B→Y), l::(A↓B), r::(X↓Y),
-                                  t2::(X→C), b2::(Y→D), r2::(C↓D))
+                                 t::(A→X), b::(B→Y), l::(A↓B), r::(X↓Y),
+                                 t2::(X→C), b2::(Y→D), r2::(C↓D))
 end
 
 # Convenience constructors

--- a/src/theories/Category.jl
+++ b/src/theories/Category.jl
@@ -1,6 +1,6 @@
 export Category, FreeCategory, Ob, Hom, dom, codom, id, compose, ⋅,
   Category2, FreeCategory2, Hom2, compose2, 
-  DoubleCategory, HomH, HomV, idH, idV, composeH, composeV, FreeDoubleCategory
+  DoubleCategory, FreeDoubleCategory, HomH, HomV, idH, idV, composeH, composeV, ⋆
 
 import Base: show
 
@@ -144,8 +144,8 @@ end
     (→) := HomH
     (↓) := HomV
     (⇒) := Hom2
-    (⋅) := composeH
-    (⋆) := composeV
+    (⋆) := composeH
+    (⋅) := composeV
   end
 
   idH(A::Ob)::(A → A) ⊣ (A::Ob)
@@ -154,10 +154,10 @@ end
   composeV(f::(A ↓ B), g::(B ↓ C))::(A ↓ C) ⊣ (A::Ob, B::Ob, C::Ob)
 
   # Category axioms for Horizontal morphisms
-  ((f ⋅ g) ⋅ h == f ⋅ (g ⋅ h)
+  ((f ⋆ g) ⋆ h == f ⋆ (g ⋆ h)
     ⊣ (A::Ob, B::Ob, C::Ob, D::Ob, f::(A → B), g::(B → C), h::(C → D)))
-  f ⋅ idH(B) == f ⊣ (A::Ob, B::Ob, f::(A → B))
-  idH(A) ⋅ f == f ⊣ (A::Ob, B::Ob, f::(A → B))
+  f ⋆ idH(B) == f ⊣ (A::Ob, B::Ob, f::(A → B))
+  idH(A) ⋆ f == f ⊣ (A::Ob, B::Ob, f::(A → B))
 
   # Category axioms for Vertical morphisms
   ((f ⋅ g) ⋅ h == f ⋅ (g ⋅ h)
@@ -184,7 +184,7 @@ end
   composeH(
     α::Hom2(t,b,l,r),
     β::Hom2(t2,b2,r,r2)
-  )::Hom2(t⋅t2, b⋅b2, l, r2)  ⊣ (A::Ob, B::Ob, X::Ob, Y::Ob, C::Ob, D::Ob,
+  )::Hom2(t⋆t2, b⋆b2, l, r2)  ⊣ (A::Ob, B::Ob, X::Ob, Y::Ob, C::Ob, D::Ob,
                                  t::(A→X), b::(B→Y), l::(A↓B), r::(X↓Y),
                                  t2::(X→C), b2::(Y→D), r2::(C↓D))
 end
@@ -207,16 +207,16 @@ Checks domains of morphisms but not 2-morphisms.
   composeV(α::Hom2, β::Hom2) = associate(new(α,β))
 end
 
-function show_unicode(io::IO, expr::Hom2Expr{:composeH}; kw...)
+function show_unicode(io::IO, expr::Hom2Expr{:composeV}; kw...)
   Syntax.show_unicode_infix(io, expr, "⋅"; kw...)
 end
-function show_unicode(io::IO, expr::Hom2Expr{:composeV}; kw...)
+function show_unicode(io::IO, expr::Hom2Expr{:composeH}; kw...)
   Syntax.show_unicode_infix(io, expr, "*"; kw...)
 end
 
-function show_latex(io::IO, expr::Hom2Expr{:composeH}; kw...)
+function show_latex(io::IO, expr::Hom2Expr{:composeV}; kw...)
   Syntax.show_latex_infix(io, expr, "\\cdot"; kw...)
 end
-function show_latex(io::IO, expr::Hom2Expr{:composeV}; kw...)
+function show_latex(io::IO, expr::Hom2Expr{:composeH}; kw...)
   Syntax.show_latex_infix(io, expr, "\\star"; kw...)
 end

--- a/src/theories/Theories.jl
+++ b/src/theories/Theories.jl
@@ -13,7 +13,11 @@ import ..Syntax: GATExpr, show_unicode, show_latex
 abstract type CategoryExpr{T} <: GATExpr{T} end
 abstract type ObExpr{T} <: CategoryExpr{T} end
 abstract type HomExpr{T} <: CategoryExpr{T} end
+# 2-categories and double categories
 abstract type Hom2Expr{T} <: CategoryExpr{T} end
+# double categories
+abstract type HomVExpr{T} <: CategoryExpr{T} end
+abstract type HomHExpr{T} <: CategoryExpr{T} end
 
 # Convenience methods
 Ob(mod::Module, args...) = Ob(mod.Ob, args...)

--- a/test/categorical_algebra/CategoricalAlgebra.jl
+++ b/test/categorical_algebra/CategoricalAlgebra.jl
@@ -39,4 +39,8 @@ end
   include("StructuredCospans.jl")
 end
 
+@testset "PredicatedSets" begin
+  include("Squares.jl")
+end
+
 end

--- a/test/categorical_algebra/CategoricalAlgebra.jl
+++ b/test/categorical_algebra/CategoricalAlgebra.jl
@@ -39,7 +39,7 @@ end
   include("StructuredCospans.jl")
 end
 
-@testset "PredicatedSets" begin
+@testset "Squares" begin
   include("Squares.jl")
 end
 

--- a/test/categorical_algebra/FreeDiagrams.jl
+++ b/test/categorical_algebra/FreeDiagrams.jl
@@ -167,7 +167,6 @@ end
 
 l, t, b, r = Hom(:lef, A,B), Hom(:top, A, C), Hom(:bot, B, D), Hom(:rht, C,D)
 sq1 = SquareDiagram(l,t,b,r)
-@show sq1
 
 @test_throws AssertionError hcompose(sq1, sq1)
 

--- a/test/categorical_algebra/FreeDiagrams.jl
+++ b/test/categorical_algebra/FreeDiagrams.jl
@@ -114,13 +114,12 @@ diagram = FreeDiagram(para)
 @test src(diagram) == [1,1,1]
 @test tgt(diagram) == [2,2,2]
 
-
-# double category of squares
+# Commutative squares.
 
 l, t, b, r = Hom(:lef, A,B), Hom(:top, A, C), Hom(:bot, B, D), Hom(:rht, C,D)
 sq1 = SquareDiagram(t, b, l, r)
 
-@test_throws AssertionError hcompose(sq1, sq1)
+@test_throws AssertionError composeH(sq1, sq1)
 @test hom(FreeDiagram(sq1))[1] == t
 @test hom(FreeDiagram(sq1))[2] == b
 @test hom(FreeDiagram(sq1))[3] == l
@@ -129,18 +128,18 @@ sq1 = SquareDiagram(t, b, l, r)
 l, t, b, r = Hom(:lef, A,B), Hom(:top, A, A), Hom(:bot, B, B), Hom(:rht, A,B)
 rr = Hom(:rr, A,B)
 sq2 = SquareDiagram(t, b, l, r)
-sq3 = hcompose(sq2, SquareDiagram(t, b, r, rr))
+sq3 = composeH(sq2, SquareDiagram(t, b, r, rr))
 @test left(sq3)   == l
 @test top(sq3)    == compose(t,t)
 @test bottom(sq3) == compose(b,b)
 @test right(sq3)  == rr
 
 
-@test_throws AssertionError vcompose(sq2, sq2)
+@test_throws AssertionError composeV(sq2, sq2)
 
 ll = Hom(:ll, B, A)
 rr = Hom(:rr, B, A)
-sq4 = vcompose(sq2, SquareDiagram(b, t, ll, rr))
+sq4 = composeV(sq2, SquareDiagram(b, t, ll, rr))
 @test left(sq4)    == compose(l, ll)
 @test right(sq4)  == compose(r, rr)
 @test top(sq4)   == t

--- a/test/categorical_algebra/FreeDiagrams.jl
+++ b/test/categorical_algebra/FreeDiagrams.jl
@@ -114,68 +114,26 @@ diagram = FreeDiagram(para)
 @test src(diagram) == [1,1,1]
 @test tgt(diagram) == [2,2,2]
 
-function SquareDiagram(top, bottom, left, right)
-    # check that the domains and codomains match
-    #   1   -top->   3
-    #   |            |
-    # left         right
-    #   v            v
-    #   2  -bottom-> 4
-    # this is numbered as if it were a pushout square.
 
-    @assert codom(top) == dom(right)
-    @assert dom(top) == dom(left)
-    @assert dom(bottom) == codom(left)
-    @assert codom(bottom) == codom(right)
-
-    V = [dom(left), codom(left), dom(right), codom(right)]
-    E = [(1,2, left), (1,3, top), (2,4, bottom), (3,4, right)] 
-    return FreeDiagram(V, E)
-end
-
-
-function hcompose(s₁::AbstractFreeDiagram, s₂::AbstractFreeDiagram)
-    #   1   -f->   3  -g->   5
-    #   |          |         |
-    #   |          |         |
-    #   v          v         v
-    #   2  -f'->   4  -g'->  6
-    # 
-    @assert ob(s₁)[3] == ob(s₂)[1]
-    @assert ob(s₁)[4] == ob(s₂)[2]
-    @assert hom(s₁)[4] == hom(s₂)[1]
-
-    f = hom(s₁)[2]
-    f′= hom(s₁)[3]
-    g = hom(s₂)[2]
-    g′= hom(s₂)[3]
-    return SquareDiagram(f⋅g, f′⋅g′, hom(s₁)[1], hom(s₂)[end])
-end
-
-function vcompose(s₁::AbstractFreeDiagram, s₂::AbstractFreeDiagram)
-    @assert ob(s₁)[2] == ob(s₂)[1]
-    @assert ob(s₁)[4] == ob(s₂)[3]
-    @assert hom(s₁)[3] == hom(s₂)[2]
-    f = hom(s₁)[1]
-    f′= hom(s₁)[4]
-    g = hom(s₂)[1]
-    g′= hom(s₂)[4]
-    return SquareDiagram(hom(s₁)[2], hom(s₂)[3], f⋅g, f′⋅g′)
-end
+# double category of squares
 
 l, t, b, r = Hom(:lef, A,B), Hom(:top, A, C), Hom(:bot, B, D), Hom(:rht, C,D)
 sq1 = SquareDiagram(t, b, l, r)
 
 @test_throws AssertionError hcompose(sq1, sq1)
+@test hom(FreeDiagram(sq1))[1] == t
+@test hom(FreeDiagram(sq1))[2] == b
+@test hom(FreeDiagram(sq1))[3] == l
+@test hom(FreeDiagram(sq1))[4] == r
 
 l, t, b, r = Hom(:lef, A,B), Hom(:top, A, A), Hom(:bot, B, B), Hom(:rht, A,B)
 rr = Hom(:rr, A,B)
 sq2 = SquareDiagram(t, b, l, r)
 sq3 = hcompose(sq2, SquareDiagram(t, b, r, rr))
-@test hom(sq3)[1] == l
-@test hom(sq3)[2] == compose(t,t)
-@test hom(sq3)[3] == compose(b,b)
-@test hom(sq3)[4] == rr
+@test left(sq3)   == l
+@test top(sq3)    == compose(t,t)
+@test bottom(sq3) == compose(b,b)
+@test right(sq3)  == rr
 
 
 @test_throws AssertionError vcompose(sq2, sq2)
@@ -183,9 +141,9 @@ sq3 = hcompose(sq2, SquareDiagram(t, b, r, rr))
 ll = Hom(:ll, B, A)
 rr = Hom(:rr, B, A)
 sq4 = vcompose(sq2, SquareDiagram(b, t, ll, rr))
-@test hom(sq4)[1] == compose(l, ll)
-@test hom(sq4)[4] == compose(r, rr)
-@test hom(sq4)[2] == t
-@test hom(sq4)[3] == t
+@test left(sq4)    == compose(l, ll)
+@test right(sq4)  == compose(r, rr)
+@test top(sq4)   == t
+@test bottom(sq4) == t
 
 end

--- a/test/categorical_algebra/FreeDiagrams.jl
+++ b/test/categorical_algebra/FreeDiagrams.jl
@@ -146,4 +146,5 @@ sq4 = vcompose(sq2, SquareDiagram(b, t, ll, rr))
 @test top(sq4)   == t
 @test bottom(sq4) == t
 
+@test hom(sq4) == [top(sq4), bottom(sq4), left(sq4), right(sq4)]
 end

--- a/test/categorical_algebra/FreeDiagrams.jl
+++ b/test/categorical_algebra/FreeDiagrams.jl
@@ -135,9 +135,6 @@ function SquareDiagram(left, top, bottom, right)
     return FreeDiagram(V, E)
 end
 
-l, t, b, r = Hom(:lef, A,B), Hom(:top, A, C), Hom(:bot, B, D), Hom(:rht, C,D)
-sq1 = SquareDiagram(l,t,b,r)
-@show sq1
 
 function hcompose(s₁::AbstractFreeDiagram, s₂::AbstractFreeDiagram)
     #   1   -f->   3  -g->   5
@@ -148,19 +145,29 @@ function hcompose(s₁::AbstractFreeDiagram, s₂::AbstractFreeDiagram)
     # 
     @assert ob(s₁)[3] == ob(s₂)[1]
     @assert ob(s₁)[4] == ob(s₂)[2]
-    @show hom(s₁)[4]
-    @show hom(s₂)[1]
     @assert hom(s₁)[4] == hom(s₂)[1]
 
     f = hom(s₁)[2]
     f′= hom(s₁)[3]
     g = hom(s₂)[2]
     g′= hom(s₂)[3]
-    @show f⋅g
-    @show f′⋅g′
-    # return SquareDiagram(hom(s₁)[1]⋅id(ob(s₁)[2]), f⋅g, f′⋅g′, hom(s₂)[end]⋅id(ob(s₂)[4]))
     return SquareDiagram(hom(s₁)[1], f⋅g, f′⋅g′, hom(s₂)[end])
 end
+
+function vcompose(s₁::AbstractFreeDiagram, s₂::AbstractFreeDiagram)
+    @assert ob(s₁)[2] == ob(s₂)[1]
+    @assert ob(s₁)[4] == ob(s₂)[3]
+    @assert hom(s₁)[3] == hom(s₂)[2]
+    f = hom(s₁)[1]
+    f′= hom(s₁)[4]
+    g = hom(s₂)[1]
+    g′= hom(s₂)[4]
+    return SquareDiagram(f⋅g, hom(s₁)[2], hom(s₂)[3], f′⋅g′)
+end
+
+l, t, b, r = Hom(:lef, A,B), Hom(:top, A, C), Hom(:bot, B, D), Hom(:rht, C,D)
+sq1 = SquareDiagram(l,t,b,r)
+@show sq1
 
 @test_throws AssertionError hcompose(sq1, sq1)
 
@@ -172,5 +179,16 @@ sq3 = hcompose(sq2, SquareDiagram(r, t, b, rr))
 @test hom(sq3)[2] == compose(t,t)
 @test hom(sq3)[3] == compose(b,b)
 @test hom(sq3)[4] == rr
+
+
+@test_throws AssertionError vcompose(sq2, sq2)
+
+ll = Hom(:ll, B, A)
+rr = Hom(:rr, B, A)
+sq4 = vcompose(sq2, SquareDiagram(ll, b, t, rr))
+@test hom(sq4)[1] == compose(l, ll)
+@test hom(sq4)[4] == compose(r, rr)
+@test hom(sq4)[2] == t
+@test hom(sq4)[3] == t
 
 end

--- a/test/categorical_algebra/FreeDiagrams.jl
+++ b/test/categorical_algebra/FreeDiagrams.jl
@@ -114,9 +114,7 @@ diagram = FreeDiagram(para)
 @test src(diagram) == [1,1,1]
 @test tgt(diagram) == [2,2,2]
 
-@show typeof(diagram)
-
-function SquareDiagram(left, top, bottom, right)
+function SquareDiagram(top, bottom, left, right)
     # check that the domains and codomains match
     #   1   -top->   3
     #   |            |
@@ -151,7 +149,7 @@ function hcompose(s₁::AbstractFreeDiagram, s₂::AbstractFreeDiagram)
     f′= hom(s₁)[3]
     g = hom(s₂)[2]
     g′= hom(s₂)[3]
-    return SquareDiagram(hom(s₁)[1], f⋅g, f′⋅g′, hom(s₂)[end])
+    return SquareDiagram(f⋅g, f′⋅g′, hom(s₁)[1], hom(s₂)[end])
 end
 
 function vcompose(s₁::AbstractFreeDiagram, s₂::AbstractFreeDiagram)
@@ -162,18 +160,18 @@ function vcompose(s₁::AbstractFreeDiagram, s₂::AbstractFreeDiagram)
     f′= hom(s₁)[4]
     g = hom(s₂)[1]
     g′= hom(s₂)[4]
-    return SquareDiagram(f⋅g, hom(s₁)[2], hom(s₂)[3], f′⋅g′)
+    return SquareDiagram(hom(s₁)[2], hom(s₂)[3], f⋅g, f′⋅g′)
 end
 
 l, t, b, r = Hom(:lef, A,B), Hom(:top, A, C), Hom(:bot, B, D), Hom(:rht, C,D)
-sq1 = SquareDiagram(l,t,b,r)
+sq1 = SquareDiagram(t, b, l, r)
 
 @test_throws AssertionError hcompose(sq1, sq1)
 
 l, t, b, r = Hom(:lef, A,B), Hom(:top, A, A), Hom(:bot, B, B), Hom(:rht, A,B)
 rr = Hom(:rr, A,B)
-sq2 = SquareDiagram(l,t,b,r)
-sq3 = hcompose(sq2, SquareDiagram(r, t, b, rr))
+sq2 = SquareDiagram(t, b, l, r)
+sq3 = hcompose(sq2, SquareDiagram(t, b, r, rr))
 @test hom(sq3)[1] == l
 @test hom(sq3)[2] == compose(t,t)
 @test hom(sq3)[3] == compose(b,b)
@@ -184,7 +182,7 @@ sq3 = hcompose(sq2, SquareDiagram(r, t, b, rr))
 
 ll = Hom(:ll, B, A)
 rr = Hom(:rr, B, A)
-sq4 = vcompose(sq2, SquareDiagram(ll, b, t, rr))
+sq4 = vcompose(sq2, SquareDiagram(b, t, ll, rr))
 @test hom(sq4)[1] == compose(l, ll)
 @test hom(sq4)[4] == compose(r, rr)
 @test hom(sq4)[2] == t

--- a/test/categorical_algebra/Squares.jl
+++ b/test/categorical_algebra/Squares.jl
@@ -46,4 +46,11 @@ r = FinFunction([1,2,2,3,3], 3)
 @test_throws AssertionError composeH(α, β)
 @test collect(left(γ)) == [1,2,2] 
 @test collect(right(γ)) == [1,1,1] 
+
+@test collect(idH(FinSet(3))) == collect(1:3)
+@test collect(idV(FinSet(5))) == collect(1:5)
+@test collect(idH(FinSet(0))) == []
+
+@test collect(composeH(FinFunction([2,1], 3), FinFunction([2, 1, 3]))) == [1,2]
+@test collect(composeV(FinFunction([2,1], 3), FinFunction([2, 1, 3]))) == [1,2]
 end #module

--- a/test/categorical_algebra/Squares.jl
+++ b/test/categorical_algebra/Squares.jl
@@ -21,4 +21,29 @@ b₁ = FinFunction([1,1,1], 1)
 @test bottom(γ) == b⋅b₁
 @test left(γ) == left(α)
 @test right(γ) == right(β)
+
+t = FinFunction([1,2,4], 5)
+b = FinFunction([2,1,3], 3)
+l = FinFunction([2,1,3], 3)
+r = FinFunction([1,2,2,3,3], 3)
+α = SquareDiagram(t,b,l,r)
+β = SquareDiagram(FinFunction([1,2,1,2,1], 2),
+                  FinFunction([1,1,1],1),
+                  FinFunction([1,2,2,3,3], 3),
+                  FinFunction([1,1],1)
+)
+γ = composeH(α, β)
+@test collect(top(γ)) == [1,2,2] 
+@test collect(bottom(γ)) == [1,1,1] 
+
+α = SquareDiagram(l,r, t,b)
+β = SquareDiagram(FinFunction([1,2,2,3,3], 3),
+                  FinFunction([1,1],1),
+                  FinFunction([1,2,1,2,1], 2),
+                  FinFunction([1,1,1],1)
+)
+γ = composeV(α, β)
+@test_throws AssertionError composeH(α, β)
+@test collect(left(γ)) == [1,2,2] 
+@test collect(right(γ)) == [1,1,1] 
 end #module

--- a/test/categorical_algebra/Squares.jl
+++ b/test/categorical_algebra/Squares.jl
@@ -1,0 +1,24 @@
+module TestSquares
+using Test
+using Catlab.Theories, Catlab.CategoricalAlgebra
+using Catlab.CategoricalAlgebra.FinSets
+using Catlab.CategoricalAlgebra.Squares
+
+t  = FinFunction([1,2,4], 5)
+l  = FinFunction([1,2,3], 3)
+b = FinFunction([2,3,1], 3)
+f  = FinFunction([2,3,2,1,3], 3)
+
+α = SquareDiagram(t, b, l, f)
+
+t₁ = FinFunction([1,1,1,1,1], 1)
+r  = FinFunction([1], 1)
+b₁ = FinFunction([1,1,1], 1)
+
+β = SquareDiagram(t₁, b₁, f, r)
+γ = composeH(α, β)
+@test top(γ) == t⋅t₁
+@test bottom(γ) == b⋅b₁
+@test left(γ) == left(α)
+@test right(γ) == right(β)
+end #module

--- a/test/categorical_algebra/Squares.jl
+++ b/test/categorical_algebra/Squares.jl
@@ -53,4 +53,5 @@ r = FinFunction([1,2,2,3,3], 3)
 
 @test collect(composeH(FinFunction([2,1], 3), FinFunction([2, 1, 3]))) == [1,2]
 @test collect(composeV(FinFunction([2,1], 3), FinFunction([2, 1, 3]))) == [1,2]
-end #module
+
+end

--- a/test/categorical_algebra/Squares.jl
+++ b/test/categorical_algebra/Squares.jl
@@ -1,5 +1,6 @@
 module TestSquares
 using Test
+
 using Catlab.Theories, Catlab.CategoricalAlgebra
 using Catlab.CategoricalAlgebra.FinSets
 using Catlab.CategoricalAlgebra.Squares

--- a/test/theories/Category.jl
+++ b/test/theories/Category.jl
@@ -90,3 +90,17 @@ h, k, H, K = [ Hom(sym, B, C) for sym in [:h,:k,:H,:K] ]
 f = Hom(:f, Ob(FreeCategory, :A), Ob(FreeCategory, :B))
 g = Hom(:g, Ob(FreeCategory2, :B), Ob(FreeCategory2, :C))
 @test_throws MethodError compose(f,g)
+
+
+# Double Category
+#################
+
+A, B, C, D, X, Y = [Ob(FreeDoubleCategory, x) for x in [:A, :B, :C, :D, :X, :Y]]
+@show typeof(A), typeof(X)
+f, g, h, k = HomH(:f, A, X), HomH(:g, B, Y), HomH(h, X, C), HomH(:k, Y, D)
+l, r, rr = HomV(:ϕ, A, B), HomV(:r, X, Y), HomV(:rr, C, D)
+α, β = Hom2(:α, f, g, l, r), Hom2(:β, h, k, r, rr)
+@test composeH(α, β) == α⋅β
+αβ = composeH(α, β)
+#@test top(αβ) == composeH(f, h)
+#@test bottom(αβ) == composeH(g, k)

--- a/test/theories/Category.jl
+++ b/test/theories/Category.jl
@@ -96,11 +96,10 @@ g = Hom(:g, Ob(FreeCategory2, :B), Ob(FreeCategory2, :C))
 #################
 
 A, B, C, D, X, Y = [Ob(FreeDoubleCategory, x) for x in [:A, :B, :C, :D, :X, :Y]]
-@show typeof(A), typeof(X)
 f, g, h, k = HomH(:f, A, X), HomH(:g, B, Y), HomH(h, X, C), HomH(:k, Y, D)
 l, r, rr = HomV(:ϕ, A, B), HomV(:r, X, Y), HomV(:rr, C, D)
 α, β = Hom2(:α, f, g, l, r), Hom2(:β, h, k, r, rr)
-@test composeH(α, β) == α⋅β
+@test composeH(α, β) == α⋆β
 αβ = composeH(α, β)
 #@test top(αβ) == composeH(f, h)
 #@test bottom(αβ) == composeH(g, k)


### PR DESCRIPTION
The goal of this PR is to implement the double category of commutative squares over any category. Starting off with

- [x] Implement Square as (left, right, top bottom) as a subtype of FreeDiagram.
- [x] Define \circ_1, \circ_2 as horizontal and vertical composition
- [x] Make a @theory DoubleCategory with
    - Ob, Hom1, Hom2, Cell for the 0,1,2 cells respectively
    - Term constructors compose1, compose2 for the 2 types of 2-cell compositions
    - Include 2 copies of the definition of category for the two types of 1-cells
- [x] Make an instance @instance DoubleCategory(Category.Ob, Category.Hom, Category.Hom, Square)
I should harmonize naming with 2 categories signature of the theory of 2-categories https://github.com/AlgebraicJulia/Catlab.jl/blob/f218d45f6f85e113eede4247bf3d63fe63751b81/src/theories/Category.jl#L82