### PR TITLE
Structured cospans of attributed C-sets

### DIFF
--- a/src/categorical_algebra/CSetMorphisms.jl
+++ b/src/categorical_algebra/CSetMorphisms.jl
@@ -186,7 +186,7 @@ unpack_diagram(diagram::DiscreteDiagram{<:AbstractACSet}) =
 unpack_diagram(span::Multispan{<:AbstractACSet}) =
   map(Multispan, finsets(apex(span)), unpack_components(legs(span)))
 unpack_diagram(cospan::Multicospan{<:AbstractACSet}) =
-  map(Multicospan, finsets(base(cospan)), unpack_components(legs(cospan)))
+  map(Multicospan, finsets(apex(cospan)), unpack_components(legs(cospan)))
 unpack_diagram(para::ParallelMorphisms{<:AbstractACSet}) =
   map(ParallelMorphisms, unpack_components(hom(para)))
 
@@ -212,7 +212,8 @@ end
 """ Objects in diagram that will have explicit legs in limit cone.
 
 Encodes common conventions such as, when taking a pullback of a cospan, not
-including a leg for the base since it can be computed from the other legs.
+including a cone leg for the cospan apex since it can be computed from the other
+legs.
 """
 cone_objects(diagram) = ob(diagram)
 cone_objects(cospan::Multicospan) = map(dom, legs(cospan))

--- a/src/categorical_algebra/CSetMorphisms.jl
+++ b/src/categorical_algebra/CSetMorphisms.jl
@@ -212,17 +212,17 @@ end
 """ Objects in diagram that will have explicit legs in limit cone.
 
 Encodes common conventions such as, when taking a pullback of a cospan, not
-including a cone leg for the cospan apex since it can be computed from the other
-legs.
+explicitly including a cone leg for the cospan apex since it can be computed
+from the other legs.
 """
 cone_objects(diagram) = ob(diagram)
-cone_objects(cospan::Multicospan) = map(dom, legs(cospan))
+cone_objects(cospan::Multicospan) = feet(cospan)
 cone_objects(para::ParallelMorphisms) = SVector(dom(para))
 
 """ Objects in diagram that will have explicit legs in colimit cocone.
 """
 cocone_objects(diagram) = ob(diagram)
-cocone_objects(span::Multispan) = map(codom, legs(span))
+cocone_objects(span::Multispan) = feet(span)
 cocone_objects(para::ParallelMorphisms) = SVector(codom(para))
 
 end

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -193,8 +193,6 @@ function Base.copy(acs::T) where T <: ACSet
   T(map(copy, acs.tables), map(copy, acs.indices))
 end
 
