### PR TITLE
Structured cospans as a hypergraph category

### DIFF
--- a/src/categorical_algebra/CSetMorphisms.jl
+++ b/src/categorical_algebra/CSetMorphisms.jl
@@ -1,7 +1,7 @@
 """ Morphisms of C-sets and attributed C-sets.
 """
 module CSetMorphisms
-export ACSetTransformation, CSetTransformation, components, is_natural
+export ACSetTransformation, CSetTransformation, components, force, is_natural
 
 using Compat: isnothing
 

--- a/src/categorical_algebra/CSetMorphisms.jl
+++ b/src/categorical_algebra/CSetMorphisms.jl
@@ -121,6 +121,15 @@ struct CSetLimit{Ob <: AbstractCSet, Diagram, Cone <: Multispan{Ob},
   limits::Limits
 end
 
+""" Colimit of attributed C-sets that stores the pointwise colimits in FinSet.
+"""
+struct ACSetColimit{Ob <: AbstractACSet, Diagram, Cocone <: Multicospan{Ob},
+                    Colimits <: NamedTuple} <: AbstractColimit{Ob,Diagram}
+  diagram::Diagram
+  cocone::Cocone
+  colimits::Colimits
+end
+
 # Compute limits and colimits of C-sets by reducing to those in FinSet using the
 # "pointwise" formula for (co)limits in functor categories.
 
@@ -185,7 +194,12 @@ function colimit(diagram::AbstractFreeDiagram{ACS}) where
     set_subpart!(Y, attr, map(something, data))
   end
 
-  Colimit(diagram, Multicospan(Y, ιs))
+  ACSetColimit(diagram, Multicospan(Y, ιs), colimits)
+end
+
+function universal(colim::ACSetColimit, cocone::Multicospan)
+  components = map(universal, colim.colimits, unpack_diagram(cocone))
+  ACSetTransformation(components, ob(colim), apex(cocone))
 end
 
 """ Diagram in C-Set → named tuple of diagrams in FinSet

--- a/src/categorical_algebra/FreeDiagrams.jl
+++ b/src/categorical_algebra/FreeDiagrams.jl
@@ -16,8 +16,8 @@ export AbstractFreeDiagram, FreeDiagram, FixedShapeFreeDiagram, DiscreteDiagram,
 using AutoHashEquals
 using StaticArrays: StaticVector, SVector, @SVector
 
+using ...Present, ...Theories, ..CSets, ..Graphs
 import ...Theories: ob, hom, dom, codom
-using ...Present, ..CSets, ..Graphs
 using ..Graphs: TheoryGraph
 
 # Diagrams of fixed shape
@@ -71,7 +71,7 @@ const SMultispan{N,Ob} = Multispan{Ob,<:StaticVector{N}}
 
 SMultispan{N}(apex, legs::Vararg{Any,N}) where N =
   Multispan(apex, SVector{N}(legs...))
-SMultispan{0}(apex) = Multispan(apex, SVector{0,Any}())
+SMultispan{0}(apex) = Multispan(apex, SVector{0,typeof(id(apex))}())
 SMultispan{N}(legs::Vararg{Any,N}) where N = Multispan(SVector{N}(legs...))
 
 """ Span of morphims in a category.
@@ -111,7 +111,7 @@ const SMulticospan{N,Ob} = Multicospan{Ob,<:StaticVector{N}}
 
 SMulticospan{N}(apex, legs::Vararg{Any,N}) where N =
   Multicospan(apex, SVector{N}(legs...))
-SMulticospan{0}(apex) = Multicospan(apex, SVector{0,Any}())
+SMulticospan{0}(apex) = Multicospan(apex, SVector{0,typeof(id(apex))}())
 SMulticospan{N}(legs::Vararg{Any,N}) where N = Multicospan(SVector{N}(legs...))
 
 """ Cospan of morphisms in a category.

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -153,6 +153,7 @@ initial(T::Type) = colimit(EmptyDiagram{T}())
 To implement for a type `T`, define the method
 `universal(::Terminal{T}, ::SMultispan{0,T})`.
 """
+delete(A::T) where T = delete(terminal(T), A)
 delete(lim::Terminal, A) = universal(lim, SMultispan{0}(A))
 
 """ Unique morphism out of an initial object.
@@ -160,6 +161,7 @@ delete(lim::Terminal, A) = universal(lim, SMultispan{0}(A))
 To implement for a type `T`, define the method
 `universal(::Initial{T}, ::SMulticospan{0,T})`.
 """
+create(A::T) where T = create(initial(T), A)
 create(colim::Initial, A) = universal(colim, SMulticospan{0}(A))
 
 """ Product of objects.
@@ -218,6 +220,8 @@ To implement for products of type `T`, define the method
 `universal(::BinaryProduct{T}, ::Span{T})` and/or
 `universal(::Product{T}, ::Multispan{T})` and similarly for pullbacks.
 """
+pair(f, g) = pair(product(codom(f), codom(g)), f, g)
+pair(fs::AbstractVector) = pair(product(map(codom, fs)), fs)
 pair(lim::Union{BinaryProduct,BinaryPullback}, f, g) =
   universal(lim, Span(f, g))
 pair(lim::Union{Product,Pullback}, fs::AbstractVector) =
@@ -229,6 +233,8 @@ To implement for coproducts of type `T`, define the method
 `universal(::BinaryCoproduct{T}, ::Cospan{T})` and/or
 `universal(::Coproduct{T}, ::Multicospan{T})` and similarly for pushouts.
 """
+copair(f, g) = copair(coproduct(dom(f), dom(g)), f, g)
+copair(fs::AbstractVector) = copair(coproduct(map(dom, fs)), fs)
 copair(colim::Union{BinaryCoproduct,BinaryPushout}, f, g) =
   universal(colim, Cospan(f, g))
 copair(colim::Union{Coproduct,Pushout}, fs::AbstractVector) =

--- a/src/categorical_algebra/StructuredCospans.jl
+++ b/src/categorical_algebra/StructuredCospans.jl
@@ -133,9 +133,10 @@ begin
     StructuredCospanOb{L}(ob(initial(dom(L))))
 
   function braid(a::StructuredCospanOb{L}, b::StructuredCospanOb{L}) where L
-    ab, ba = coproduct(a.ob, b.ob), coproduct(b.ob, a.ob)
-    cospan = Cospan(id(ob(ab)), copair(ba, coproj2(ab), coproj1(ab)))
-    StructuredCospan{L}(L(ob(ab)), cospan)
+    x, y = L(a.ob), L(b.ob)
+    xy, yx = coproduct(x, y), coproduct(y, x)
+    cospan = Cospan(ob(xy), id(ob(xy)), copair(yx, coproj2(xy), coproj1(xy)))
+    StructuredCospan{L}(cospan, a⊗b, b⊗a)
   end
 
   mcopy(a::StructuredCospanOb{L}) where L = let x = L(a.ob), i = id(x)
@@ -241,14 +242,20 @@ struct DiscreteACSet{A <: AbstractACSet, X} <: AbstractDiscreteACSet{X} end
 
 dom(::Type{<:DiscreteACSet{A}}) where A = A
 
-function StructuredCospan{L}(
-    x::AbstractACSet, cospan::Cospan{<:FinSet{Int}}) where
-    {A, L<:DiscreteACSet{A}}
+function StructuredCospan{L}(x::AbstractACSet, cospan::Cospan{<:FinSet{Int}}) where
+    {A, L <: DiscreteACSet{A}}
   a = A()
   copy_common_parts!(a, x)
   f, g = cospan
   ϕ, ψ = induced_transformation(a, f), induced_transformation(a, g)
   StructuredCospan{L}(x, Cospan(a, ϕ, ψ))
+end
+
+function StructuredCospanOb{L}(set::FinSet{Int}; kw...) where
+    {CD, A <: AbstractACSet{CD}, L <: DiscreteACSet{A}}
+  a = A()
+  add_parts!(a, only(CD.ob), length(set); kw...)
+  StructuredCospanOb{L}(a)
 end
 
 """ C-set transformation b → a induced by function `f` into parts of `a`.

--- a/test/categorical_algebra/CSetMorphisms.jl
+++ b/test/categorical_algebra/CSetMorphisms.jl
@@ -43,7 +43,9 @@ add_edges!(h, [1,2], [2,1])
 # Terminal object in Graph: the self-loop.
 term = Graph(1)
 add_edge!(term, 1, 1)
-@test ob(terminal(Graph)) == term
+lim = terminal(Graph)
+@test ob(lim) == term
+@test delete(lim, g) == CSetTransformation((V=fill(1,4), E=fill(1,3)), g, term)
 
 # Products in Graph: unitality.
 lim = product(g, term)
@@ -70,11 +72,17 @@ g0 = ob(product(g, Graph(1)))
 # Product in Graph: copying edges by multiplying by the double self-loop.
 cycle2 = Graph(1)
 add_edges!(cycle2, [1,1], [1,1])
-g2 = ob(product(g, cycle2))
+lim = product(g, cycle2)
+g2 = ob(lim)
 @test nv(g2) == nv(g)
 @test ne(g2) == 2*ne(g)
 @test src(g2) == repeat(src(g), 2)
 @test tgt(g2) == repeat(tgt(g), 2)
+α = CSetTransformation((V=[2,3], E=[2]), I, g)
+β = CSetTransformation((V=[1,1], E=[2]), I, cycle2)
+γ = pair(lim, α, β)
+@test force(γ⋅proj1(lim)) == α
+@test force(γ⋅proj2(lim)) == β
 
 # Equalizer in Graph from (Reyes et al 2004, p. 50).
 g, h = Graph(2), Graph(2)

--- a/test/categorical_algebra/CSetMorphisms.jl
+++ b/test/categorical_algebra/CSetMorphisms.jl
@@ -116,7 +116,9 @@ lim = pullback(ϕ, ψ)
 #---------
 
 # Initial object in graph: the empty graph.
-@test ob(initial(Graph)) == Graph()
+colim = initial(Graph)
+@test ob(colim) == Graph()
+@test create(colim, g) == CSetTransformation((V=Int[], E=Int[]), Graph(), g)
 
 # Coproducts in Graph: unitality.
 g = Graph(4)
@@ -130,10 +132,16 @@ colim = coproduct(g, Graph())
 # Coproduct in Graph.
 h = Graph(2)
 add_edges!(h, [1,2], [2,1])
-coprod = ob(coproduct(g, h))
+colim = coproduct(g, h)
+coprod = ob(colim)
 @test nv(coprod) == 6
 @test src(coprod) == [1,2,3,5,6]
 @test tgt(coprod) == [2,3,4,6,5]
+α = CSetTransformation((V=[1,2,1,2], E=[1,2,1]), g, h)
+β = id(h)
+γ = copair(colim, α, β)
+@test force(coproj1(colim)⋅γ) == α
+@test force(coproj2(colim)⋅γ) == force(β)
 
 # Coequalizer in Graph: collapsing a segment to a loop.
 g = Graph(2)

--- a/test/categorical_algebra/StructuredCospans.jl
+++ b/test/categorical_algebra/StructuredCospans.jl
@@ -19,6 +19,8 @@ g = OpenGraph(g0, FinFunction([1],4), FinFunction([3,4],4))
 @test apex(g) == g0
 @test dom.(legs(g)) == [Graph(1), Graph(2)]
 @test feet(g) == [FinSet(1), FinSet(2)]
+@test dom(g) == OpenGraphOb(FinSet(1))
+@test codom(g) == OpenGraphOb(FinSet(2))
 
 # Opposite of previous graph.
 h0 = Graph(4)
@@ -84,12 +86,15 @@ const OpenWeightedGraphOb, OpenWeightedGraph = OpenACSetTypes(WeightedGraph, :V)
 g0 = WeightedGraph{Float64}(2)
 add_edge!(g0, 1, 2, weight=1.5)
 g = OpenWeightedGraph{Float64}(g0, FinFunction([1],2), FinFunction([2],2))
-@test dom.(legs(g)) == [WeightedGraph{Float64}(1), WeightedGraph{Float64}(1)]
-@test feet(g) == [FinSet(1), FinSet(1)]
 
 h0 = WeightedGraph{Float64}(3)
 add_edges!(h0, [1,1], [2,3], weight=[1.0,2.0])
 h = OpenWeightedGraph{Float64}(h0, FinFunction([1],3), FinFunction([2,3],3))
+@test dom.(legs(h)) == [WeightedGraph{Float64}(1), WeightedGraph{Float64}(2)]
+@test feet(h) == [FinSet(1), FinSet(2)]
+@test dom(h) == OpenWeightedGraphOb{Float64}(FinSet(1))
+@test codom(h) == OpenWeightedGraphOb{Float64}(FinSet(2))
+
 k = compose(g, h)
 k0 = apex(k)
 @test src(k0) == [1,2,2]
@@ -118,12 +123,13 @@ add_vertices!(h0, 3, vlabel=[:y,:w,:z])
 add_edges!(h0, [1,1], [2,3], elabel=[:g,:h])
 h = OpenLabeledGraph{Symbol}(h0, FinFunction([1],3), FinFunction([2,3],3))
 lfoot, rfoot = feet(h)
-@test lfoot isa ACSet
-@test keys(lfoot.tables) == (:V,)
-@test nparts(lfoot, :V) == 1
 @test nparts(rfoot, :V) == 2
-@test subpart(lfoot, :vlabel) == [:y]
 @test subpart(rfoot, :vlabel) == [:w,:z]
+@test dom(h) == OpenLabeledGraphOb{Symbol}(FinSet(1), vlabel=:y)
+@test codom(h) == OpenLabeledGraphOb{Symbol}(FinSet(2), vlabel=[:w,:z])
+
+# Category
+#---------
 
 k = compose(g, h)
 k0 = apex(k)
@@ -136,5 +142,18 @@ k0 = apex(k)
 set_subpart!(h0, 1, :vlabel, :y′)
 h = OpenLabeledGraph{Symbol}(h0, FinFunction([1],3), FinFunction([2,3],3))
 @test_throws ErrorException compose(g, h)
+
+# Symmetric monoidal category
+#----------------------------
+
+k = otimes(g, h)
+@test dom(k) == dom(g)⊗dom(h)
+@test codom(k) == codom(g)⊗codom(h)
+@test (nv(apex(k)), ne(apex(k))) == (5, 3)
+
+a = OpenLabeledGraphOb{Symbol}(FinSet(2), vlabel=[:u,:v])
+b = OpenLabeledGraphOb{Symbol}(FinSet(3), vlabel=[:x,:y,:z])
+@test dom(braid(a, b)) == a⊗b
+@test codom(braid(a, b)) == b⊗a
 
 end

--- a/test/categorical_algebra/StructuredCospans.jl
+++ b/test/categorical_algebra/StructuredCospans.jl
@@ -25,6 +25,9 @@ h0 = Graph(4)
 add_edges!(h0, [1,2,3], [3,3,4])
 h = OpenGraph(h0, FinFunction([1,2],4), FinFunction([4],4))
 
+# Symmetric monoidal category
+#----------------------------
+
 # Composition.
 k = compose(g, h)
 @test dom(k) == dom(g)
@@ -39,6 +42,19 @@ a = OpenGraphOb(FinSet(3))
 @test codom(id(a)) == a
 @test compose(g, id(codom(g))) == g
 @test compose(id(dom(g)), g) == g
+
+# Monoidal products.
+a, b = OpenGraphOb(FinSet(3)), OpenGraphOb(FinSet(2))
+@test otimes(a, b) == OpenGraphOb(FinSet(5))
+@test munit(OpenGraphOb) == OpenGraphOb(FinSet(0))
+@test dom(braid(a, b)) == a⊗b
+@test codom(braid(b, a)) == b⊗a
+@test force(braid(a,b)⋅braid(b,a)) == force(id(a⊗b))
+
+k = otimes(g, h)
+@test dom(k) == dom(g)⊗dom(h)
+@test codom(k) == codom(g)⊗codom(h)
+@test (nv(apex(k)), ne(apex(k))) == (8, 6)
 
 # Structured cospan of attributed C-sets
 ########################################

--- a/test/categorical_algebra/StructuredCospans.jl
+++ b/test/categorical_algebra/StructuredCospans.jl
@@ -25,8 +25,8 @@ h0 = Graph(4)
 add_edges!(h0, [1,2,3], [3,3,4])
 h = OpenGraph(h0, FinFunction([1,2],4), FinFunction([4],4))
 
-# Symmetric monoidal category
-#----------------------------
+# Category
+#---------
 
 # Composition.
 k = compose(g, h)
@@ -43,7 +43,9 @@ a = OpenGraphOb(FinSet(3))
 @test compose(g, id(codom(g))) == g
 @test compose(id(dom(g)), g) == g
 
-# Monoidal products.
+# Symmetric monoidal category
+#----------------------------
+
 a, b = OpenGraphOb(FinSet(3)), OpenGraphOb(FinSet(2))
 @test otimes(a, b) == OpenGraphOb(FinSet(5))
 @test munit(OpenGraphOb) == OpenGraphOb(FinSet(0))
@@ -55,6 +57,15 @@ k = otimes(g, h)
 @test dom(k) == dom(g)⊗dom(h)
 @test codom(k) == codom(g)⊗codom(h)
 @test (nv(apex(k)), ne(apex(k))) == (8, 6)
+
+# Hypergraph category
+#--------------------
+
+@test compose(create(a), mcopy(a)) == dunit(a)
+@test compose(mmerge(a), delete(a)) == dcounit(a)
+
+@test dom(dagger(g)) == codom(g)
+@test codom(dagger(g)) == dom(g)
 
 # Structured cospan of attributed C-sets
 ########################################


### PR DESCRIPTION
Finishes the initial implementation of structured cospans by implementing the hypergraph category structure, including monoidal products of cospans by taking coproducts in the underlying categories.

Also resolves #280.