### PR TITLE
Copy parts between C-sets with different schemas

### DIFF
--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -1,11 +1,11 @@
-""" Data structure for C-sets (copreshaves) and attributed C-sets.
+""" Data structure for C-sets (copresheaves) and attributed C-sets.
 """
 module CSetDataStructures
 export AbstractACSet, ACSet, AbstractCSet, CSet, Schema, FreeSchema,
   AbstractACSetType, ACSetType, AbstractCSetType, CSetType,
   tables, nparts, has_part, subpart, has_subpart, incident,
-  add_part!, add_parts!, copy_parts!, set_subpart!, set_subparts!,
-  disjoint_union
+  add_part!, add_parts!, set_subpart!, set_subparts!, copy_parts!,
+  copy_parts_only!, disjoint_union
 
 using Compat: isnothing, only
 
@@ -458,13 +458,8 @@ copy_parts!(acs::ACSet, from::ACSet, type::Symbol, parts) =
   copy_parts!(acs, from, (; type => parts))
 copy_parts!(acs::ACSet, from::ACSet, types::Tuple) =
   copy_parts!(acs::ACSet, from::ACSet, NamedTuple{types}((:) for t in types))
-
-function copy_parts!(acs::ACSet, from::ACSet, parts::NamedTuple{types}) where types
-  parts = map(types, parts) do type, part
-    part == (:) ? (1:nparts(from, type)) : part
-  end
-  _copy_parts!(acs, from, NamedTuple{types}(parts))
-end
+copy_parts!(acs::ACSet, from::ACSet, parts::NamedTuple) =
+  _copy_parts!(acs, from, replace_colons(from, parts))
 
 @generated function _copy_parts!(acs::T, from::T, parts::NamedTuple{types}) where
     {types,CD,AD,Ts,Idx,T <: ACSet{CD,AD,Ts,Idx}}
@@ -478,9 +473,7 @@ end
   end
   in_obs = Tuple(unique!(in_obs))
   quote
-    newparts = NamedTuple{$types}(tuple($(map(types) do type
-      :(_copy_parts_data!(acs, from, Val($(QuoteNode(type))), parts.$type))
-    end...)))
+    newparts = _copy_parts_only!(acs, from, parts)
     partmaps = NamedTuple{$in_obs}(tuple($(map(in_obs) do type
       :(Dict{Int,Int}(zip(parts.$type, newparts.$type)))
     end...)))
@@ -497,26 +490,53 @@ end
   end
 end
 
-""" Copy parts of a single type from one C-set to another.
+""" Copy parts from a C-set to a C′-set, ignoring non-data subparts.
 
-Any data attributes attached to the parts are also copied.
+The parts must belong to both schemas. Data attributes common to both schemas
+are also copied, but no other subparts are copied.
 """
-@generated function _copy_parts_data!(acs::T, from::T, ::Val{ob}, parts) where
-    {CD,AD,T<:ACSet{CD,AD},ob}
-  attrs = collect(filter(attr -> dom(AD, attr) == ob, AD.attr))
-  quote
-    newparts = add_parts!(acs, $(QuoteNode(ob)), length(parts))
-    $(Expr(:block, map(attrs) do attr
-       :(set_subpart!(acs, newparts, $(QuoteNode(attr)),
-                      from.tables.$ob.$attr[parts]))
-      end...))
-    newparts
-  end
+@generated function copy_parts_only!(to::ACSet{CD}, from::ACSet{CD′}) where
+    {CD, CD′}
+  obs = intersect(CD.ob, CD′.ob)
+  :(copy_parts_only!(to, from, $(Tuple(obs))))
 end
 