-Base.empty(acs::T) where T <: ACSet = T()
-
 function Base.show(io::IO, acs::AbstractACSet{CD,AD,Ts}) where {CD,AD,Ts}
   println(io, "ACSet(")
   join(io, vcat(

--- a/src/categorical_algebra/CategoricalAlgebra.jl
+++ b/src/categorical_algebra/CategoricalAlgebra.jl
@@ -12,10 +12,12 @@ include("Matrices.jl")
 include("FinRelations.jl")
 include("Permutations.jl")
 include("PredicatedSets.jl")
+include("StructuredCospans.jl")
 
 @reexport using .FreeDiagrams
 @reexport using .Limits
 @reexport using .CSets
 @reexport using .CSetMorphisms
+@reexport using .StructuredCospans
 
 end

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -206,7 +206,7 @@ end
 
 function universal(colim::Initial{<:FinSet{Int}},
                    cocone::SMulticospan{0,<:FinSet{Int}})
-  FinFunction(Int[], base(cocone))
+  FinFunction(Int[], apex(cocone))
 end
 
 function colimit(Xs::ObjectPair{<:FinSet{Int}})
@@ -219,7 +219,7 @@ end
 function universal(colim::BinaryCoproduct{<:FinSet{Int}},
                    cocone::Cospan{<:FinSet{Int}})
   f, g = cocone
-  FinFunction(vcat(collect(f), collect(g)), ob(colim), base(cocone))
+  FinFunction(vcat(collect(f), collect(g)), ob(colim), apex(cocone))
 end
 
 function colimit(Xs::DiscreteDiagram{<:FinSet{Int}})
@@ -233,7 +233,7 @@ end
 function universal(colim::Coproduct{<:FinSet{Int}},
                    cocone::Multicospan{<:FinSet{Int}})
   FinFunction(reduce(vcat, (collect(f) for f in cocone), init=Int[]),
-              ob(colim), base(cocone))
+              ob(colim), apex(cocone))
 end
 
 function colimit(pair::ParallelPair{<:FinSet{Int}})

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -46,6 +46,8 @@ FinSet(set::S) where {T,S<:AbstractSet{T}} = FinSet{S,T}(set)
 iterable(s::FinSet{Int}) = 1:s.set
 iterable(s::FinSet{<:AbstractSet}) = s.set
 
+Base.show(io::IO, s::FinSet) = print(io, "FinSet($(s.set))")
+
 """ Function between finite sets.
 
 The function can be defined implicitly by an arbitrary Julia function, in which
@@ -73,6 +75,11 @@ FinFunctionCallable(f::Function, dom::Int, codom::Int) =
 FinFunctionCallable(f::Function, dom::FinSet{S,T}, codom::FinSet{S,T}) where {S,T} =
   FinFunctionCallable(FunctionWrapper{T,Tuple{T}}(f), dom, codom)
 
+function Base.show(io::IO, f::FinFunctionCallable)
+  func = f.func.obj[] # Deference FunctionWrapper
+  print(io, "FinFunction($(nameof(func)), $(f.dom), $(f.codom))")
+end
+
 (f::FinFunctionCallable)(x) = f.func(x)
 
 """ Function in FinSet represented explicitly by a vector.
@@ -99,6 +106,9 @@ FinFunctionVector(f::AbstractVector, dom::FinSet{Int}, codom::FinSet{Int}) =
 dom(f::FinFunctionVector) = FinSet(length(f.func))
 codom(f::FinFunctionVector) = FinSet(f.codom)
 
+Base.show(io::IO, f::FinFunctionVector) =
+  print(io, "FinFunction($(f.func), $(length(f.func)), $(f.codom))")
+
 (f::FinFunctionVector)(x) = f.func[x]
 
 """ Force evaluation of lazy function or relation.
@@ -122,6 +132,9 @@ FinFunctionIdentity(n::Int) = FinFunctionIdentity(FinSet(n))
 
 dom(f::FinFunctionIdentity) = f.dom
 codom(f::FinFunctionIdentity) = f.dom
+
+Base.show(io::IO, f::FinFunctionIdentity) =
+  print(io, "FinFunction(identity, $(f.dom))")
 
 (f::FinFunctionIdentity)(x) = x
 

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -209,7 +209,7 @@ function limit(pair::ParallelPair{<:FinSet{Int}})
   f, g = pair
   m = length(dom(pair))
   eq = FinFunction(filter(i -> f(i) == g(i), 1:m), m)
-  Limit(pair, SMultispan(eq))
+  Limit(pair, SMultispan{1}(eq))
 end
 
 function limit(para::ParallelMorphisms{<:FinSet{Int}})
@@ -217,7 +217,7 @@ function limit(para::ParallelMorphisms{<:FinSet{Int}})
   f1, frest = para[1], para[2:end]
   m = length(dom(para))
   eq = FinFunction(filter(i -> all(f1(i) == f(i) for f in frest), 1:m), m)
-  Limit(para, SMultispan(eq))
+  Limit(para, SMultispan{1}(eq))
 end
 
 function universal(lim::Equalizer{<:FinSet{Int}},
@@ -286,7 +286,7 @@ function colimit(pair::ParallelPair{<:FinSet{Int}})
   h = [ find_root(sets, i) for i in 1:n ]
   roots = unique!(sort(h))
   coeq = FinFunction([ searchsortedfirst(roots, r) for r in h], length(roots))
-  Colimit(pair, SMulticospan(coeq))
+  Colimit(pair, SMulticospan{1}(coeq))
 end
 
 function colimit(para::ParallelMorphisms{<:FinSet{Int}})
@@ -302,7 +302,7 @@ function colimit(para::ParallelMorphisms{<:FinSet{Int}})
   h = [ find_root(sets, i) for i in 1:n ]
   roots = unique!(sort(h))
   coeq = FinFunction([ searchsortedfirst(roots, r) for r in h ], length(roots))
-  Colimit(para, SMulticospan(coeq))
+  Colimit(para, SMulticospan{1}(coeq))
 end
 
 function universal(coeq::Coequalizer{<:FinSet{Int}},

--- a/src/categorical_algebra/FreeDiagrams.jl
+++ b/src/categorical_algebra/FreeDiagrams.jl
@@ -9,7 +9,7 @@ module FreeDiagrams
 export AbstractFreeDiagram, FreeDiagram, FixedShapeFreeDiagram, DiscreteDiagram,
   EmptyDiagram, ObjectPair, Span, Cospan, Multispan, Multicospan,
   SMultispan, SMulticospan, ParallelPair, ParallelMorphisms,
-  ob, hom, dom, codom, apex, base, legs, left, right,
+  ob, hom, dom, codom, apex, legs, left, right,
   nv, ne, src, tgt, vertices, edges, has_vertex, has_edge,
   add_vertex!, add_vertices!, add_edge!, add_edges!
 
@@ -62,7 +62,7 @@ shape is a pushout.
 end
 
 function Multispan(legs::AbstractVector)
-  !isempty(legs) || error("Empty list of legs but no base given")
+  !isempty(legs) || error("Empty list of legs but no apex given")
   allequal(dom.(legs)) || error("Legs $legs do not have common domain")
   Multispan(dom(first(legs)), legs)
 end
@@ -95,12 +95,12 @@ legs different than two. A limit of this shape is a pullback.
 """
 @auto_hash_equals struct Multicospan{Ob,Legs<:AbstractVector} <:
     FixedShapeFreeDiagram{Ob}
-  base::Ob
+  apex::Ob
   legs::Legs
 end
 
 function Multicospan(legs::AbstractVector)
-  !isempty(legs) || error("Empty list of legs but no base given")
+  !isempty(legs) || error("Empty list of legs but no apex given")
   allequal(codom.(legs)) || error("Legs $legs do not have common codomain")
   Multicospan(codom(first(legs)), legs)
 end
@@ -109,7 +109,7 @@ const SMulticospan{N,Ob} = Multicospan{Ob,<:StaticVector{N}}
 
 SMulticospan(legs...) = Multicospan(SVector(legs...))
 SMulticospan{N}(legs...) where N = Multicospan(SVector{N}(legs...))
-SMulticospan{0}(base) = Multicospan(base, SVector{0,Any}())
+SMulticospan{0}(apex) = Multicospan(apex, SVector{0,Any}())
 
 """ Cospan of morphisms in a category.
 
@@ -117,7 +117,7 @@ A common special case of [`Multicospan`](@ref). See also [`Span`](@ref).
 """
 const Cospan{Ob} = SMulticospan{2,Ob}
 
-base(cospan::Multicospan) = cospan.base
+apex(cospan::Multicospan) = cospan.apex
 legs(cospan::Multicospan) = cospan.legs
 left(cospan::Cospan) = cospan.legs[1]
 right(cospan::Cospan) = cospan.legs[2]
@@ -222,7 +222,7 @@ end
 function FreeDiagram(cospan::Multicospan{Ob}) where Ob
   d = FreeDiagram{Ob,eltype(cospan)}()
   vs = add_vertices!(d, length(cospan), ob=dom.(legs(cospan)))
-  v0 = add_vertex!(d, ob=base(cospan))
+  v0 = add_vertex!(d, ob=apex(cospan))
   add_edges!(d, vs, fill(v0, length(cospan)), hom=legs(cospan))
   return d
 end

--- a/src/categorical_algebra/FreeDiagrams.jl
+++ b/src/categorical_algebra/FreeDiagrams.jl
@@ -11,9 +11,7 @@ export AbstractFreeDiagram, FreeDiagram, FixedShapeFreeDiagram, DiscreteDiagram,
   SMultispan, SMulticospan, ParallelPair, ParallelMorphisms,
   ob, hom, dom, codom, apex, base, legs, left, right,
   nv, ne, src, tgt, vertices, edges, has_vertex, has_edge,
-  add_vertex!, add_vertices!, add_edge!, add_edges!,
-  DecoratedCospan, AbstractFunctor, AbstractLaxator, LaxMonoidalFunctor,
-  decorator, decoration, undecorate
+  add_vertex!, add_vertices!, add_edge!, add_edges!
 
 using AutoHashEquals
 using StaticArrays: StaticVector, SVector, @SVector
@@ -174,33 +172,6 @@ Base.firstindex(para::ParallelMorphisms) = firstindex(para.homs)
 Base.lastindex(para::ParallelMorphisms) = lastindex(para.homs)
 
 allequal(xs::AbstractVector) = all(isequal(x, xs[1]) for x in xs[2:end])
-
-# Decorated cospans
-#------------------
-
-# FIXME: Types and structs for functors do not belong here.
-abstract type AbstractFunctor end
-abstract type AbstractLaxator end
-
-struct LaxMonoidalFunctor{Ftr <: AbstractFunctor, Lxr <: AbstractLaxator} <: AbstractFunctor
-  F::Ftr
-  L::Lxr
-end
-
-""" Decorate Cospan of morphisms for representing open networks.
-"""
-struct DecoratedCospan{Decorator <: AbstractFunctor,Decoration}
-  cospan::Cospan
-  decorator::Decorator
-  decoration::Decoration
-end
-
-decorator(m::DecoratedCospan) = m.decorator
-decoration(m::DecoratedCospan) = m.decoration
-undecorate(m::DecoratedCospan) = m.cospan
-base(m::DecoratedCospan) = base(m.cospan)
-left(m::DecoratedCospan) = left(m.cospan)
-right(m::DecoratedCospan) = right(m.cospan)
 
 # General diagrams
 ##################

--- a/src/categorical_algebra/FreeDiagrams.jl
+++ b/src/categorical_algebra/FreeDiagrams.jl
@@ -69,9 +69,10 @@ end
 
 const SMultispan{N,Ob} = Multispan{Ob,<:StaticVector{N}}
 
-SMultispan(legs...) = Multispan(SVector(legs...))
-SMultispan{N}(legs...) where N = Multispan(SVector{N}(legs...))
+SMultispan{N}(apex, legs::Vararg{Any,N}) where N =
+  Multispan(apex, SVector{N}(legs...))
 SMultispan{0}(apex) = Multispan(apex, SVector{0,Any}())
+SMultispan{N}(legs::Vararg{Any,N}) where N = Multispan(SVector{N}(legs...))
 
 """ Span of morphims in a category.
 
@@ -108,9 +109,10 @@ end
 
 const SMulticospan{N,Ob} = Multicospan{Ob,<:StaticVector{N}}
 
-SMulticospan(legs...) = Multicospan(SVector(legs...))
-SMulticospan{N}(legs...) where N = Multicospan(SVector{N}(legs...))
+SMulticospan{N}(apex, legs::Vararg{Any,N}) where N =
+  Multicospan(apex, SVector{N}(legs...))
 SMulticospan{0}(apex) = Multicospan(apex, SVector{0,Any}())
+SMulticospan{N}(legs::Vararg{Any,N}) where N = Multicospan(SVector{N}(legs...))
 
 """ Cospan of morphisms in a category.
 

--- a/src/categorical_algebra/FreeDiagrams.jl
+++ b/src/categorical_algebra/FreeDiagrams.jl
@@ -9,7 +9,7 @@ module FreeDiagrams
 export AbstractFreeDiagram, FreeDiagram, FixedShapeFreeDiagram, DiscreteDiagram,
   EmptyDiagram, ObjectPair, Span, Cospan, Multispan, Multicospan,
   SMultispan, SMulticospan, ParallelPair, ParallelMorphisms,
-  ob, hom, dom, codom, apex, legs, left, right,
+  ob, hom, dom, codom, apex, legs, feet, left, right,
   nv, ne, src, tgt, vertices, edges, has_vertex, has_edge,
   add_vertex!, add_vertices!, add_edge!, add_edges!
 
@@ -81,6 +81,7 @@ const Span{Ob} = SMultispan{2,Ob}
 
 apex(span::Multispan) = span.apex
 legs(span::Multispan) = span.legs
+feet(span::Multispan) = map(codom, span.legs)
 left(span::Span) = span.legs[1]
 right(span::Span) = span.legs[2]
 
@@ -119,6 +120,7 @@ const Cospan{Ob} = SMulticospan{2,Ob}
 
 apex(cospan::Multicospan) = cospan.apex
 legs(cospan::Multicospan) = cospan.legs
+feet(cospan::Multicospan) = map(dom, cospan.legs)
 left(cospan::Cospan) = cospan.legs[1]
 right(cospan::Cospan) = cospan.legs[2]
 
@@ -214,14 +216,14 @@ end
 function FreeDiagram(span::Multispan{Ob}) where Ob
   d = FreeDiagram{Ob,eltype(span)}()
   v0 = add_vertex!(d, ob=apex(span))
-  vs = add_vertices!(d, length(span), ob=codom.(legs(span)))
+  vs = add_vertices!(d, length(span), ob=feet(span))
   add_edges!(d, fill(v0, length(span)), vs, hom=legs(span))
   return d
 end
 
 function FreeDiagram(cospan::Multicospan{Ob}) where Ob
   d = FreeDiagram{Ob,eltype(cospan)}()
-  vs = add_vertices!(d, length(cospan), ob=dom.(legs(cospan)))
+  vs = add_vertices!(d, length(cospan), ob=feet(cospan))
   v0 = add_vertex!(d, ob=apex(cospan))
   add_edges!(d, vs, fill(v0, length(cospan)), hom=legs(cospan))
   return d

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -240,8 +240,8 @@ To implement for equalizers of type `T`, define the method
 `universal(::Equalizer{T}, ::SMultispan{1,T})`. For coequalizers of type `T`,
 define the method `universal(::Coequalizer{T}, ::SMulticospan{1,T})`.
 """
-factorize(lim::Equalizer, h) = universal(lim, SMultispan(h))
-factorize(colim::Coequalizer, h) = universal(colim, SMulticospan(h))
+factorize(lim::Equalizer, h) = universal(lim, SMultispan{1}(h))
+factorize(colim::Coequalizer, h) = universal(colim, SMulticospan{1}(h))
 
 # Composite (co)limits
 ######################

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -2,7 +2,7 @@
 """
 module Limits
 export AbstractLimit, AbstractColimit, Limit, Colimit,
-  ob, cone, cocone, apex, base, legs, limit, colimit, universal,
+  ob, cone, cocone, apex, legs, limit, colimit, universal,
   Terminal, Initial, terminal, initial, delete, create, factorize,
   BinaryProduct, Product, product, proj1, proj2, pair,
   BinaryPullback, Pullback, BinaryEqualizer, Equalizer, pullback, incl,
@@ -19,7 +19,7 @@ import ...Theories: ob, terminal, product, proj1, proj2, equalizer, incl,
   initial, coproduct, coproj1, coproj2, coequalizer, proj,
   delete, create, pair, copair, factorize
 using ..FreeDiagrams
-import ..FreeDiagrams: apex, base, legs
+import ..FreeDiagrams: apex, legs
 
 # Data types for limits
 #######################
@@ -70,9 +70,9 @@ reasons certain categories may use different subtypes to include extra data.
 """
 abstract type AbstractColimit{Ob,Diagram} end
 
-ob(colim::AbstractColimit) = base(colim)
+ob(colim::AbstractColimit) = apex(colim)
 cocone(colim::AbstractColimit) = colim.cocone
-base(colim::AbstractColimit) = base(cocone(colim))
+apex(colim::AbstractColimit) = apex(cocone(colim))
 legs(colim::AbstractColimit) = legs(cocone(colim))
 
 Base.iterate(colim::AbstractColimit, args...) = iterate(cocone(colim), args...)

--- a/src/categorical_algebra/StructuredCospans.jl
+++ b/src/categorical_algebra/StructuredCospans.jl
@@ -1,0 +1,60 @@
+""" Structured cospans.
+
+This module provides a generic interface for structured cospans with a concrete
+implementation for attributed C-sets.
+"""
+module StructuredCospans
+export StructuredCospan, StructuredMulticospan
+
+using StaticArrays: StaticVector
+
+using ..FreeDiagrams
+import ..FreeDiagrams: apex, legs, feet, left, right
+
+""" Structured multicospan.
+
+A structured multicospan is like a structured cospan except that it may have a
+number of legs different than two.
+
+See also: [`StructuredCospan`](@ref).
+"""
+struct StructuredMulticospan{L,X,A,Cosp<:Multicospan{X},Feet<:AbstractVector{A}}
+  cospan::Cosp
+  feet::Feet
+end
+
+""" Structured cospan.
+
+The first type parameter `L` encodes a functor L: A → X from the base category
+`A`, often FinSet, to a category `X` with "extra structure." An L-structured
+cospan is then a cospan in X whose feet are images under L of objects in A. The
+category X is assumed to have pushouts.
+
+Structured cospans form a double category with no assumptions on the functor L.
+To obtain a symmetric monoidal double category, L must preserve finite
+coproducts. In practice, L usually has a right adjoint R: X → A, which implies
+that L preserves all finite colimits. It also allows structured cospans to be
+constructed more conveniently from an object x in X plus a cospan in A with apex
+R(x).
+
+See also: [`StructuredMulticospan`](@ref).
+"""
+const StructuredCospan{L,X,A} =
+  StructuredMulticospan{L,X,A,<:Cospan{X},<:StaticVector{2,A}}
+
+apex(cospan::StructuredMulticospan) = apex(cospan.cospan)
+legs(cospan::StructuredMulticospan) = legs(cospan.cospan)
+feet(cospan::StructuredMulticospan) = cospan.feet
+left(cospan::StructuredCospan) = first(legs(cospan))
+right(cospan::StructuredCospan) = last(legs(cospan))
+
+function StructuredMulticospan{L,X,A}(x::X, cospan::Multicospan{A}) where {L,X,A}
+  ϵ = counit(L, x) # Component L(R(x)) → x of counit of adjunction
+  StructuredMulticospan{L,X,A}(
+    Multicospan(x, map(leg -> L(leg)⋅ϵ, legs(cospan))),
+    feet(cospan))
+end
+StructuredCospan{L,X,A}(apex::X, cospan::Cospan{A}) where {L,X,A} =
+  StructuredMulticospan{L,X,A}(apex, cospan)
+
+end

--- a/src/categorical_algebra/StructuredCospans.jl
+++ b/src/categorical_algebra/StructuredCospans.jl
@@ -150,8 +150,9 @@ function OpenACSetTypes(::Type{X}, ob₀::Symbol) where
   L = if isempty(attrs₀)
     FinSetDiscreteACSet{ob₀, X{type_vars...}}
   else
+    adom = Tuple(ones(Int, length(attrs₀)))
     CD₀ = CatDesc{(ob₀,),(),(),()}
-    AD₀ = AttrDesc{CD₀,AD.data,AD.attr[attrs₀],AD.adom[attrs₀],AD.acodom[attrs₀]}
+    AD₀ = AttrDesc{CD₀,AD.data,AD.attr[attrs₀],adom,AD.acodom[attrs₀]}
     DiscreteACSet{ACSet{CD₀,AD₀,Tuple{type_vars...},(),()}, X{type_vars...}}
   end
   (foldr(UnionAll, type_vars, init=StructuredCospanOb{L}),

--- a/src/categorical_algebra/StructuredCospans.jl
+++ b/src/categorical_algebra/StructuredCospans.jl
@@ -7,6 +7,8 @@ module StructuredCospans
 export StructuredMulticospan, StructuredCospan, StructuredCospanOb,
   OpenCSetTypes, OpenACSetTypes
 
+using Compat: only
+
 using AutoHashEquals
 using StaticArrays: StaticVector, SVector
 
@@ -119,68 +121,121 @@ end
 # Structured cospans of C-sets
 ##############################
 
-struct FinSetDiscreteACSet{ob₀, X <: AbstractACSet} end
-struct DiscreteACSet{A <: AbstractACSet, X <: AbstractACSet} end
-
 """ Create types for open C-sets from a C-set type.
 
-Returns two types, for objects and morphisms (structured cospans).
+Returns two types, for objects, a subtype of [`StructuredCospanOb`](@ref), and
+for morphisms, a subtype of [`StructuredCospan`](@ref).
 
 See also: [`OpenACSetTypes`](@ref).
 """
-function OpenCSetTypes(::Type{X}, ob₀::Symbol) where {X<:AbstractCSet}
+function OpenCSetTypes(::Type{X}, ob₀::Symbol) where
+    {CD<:CatDesc, X<:AbstractCSet{CD}}
+  @assert ob₀ ∈ CD.ob
   L = FinSetDiscreteACSet{ob₀, X}
   (StructuredCospanOb{L}, StructuredCospan{L})
 end
 
 """ Create types for open attributed C-sets from an attributed C-set type.
 
-TODO
+The resulting types, for objects and morphisms, each have the same type
+parameters for data types as the original type.
+
+See also: [`OpenCSetTypes`](@ref).
 """
 function OpenACSetTypes(::Type{X}, ob₀::Symbol) where
     {CD<:CatDesc, AD<:AttrDesc{CD}, X<:AbstractACSet{CD,AD}}
   @assert ob₀ ∈ CD.ob
-  type_vars = [ TypeVar(data) for data in AD.data ]
+  type_vars = map(TypeVar, AD.data)
   attrs₀ = [ i for (i,j) in enumerate(AD.adom) if CD.ob[j] == ob₀ ]
   L = if isempty(attrs₀)
     FinSetDiscreteACSet{ob₀, X{type_vars...}}
   else
     CD₀ = CatDesc{(ob₀,),(),(),()}
-    AD₀ = AttrDesc{CD₀,AD.Data,AD.Attr[attrs₀],AD.ADom[attrs₀],AD.ACodom[attrs₀]}
+    AD₀ = AttrDesc{CD₀,AD.data,AD.attr[attrs₀],AD.adom[attrs₀],AD.acodom[attrs₀]}
     DiscreteACSet{ACSet{CD₀,AD₀,Tuple{type_vars...},(),()}, X{type_vars...}}
   end
   (foldr(UnionAll, type_vars, init=StructuredCospanOb{L}),
    foldr(UnionAll, type_vars, init=StructuredCospan{L}))
 end
 
-function (::Type{L})(a::FinSet{Int}) where
-    {ob₀, X, L <: FinSetDiscreteACSet{ob₀,X}}
-  x = X()
-  add_parts!(x, ob₀, length(a))
-  return x
-end
-function (::Type{L})(a::AbstractACSet) where
-    {CD₀, AD₀, A <: AbstractACSet{CD₀,AD₀}, X, L <: DiscreteACSet{A,X}}
-  x = X()
-  for ob in CD₀.ob
-    add_parts!(x, ob, nparts(a, ob))
-  end
-  for attr in AD₀.attr
-    set_subpart!(x, attr, subpart(a, attr))
-  end
-  return x
+abstract type AbstractDiscreteACSet{X <: AbstractACSet} end
+
+StructuredCospan{L}(x::AbstractACSet, f::FinFunction{Int},
+                    g::FinFunction{Int}) where {L<:AbstractDiscreteACSet} =
+ StructuredCospan{L}(x, Cospan(f, g))
+
+""" A functor L: FinSet → C-Set giving the discrete C-set wrt an object in C.
+
+This functor has a right adjoint R: C-Set → FinSet giving the underlying set at
+that object. Instead of instantiating this type directly, you should use
+[`OpenCSetTypes`](@ref) or [`OpenACSetTypes`](@ref).
+"""
+struct FinSetDiscreteACSet{ob₀, X} <: AbstractDiscreteACSet{X} end
+
+""" A functor L: C₀-Set → C-Set giving the discrete C-set for C₀.
+
+Here C₀ is assumed to contain a single object from C and the discreteness is
+with respect to this object. The functor L has a right adjoint R: C-Set → C₀-Set
+forgetting the rest of C. Data attributes of the chosen object are preserved.
+"""
+struct DiscreteACSet{A <: AbstractACSet, X} <: AbstractDiscreteACSet{X} end
+
+function StructuredCospan{L}(
+    x::AbstractACSet, cospan::Cospan{<:FinSet{Int}}) where
+    {A, L<:DiscreteACSet{A}}
+  a = A()
+  copy_common_parts!(a, x)
+  f, g = cospan
+  ϕ, ψ = induced_transformation(a, f), induced_transformation(a, g)
+  StructuredCospan{L}(x, Cospan(a, ϕ, ψ))
 end
 
+""" C-set transformation b → a induced by function `f` into parts of `a`.
+"""
+function induced_transformation(a::A, f::FinFunction{Int}) where
+    {CD, AD, A <: AbstractACSet{CD,AD}}
+  ob = only(CD.ob)
+  @assert nparts(a, ob) == length(codom(f))
+  b = A()
+  add_parts!(b, ob, length(dom(f)))
+  f_vec = collect(f)
+  for attr in AD.attr
+    set_subpart!(b, attr, subpart(a, f_vec, attr))
+  end
+  ACSetTransformation((; ob => f), b, a)
+end
+
+""" Apply left adjoint L: FinSet → C-Set to object.
+"""
+function (::Type{L})(a::FinSet{Int}) where {ob₀,X,L<:FinSetDiscreteACSet{ob₀,X}}
+  x = X()
+  add_parts!(x, ob₀, length(a))
+  x
+end
+
+""" Apply left adjoint L: C₀-Set → C-Set to object.
+"""
+function (::Type{L})(a::AbstractACSet) where {A,X,L<:DiscreteACSet{A,X}}
+  x = X()
+  copy_common_parts!(x, a)
+  x
+end
+
+""" Apply left adjoint L: FinSet → C-Set to morphism.
+"""
 function (::Type{L})(f::FinFunction{Int}) where
     {ob₀, L <: FinSetDiscreteACSet{ob₀}}
   ACSetTransformation((; ob₀ => f), L(dom(f)), L(codom(f)))
 end
+
+""" Apply left adjoint L: C₀-Set → C-Set to morphism.
+"""
 function (::Type{L})(ϕ::ACSetTransformation) where {L <: DiscreteACSet}
   ACSetTransformation(components(ϕ), L(dom(ϕ)), L(codom(ϕ)))
 end
 
 """ Convert morphism a → R(x) to morphism L(a) → x using discrete-forgetful
-adjunction L ⊣ R.
+adjunction L ⊣ R: A ↔ X.
 """
 function shift_left(::Type{L}, x::AbstractACSet, f::FinFunction{Int}) where
     {ob₀, L <: FinSetDiscreteACSet{ob₀}}
@@ -189,6 +244,28 @@ end
 function shift_left(::Type{L}, x::AbstractACSet, ϕ::ACSetTransformation) where
     {L <: DiscreteACSet}
   ACSetTransformation(components(ϕ), L(dom(ϕ)), x)
+end
+
+""" Copy parts into a C-set from a C′-set along intersection of C and C′.
+
+TODO: Both more and less general than `copy_parts!` in the `CSets` module: more
+general in allowing C != C′, but less general in not copying subparts, only
+common data attributes. Ideally this functionality would be unified.
+"""
+@generated function copy_common_parts!(to::ACSet{CD,AD}, from::ACSet{CD′,AD′}) where
+    {CD, AD, CD′, AD′}
+  obs = intersect(CD.ob, CD′.ob)
+  attrs = intersect(AD.attr, AD′.attr)
+  @assert all(dom(AD, attr) == dom(AD′, attr) for attr in attrs)
+  Expr(:block,
+    :(newparts = (; $(map(obs) do ob
+        Expr(:kw, ob, :(add_parts!(to, $(QuoteNode(ob)),
+                                   nparts(from, $(QuoteNode(ob))))))
+        end...))),
+    map(attrs) do attr
+      :(set_subpart!(to, newparts.$(dom(AD, attr)), $(QuoteNode(attr)),
+                     subpart(from, $(QuoteNode(attr)))))
+    end...)
 end
 
 end

--- a/src/categorical_algebra/StructuredCospans.jl
+++ b/src/categorical_algebra/StructuredCospans.jl
@@ -4,12 +4,19 @@ This module provides a generic interface for structured cospans with a concrete
 implementation for attributed C-sets.
 """
 module StructuredCospans
-export StructuredCospan, StructuredMulticospan
+export StructuredMulticospan, StructuredCospan, StructuredCospanOb,
+  OpenCSetTypes, OpenACSetTypes
 
-using StaticArrays: StaticVector
+using AutoHashEquals
+using StaticArrays: StaticVector, SVector
 
-using ..FreeDiagrams
+using ...GAT, ..FreeDiagrams, ..Limits, ..FinSets, ..CSets, ..CSetMorphisms
 import ..FreeDiagrams: apex, legs, feet, left, right
+using ...Theories: Category
+import ...Theories: dom, codom, compose, ⋅, id
+
+# Generic structured cospans
+############################
 
 """ Structured multicospan.
 
@@ -18,10 +25,25 @@ number of legs different than two.
 
 See also: [`StructuredCospan`](@ref).
 """
-struct StructuredMulticospan{L,X,A,Cosp<:Multicospan{X},Feet<:AbstractVector{A}}
+@auto_hash_equals struct StructuredMulticospan{L, Cosp <: Multicospan,
+                                               Feet <: AbstractVector}
   cospan::Cosp
   feet::Feet
+
+  StructuredMulticospan{L}(cospan::Cosp, feet::Feet) where
+      {L, Cosp <: Multicospan, Feet <: AbstractVector} =
+    new{L,Cosp,Feet}(cospan, feet)
 end
+
+function StructuredMulticospan{L}(apex, cospan::Multicospan) where L
+  ϵ = counit(L, apex)
+  StructuredMulticospan{L}(
+    Multicospan(apex, map(leg -> L(leg)⋅ϵ, legs(cospan))), feet(cospan))
+end
+
+apex(cospan::StructuredMulticospan) = apex(cospan.cospan)
+legs(cospan::StructuredMulticospan) = legs(cospan.cospan)
+feet(cospan::StructuredMulticospan) = cospan.feet
 
 """ Structured cospan.
 
@@ -30,31 +52,92 @@ The first type parameter `L` encodes a functor L: A → X from the base category
 cospan is then a cospan in X whose feet are images under L of objects in A. The
 category X is assumed to have pushouts.
 
-Structured cospans form a double category with no assumptions on the functor L.
-To obtain a symmetric monoidal double category, L must preserve finite
-coproducts. In practice, L usually has a right adjoint R: X → A, which implies
-that L preserves all finite colimits. It also allows structured cospans to be
-constructed more conveniently from an object x in X plus a cospan in A with apex
-R(x).
+Structured cospans form a double category with no further assumptions on the
+functor L. To obtain a symmetric monoidal double category, L must preserve
+finite coproducts. In practice, L usually has a right adjoint R: X → A, which
+implies that L preserves all finite colimits. It also allows structured cospans
+to be constructed more conveniently from an object x in X plus a cospan in A
+with apex R(x).
 
 See also: [`StructuredMulticospan`](@ref).
 """
-const StructuredCospan{L,X,A} =
-  StructuredMulticospan{L,X,A,<:Cospan{X},<:StaticVector{2,A}}
+const StructuredCospan{L, Cosp <: Cospan, Feet <: StaticVector{2}} =
+  StructuredMulticospan{L,Cosp,Feet}
 
-apex(cospan::StructuredMulticospan) = apex(cospan.cospan)
-legs(cospan::StructuredMulticospan) = legs(cospan.cospan)
-feet(cospan::StructuredMulticospan) = cospan.feet
+StructuredCospan{L}(cospan::Cospan, feet::StaticVector{2}) where L =
+  StructuredMulticospan{L}(cospan, feet)
+StructuredCospan{L}(apex, cospan::Cospan) where L =
+  StructuredMulticospan{L}(apex, cospan)
+
 left(cospan::StructuredCospan) = first(legs(cospan))
 right(cospan::StructuredCospan) = last(legs(cospan))
 
-function StructuredMulticospan{L,X,A}(x::X, cospan::Multicospan{A}) where {L,X,A}
-  ϵ = counit(L, x) # Component L(R(x)) → x of counit of adjunction
-  StructuredMulticospan{L,X,A}(
-    Multicospan(x, map(leg -> L(leg)⋅ϵ, legs(cospan))),
-    feet(cospan))
+# Category of structured cospans
+################################
+
+""" Object in the category of L-structured cospans.
+"""
+@auto_hash_equals struct StructuredCospanOb{L,T}
+  ob::T
+  StructuredCospanOb{L}(ob::T) where {L,T} = new{L,T}(ob)
 end
-StructuredCospan{L,X,A}(apex::X, cospan::Cospan{A}) where {L,X,A} =
-  StructuredMulticospan{L,X,A}(apex, cospan)
+
+function StructuredCospan(cospan::Cospan, lfoot::StructuredCospanOb{L},
+                          rfoot::StructuredCospanOb{L}) where L
+  StructuredCospan{L}(cospan, SVector(lfoot.ob, rfoot.ob))
+end
+
+@instance Category{StructuredCospanOb, StructuredCospan} begin
+  @import dom, codom, id
+
+  function compose(M::StructuredCospan, N::StructuredCospan)
+    ι1, ι2 = colim = pushout(right(M), left(N))
+    cospan = Cospan(ob(colim), left(M)⋅ι1, right(N)⋅ι2)
+    StructuredCospan(cospan, dom(M), codom(N))
+  end
+end
+
+dom(cospan::StructuredCospan{L}) where L =
+  StructuredCospanOb{L}(first(feet(cospan)))
+codom(cospan::StructuredCospan{L}) where L =
+  StructuredCospanOb{L}(last(feet(cospan)))
+
+function id(a::StructuredCospanOb{L}) where L
+  leg = L(id(a.ob))
+  StructuredCospan(Cospan(leg, leg), a, a)
+end
+
+# Structured cospans of C-sets
+##############################
+
+function OpenACSetTypes(::Type{X}, ob₀::Symbol) where {CD, X <: AbstractACSet{CD}}
+  @assert ob₀ ∈ CD.ob
+  L = DiscreteACSet{ob₀,X}
+  (StructuredCospanOb{L}, StructuredCospan{L})
+end
+OpenCSetTypes(::Type{X}, ob₀::Symbol) where {X <: AbstractCSet} =
+  OpenACSetTypes(X, ob₀)
+
+struct DiscreteACSet{ob₀, X <: AbstractACSet} end
+
+function (::Type{L})(x₀::FinSet{Int}) where {ob₀, X, L<:DiscreteACSet{ob₀,X}}
+  x = X()
+  add_parts!(x, ob₀, length(x₀))
+  x
+end
+function (::Type{L})(f₀::FinFunction{Int}) where {ob₀, L<:DiscreteACSet{ob₀}}
+  ACSetTransformation((; ob₀ => f₀), L(dom(f₀)), L(codom(f₀)))
+end
+
+""" Unit a → R(L(a)) of discrete-forgetful adjunction L ⊣ R: FinSet → C-Set.
+"""
+unit(::Type{L}, a) where {L<:DiscreteACSet} = id(a)
+
+""" Counit L(R(x)) → x of discrete-forgetful adjunction L ⊣ R: FinSet → CSet.
+"""
+function counit(::Type{L}, x) where {ob₀, L<:DiscreteACSet{ob₀}}
+  x₀ = FinSet(nparts(x, ob₀))
+  ACSetTransformation((; ob₀ => id(x₀)), L(x₀), x)
+end
 
 end

--- a/src/theories/Schema.jl
+++ b/src/theories/Schema.jl
@@ -47,8 +47,7 @@ AttrDesc (describing the discrete category and the profunctor). This allows us
 to have C-sets as Attributed C-sets with an empty AttrDesc.
 """
 struct CatDesc{Ob,Hom,Dom,Codom}
-  function CatDesc{Ob,Hom,Dom,Codom}() where
-    {Ob,Hom,Dom,Codom}
+  function CatDesc{Ob,Hom,Dom,Codom}() where {Ob,Hom,Dom,Codom}
     new{Ob,Hom,Dom,Codom}()
   end
   function CatDesc(pres::Presentation{Schema})

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -96,7 +96,7 @@ set_subpart!(d, [4,5], :parent, 5)
 @test subpart(d, 4, :height) == 10
 @test subpart(d, :, :height) == [0,0,0,10,20]
 
-d2 = empty(d)
+d2 = Dendrogram{Int}()
 copy_parts!(d2, d, :X, [4,5])
 @test nparts(d2, :X) == 2
 @test subpart(d2, [1,2], :parent) == [2,2]

--- a/test/categorical_algebra/CategoricalAlgebra.jl
+++ b/test/categorical_algebra/CategoricalAlgebra.jl
@@ -39,4 +39,8 @@ end
   include("PredicatedSets.jl")
 end
 
+@testset "StructuredCospans" begin
+  include("StructuredCospans.jl")
+end
+
 end

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -16,14 +16,18 @@ h = FinFunction([3,1,2], 3)
 @test map(id(FinSet(3)), 1:3) == [1,2,3]
 @test map(FinFunction(x -> (x % 3) + 1, 3, 3), 1:3) == [2,3,1]
 
-# Composition and identities.
+# Domains and codomains.
 @test dom(f) == FinSet(3)
 @test codom(f) == FinSet(5)
+@test dom(id(FinSet(3))) == FinSet(3)
+@test codom(id(FinSet(3))) == FinSet(3)
+
+# Composition and identities.
 @test compose(f,g) == FinFunction([1,2,2], 3)
 @test compose(g,h) == FinFunction([3,3,1,1,2], 3)
 @test compose(compose(f,g),h) == compose(f,compose(g,h))
-@test force(compose(id(dom(f)),f)) == f
-@test force(compose(f,id(codom(f)))) == f
+@test compose(id(dom(f)), f) == f
+@test compose(f, id(codom(f))) == f
 
 # Limits
 #-------

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -12,9 +12,17 @@ g = FinFunction([1,1,2,2,3], 3)
 h = FinFunction([3,1,2], 3)
 
 # Evaluation.
+rot3(x) = (x % 3) + 1
 @test map(f, 1:3) == [1,3,4]
+@test map(FinFunction(rot3, 3, 3), 1:3) == [2,3,1]
 @test map(id(FinSet(3)), 1:3) == [1,2,3]
-@test map(FinFunction(x -> (x % 3) + 1, 3, 3), 1:3) == [2,3,1]
+
+# Pretty-print.
+@test sprint(show, FinSet(3)) == "FinSet(3)"
+@test sprint(show, f) == "FinFunction([1, 3, 4], 3, 5)"
+@test sprint(show, FinFunction(rot3, 3, 3)) ==
+  "FinFunction(rot3, FinSet(3), FinSet(3))"
+@test sprint(show, id(FinSet(3))) == "FinFunction(identity, FinSet(3))"
 
 # Domains and codomains.
 @test dom(f) == FinSet(3)

--- a/test/categorical_algebra/FreeDiagrams.jl
+++ b/test/categorical_algebra/FreeDiagrams.jl
@@ -42,6 +42,7 @@ f, g = Hom(:f, C, A), Hom(:g, C, B)
 span = Span(f,g)
 @test apex(span) == C
 @test legs(span) == [f,g]
+@test feet(span) == [A,B]
 @test left(span) == f
 @test right(span) == g
 
@@ -56,6 +57,7 @@ f, g, h = Hom(:f, C, A), Hom(:g, C, B), Hom(:h, C, A)
 span = Multispan([f,g,h])
 @test apex(span) == C
 @test legs(span) == [f,g,h]
+@test feet(span) == [A,B,A]
 
 diagram = FreeDiagram(span)
 @test ob(diagram) == [C,A,B,A]
@@ -68,6 +70,7 @@ f, g = Hom(:f, A, C), Hom(:g, B, C)
 cospan = Cospan(f,g)
 @test apex(cospan) == C
 @test legs(cospan) == [f,g]
+@test feet(cospan) == [A,B]
 @test left(cospan) == f
 @test right(cospan) == g
 
@@ -82,6 +85,7 @@ f, g, h = Hom(:f, A, C), Hom(:g, B, C), Hom(:h, A, C)
 cospan = Multicospan([f,g,h])
 @test apex(cospan) == C
 @test legs(cospan) == [f,g,h]
+@test feet(cospan) == [A,B,A]
 
 diagram = FreeDiagram(cospan)
 @test ob(diagram) == [A,B,A,C]

--- a/test/categorical_algebra/FreeDiagrams.jl
+++ b/test/categorical_algebra/FreeDiagrams.jl
@@ -66,7 +66,7 @@ diagram = FreeDiagram(span)
 # Cospans.
 f, g = Hom(:f, A, C), Hom(:g, B, C)
 cospan = Cospan(f,g)
-@test base(cospan) == C
+@test apex(cospan) == C
 @test legs(cospan) == [f,g]
 @test left(cospan) == f
 @test right(cospan) == g
@@ -80,7 +80,7 @@ f = Hom(:f, A ,B)
 # Multicospans.
 f, g, h = Hom(:f, A, C), Hom(:g, B, C), Hom(:h, A, C)
 cospan = Multicospan([f,g,h])
-@test base(cospan) == C
+@test apex(cospan) == C
 @test legs(cospan) == [f,g,h]
 
 diagram = FreeDiagram(cospan)

--- a/test/categorical_algebra/Limits.jl
+++ b/test/categorical_algebra/Limits.jl
@@ -32,7 +32,7 @@ f, g = Hom(:f, A, C), Hom(:g, B, C)
 colim = Colimit(ObjectPair(A,B), Cospan(f,g))
 @test colim isa BinaryCoproduct
 @test ob(colim) == C
-@test base(colim) == C
+@test apex(colim) == C
 @test legs(colim) == [f,g]
 
 colim = Colimit(DiscreteDiagram([A,B]), Cospan(f,g))

--- a/test/categorical_algebra/StructuredCospans.jl
+++ b/test/categorical_algebra/StructuredCospans.jl
@@ -15,7 +15,7 @@ const OpenGraphOb, OpenGraph = OpenCSetTypes(Graph, :V)
 # Directed fork as open graph with one input and two outputs.
 g0 = Graph(4)
 add_edges!(g0, [1,2,2], [2,3,4])
-g = OpenGraph(g0, Cospan(FinFunction([1], 4), FinFunction([3,4], 4)))
+g = OpenGraph(g0, FinFunction([1],4), FinFunction([3,4],4))
 @test apex(g) == g0
 @test dom.(legs(g)) == [Graph(1), Graph(2)]
 @test feet(g) == [FinSet(1), FinSet(2)]
@@ -23,7 +23,7 @@ g = OpenGraph(g0, Cospan(FinFunction([1], 4), FinFunction([3,4], 4)))
 # Opposite of previous graph.
 h0 = Graph(4)
 add_edges!(h0, [1,2,3], [3,3,4])
-h = OpenGraph(h0, Cospan(FinFunction([1,2], 4), FinFunction([4], 4)))
+h = OpenGraph(h0, FinFunction([1,2],4), FinFunction([4],4))
 
 # Composition.
 k = compose(g, h)
@@ -56,16 +56,58 @@ const OpenWeightedGraphOb, OpenWeightedGraph = OpenACSetTypes(WeightedGraph, :V)
 
 g0 = WeightedGraph{Float64}(2)
 add_edge!(g0, 1, 2, weight=1.5)
-g = OpenWeightedGraph{Float64}(g0, Cospan(FinFunction([1],2), FinFunction([2],2)))
+g = OpenWeightedGraph{Float64}(g0, FinFunction([1],2), FinFunction([2],2))
 @test dom.(legs(g)) == [WeightedGraph{Float64}(1), WeightedGraph{Float64}(1)]
 @test feet(g) == [FinSet(1), FinSet(1)]
 
 h0 = WeightedGraph{Float64}(3)
 add_edges!(h0, [1,1], [2,3], weight=[1.0,2.0])
-h = OpenWeightedGraph{Float64}(h0, Cospan(FinFunction([1],3), FinFunction([2,3],3)))
+h = OpenWeightedGraph{Float64}(h0, FinFunction([1],3), FinFunction([2,3],3))
 k = compose(g, h)
 k0 = apex(k)
-@test (src(k0), tgt(k0)) == ([1,2,2], [2,3,4])
+@test src(k0) == [1,2,2]
+@test tgt(k0) == [2,3,4]
 @test subpart(k0, :weight) == [1.5, 1.0, 2.0]
+
+# Attributed boundary
+#--------------------
+
+@present TheoryLabeledGraph <: TheoryGraph begin
+  Label::Data
+  vlabel::Attr(V,Label)
+  elabel::Attr(E,Label)
+end
+
+const LabeledGraph = ACSetType(TheoryLabeledGraph, index=[:src,:tgt])
+const OpenLabeledGraphOb, OpenLabeledGraph = OpenACSetTypes(LabeledGraph, :V)
+
+g0 = LabeledGraph{Symbol}()
+add_vertices!(g0, 2, vlabel=[:x,:y])
+add_edge!(g0, 1, 2, elabel=:f)
+g = OpenLabeledGraph{Symbol}(g0, FinFunction([1],2), FinFunction([2],2))
+
+h0 = LabeledGraph{Symbol}()
+add_vertices!(h0, 3, vlabel=[:y,:w,:z])
+add_edges!(h0, [1,1], [2,3], elabel=[:g,:h])
+h = OpenLabeledGraph{Symbol}(h0, FinFunction([1],3), FinFunction([2,3],3))
+lfoot, rfoot = feet(h)
+@test lfoot isa ACSet
+@test keys(lfoot.tables) == (:V,)
+@test nparts(lfoot, :V) == 1
+@test nparts(rfoot, :V) == 2
+@test subpart(lfoot, :vlabel) == [:y]
+@test subpart(rfoot, :vlabel) == [:w,:z]
+
+k = compose(g, h)
+k0 = apex(k)
+@test src(k0) == [1,2,2]
+@test tgt(k0) == [2,3,4]
+@test subpart(k0, :vlabel) == [:x, :y, :w, :z]
+@test subpart(k0, :elabel) == [:f, :g, :h]
+
+# Incompatible attributes.
+set_subpart!(h0, 1, :vlabel, :y′)
+h = OpenLabeledGraph{Symbol}(h0, FinFunction([1],3), FinFunction([2,3],3))
+@test_throws ErrorException compose(g, h)
 
 end

--- a/test/categorical_algebra/StructuredCospans.jl
+++ b/test/categorical_algebra/StructuredCospans.jl
@@ -1,0 +1,42 @@
+module TestStructuredCospans
+using Test
+
+using Catlab.Theories, Catlab.CategoricalAlgebra,
+  Catlab.CategoricalAlgebra.FinSets, Catlab.CategoricalAlgebra.Graphs
+
+# Structured cospans of C-sets
+##############################
+
+const OpenGraphOb, OpenGraph = OpenCSetTypes(Graph, :V)
+@test OpenGraphOb <: StructuredCospanOb
+@test OpenGraph <: StructuredCospan
+
+# Directed fork as open graph with one input and two outputs.
+g0 = Graph(4)
+add_edges!(g0, [1,2,2], [2,3,4])
+g = OpenGraph(g0, Cospan(FinFunction([1], 4), FinFunction([3,4], 4)))
+@test apex(g) == g0
+@test dom.(legs(g)) == [Graph(1), Graph(2)]
+@test feet(g) == [FinSet(1), FinSet(2)]
+
+# Opposite of previous graph.
+h0 = Graph(4)
+add_edges!(h0, [1,2,3], [3,3,4])
+h = OpenGraph(h0, Cospan(FinFunction([1,2], 4), FinFunction([4], 4)))
+
+# Composition.
+k = compose(g, h)
+@test dom(k) == dom(g)
+@test codom(k) == codom(h)
+k0 = apex(k)
+@test (nv(k0), ne(k0)) == (6, 6)
+@test (src(k0), tgt(k0)) == ([1,2,2,3,4,5], [2,3,4,5,5,6])
+
+# Identities.
+a = OpenGraphOb(FinSet(3))
+@test dom(id(a)) == a
+@test codom(id(a)) == a
+@test compose(g, id(codom(g))) == g
+@test compose(id(dom(g)), g) == g
+
+end

--- a/test/categorical_algebra/StructuredCospans.jl
+++ b/test/categorical_algebra/StructuredCospans.jl
@@ -1,8 +1,9 @@
 module TestStructuredCospans
 using Test
 
-using Catlab.Theories, Catlab.CategoricalAlgebra,
+using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra,
   Catlab.CategoricalAlgebra.FinSets, Catlab.CategoricalAlgebra.Graphs
+using Catlab.CategoricalAlgebra.Graphs: TheoryGraph
 
 # Structured cospans of C-sets
 ##############################
@@ -38,5 +39,33 @@ a = OpenGraphOb(FinSet(3))
 @test codom(id(a)) == a
 @test compose(g, id(codom(g))) == g
 @test compose(id(dom(g)), g) == g
+
+# Structured cospan of attributed C-sets
+########################################
+
+# Non-attributed boundary
+#------------------------
+
+@present TheoryWeightedGraph <: TheoryGraph begin
+  Weight::Data
+  weight::Attr(E,Weight)
+end
+
+const WeightedGraph = ACSetType(TheoryWeightedGraph, index=[:src,:tgt])
+const OpenWeightedGraphOb, OpenWeightedGraph = OpenACSetTypes(WeightedGraph, :V)
+
+g0 = WeightedGraph{Float64}(2)
+add_edge!(g0, 1, 2, weight=1.5)
+g = OpenWeightedGraph{Float64}(g0, Cospan(FinFunction([1],2), FinFunction([2],2)))
+@test dom.(legs(g)) == [WeightedGraph{Float64}(1), WeightedGraph{Float64}(1)]
+@test feet(g) == [FinSet(1), FinSet(1)]
+
+h0 = WeightedGraph{Float64}(3)
+add_edges!(h0, [1,1], [2,3], weight=[1.0,2.0])
+h = OpenWeightedGraph{Float64}(h0, Cospan(FinFunction([1],3), FinFunction([2,3],3)))
+k = compose(g, h)
+k0 = apex(k)
+@test (src(k0), tgt(k0)) == ([1,2,2], [2,3,4])
+@test subpart(k0, :weight) == [1.5, 1.0, 2.0]
 
 end


### PR DESCRIPTION
This PR implements a generic interface for [structured cospans](https://ncatlab.org/nlab/show/structured+cospan) plus a concrete implementation for C-sets. The category structure is implemented for structured cospans, while the hypergraph category and symmetric monoidal double category structures are deferred to subsequent PRs.

Structured cospans of C-sets have three cases to handle:

1. No data attributes: Feet are FinSets and apex is C-set
2. Attributes present, but not on the boundary: Feet are FinSets and apex is attributed C-set
3. Attributes present, including at the boundary: Feet are attributed C'-sets and apex is attributed C-set, where C' has one object (for convenience, the cospan can still be specified in FinSet)

Each of the three cases is illustrated in the tests.