-function disjoint_union(acs1::T,acs2::T) where {CD,AD,T<:ACSet{CD,AD}}
+copy_parts_only!(to::ACSet, from::ACSet, obs::Tuple) =
+  copy_parts_only!(to, from, NamedTuple{obs}((:) for ob in obs))
+copy_parts_only!(to::ACSet, from::ACSet, parts::NamedTuple) =
+  _copy_parts_only!(to, from, replace_colons(from, parts))
+
+@generated function _copy_parts_only!(
+    to::ACSet{CD,AD}, from::ACSet{CD′,AD′}, parts::NamedTuple{obs}) where
+    {CD, AD, CD′, AD′, obs}
+  @assert obs ⊆ intersect(CD.ob, CD′.ob)
+  attrs = intersect(AD.attr, AD′.attr)
+  attrs = filter(attrs) do attr
+    ob, ob′ = dom(AD, attr), dom(AD′, attr)
+    ob == ob′ && ob ∈ obs
+  end
+  Expr(:block,
+    :(newparts = (; $(map(obs) do ob
+        Expr(:kw, ob, :(add_parts!(to, $(QuoteNode(ob)), length(parts.$ob))))
+        end...))),
+    map(attrs) do attr
+      ob = dom(AD, attr)
+      :(set_subpart!(to, newparts.$ob, $(QuoteNode(attr)),
+                     subpart(from, parts.$ob, $(QuoteNode(attr)))))
+    end...,
+    :newparts
+  )
+end
+
+function replace_colons(acs::ACSet, parts::NamedTuple{types}) where {types}
+  NamedTuple{types}(map(types, parts) do type, part
+    part == (:) ? (1:nparts(acs, type)) : part
+  end)
+end
+
+function disjoint_union(acs1::T, acs2::T) where {CD,AD,T<:ACSet{CD,AD}}
   acs = copy(acs1)
-  copy_parts!(acs,acs2,CD.ob)
+  copy_parts!(acs, acs2, CD.ob)
   acs
 end
 

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -78,8 +78,8 @@ empty_dds = DDS()
 
 # Strictly speaking, this data structure is not a single dendrogram but a forest
 # of dendrograms (whose roots are the elements fixed under the `parent` map) and
-# in order to be valid dendrograms, the `height` map must satisfy
-# `compose(parent, height) ≥ height` pointwise.
+# in order to be valid dendrograms, there must be no nontrivial cycles and the
+# `height` map must satisfy `compose(parent, height) ≥ height` pointwise.
 
 @present TheoryDendrogram(FreeSchema) begin
   X::Ob
@@ -131,9 +131,31 @@ s = sprint(show, MIME"text/plain"(), d)
 @test startswith(s, "ACSet")
 
 # Allow type inheritance for data attributes.
-d = Dendrogram{Number}()
-add_parts!(d, :X, 2, parent=[0,0], height=[10.0, 4])
-@test subpart(d, :height) == [10.0, 4]
+d_abs = Dendrogram{Number}()
+add_parts!(d_abs, :X, 2, height=[10.0, 4])
+@test subpart(d_abs, :height) == [10.0, 4]
+
+# Dendrograms with leaves
+#------------------------
+
+@present TheoryLDendrogram <: TheoryDendrogram begin
+  L::Ob
+  leafparent::Hom(L,X)
+end
+
+const LDendrogram = ACSetType(TheoryLDendrogram, index=[:parent, :leafparent])
+
+# Copying between C-sets and C′-sets with C != C′.
+ld = LDendrogram{Int}()
+copy_parts!(ld, d)
+@test nparts(ld, :L) == 0
+@test subpart(ld, :parent) == subpart(d, :parent)
+
+add_parts!(ld, :L, 3, leafparent=[2,3,4])
+@test subpart(ld, :leafparent) == [2,3,4]
+d′ = Dendrogram{Int}()
+copy_parts!(d′, ld)
+@test d′ == d
 
 # Labeled sets
 ##############

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -111,7 +111,7 @@ set_subpart!(d, [4,5], :parent, 5)
 @test subpart(d, :, :height) == [0,0,0,10,20]
 
 d2 = Dendrogram{Int}()
-copy_parts!(d2, d, :X, [4,5])
+copy_parts!(d2, d, X=[4,5])
 @test nparts(d2, :X) == 2
 @test subpart(d2, [1,2], :parent) == [2,2]
 @test subpart(d2, [1,2], :height) == [10,20]


### PR DESCRIPTION
The function `copy_parts!` is generalized to allow copying from a C-set to a C'-set where C !=C'. By default, it copies all common parts and subparts. A helper function `copy_parts_only!, which copies only data attributes (not other subparts), is also exposed in the public API.

Resolves #285.