### PR TITLE
Substitute UWDs with arbitrary data attributes on junctions

### DIFF
--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -2,7 +2,7 @@
 """
 module CSetDataStructures
 export AbstractACSet, ACSet, AbstractCSet, CSet, Schema, FreeSchema,
-  AbstractACSetType, ACSetType, AbstractCSetType, CSetType,
+  AbstractACSetType, ACSetType, ACSetTableType, AbstractCSetType, CSetType,
   tables, nparts, has_part, subpart, has_subpart, incident,
   add_part!, add_parts!, set_subpart!, set_subparts!, copy_parts!,
   copy_parts_only!, disjoint_union
@@ -95,7 +95,7 @@ function AbstractACSetType(pres::Presentation{Schema})
   end
 end
 
-""" Generate a data type for attributed C-sets from a schema.
+""" Generate a type for attributed C-sets from a schema.
 
 In addition to the schema, you can specify which morphisms and data attributes
 are (uniquely) indexed using the keyword argument `index` (or `unique_index`).
@@ -110,17 +110,35 @@ function ACSetType(pres::Presentation{Schema}; index=[], unique_index=[])
   foldr(UnionAll, type_vars, init=T)
 end
 
-function ACSetDataTable(::Type{X}, ob₀::Symbol) where
-    {CD<:CatDesc, AD<:AttrDesc{CD}, X<:AbstractACSet{CD,AD}}
+""" Given an attributed C-set type, generate a new type based on one object.
+
+The resulting attributed C-set type can be seen as the type of a data table or
+data frame, hence the name.
+"""
+function ACSetTableType(X::Type, ob₀::Symbol; union_all::Bool=false)
+  (union_all ? ACSetTableUnionAll : ACSetTableDataType)(X, Val(ob₀))
+end
+
+@generated function ACSetTableDataType(::Type{X}, ::Val{ob₀}) where
+    {CD<:CatDesc, AD<:AttrDesc{CD}, Ts, X<:AbstractACSet{CD,AD,Ts}, ob₀}
+  CD₀, AD₀ = ACSetTableDesc(CD, AD, ob₀)
+  :(ACSet{$CD₀,$AD₀,$Ts,(),()})
+end
+
+@generated function ACSetTableUnionAll(::Type{X}, ::Val{ob₀}) where
+    {CD<:CatDesc, AD<:AttrDesc{CD}, X<:AbstractACSet{CD,AD}, ob₀}
+  CD₀, AD₀ = ACSetTableDesc(CD, AD, ob₀)
+  :(ACSet{$CD₀,$AD₀,Tuple{$(AD.data...)},(),()} where {$(AD.data...)})
+end
+
+function ACSetTableDesc(::Type{CD}, ::Type{AD}, ob₀::Symbol) where
+    {CD<:CatDesc, AD<:AttrDesc{CD}}
   @assert ob₀ ∈ CD.ob
   attrs₀ = [ i for (i,j) in enumerate(AD.adom) if CD.ob[j] == ob₀ ]
   adom = Tuple(ones(Int, length(attrs₀)))
   CD₀ = CatDesc{(ob₀,),(),(),()}
   AD₀ = AttrDesc{CD₀,AD.data,AD.attr[attrs₀],adom,AD.acodom[attrs₀]}
-
-  type_vars = map(TypeVar, AD.data)
-  T = ACSet{CD₀,AD₀,Tuple{type_vars...},(),()}
-  foldr(UnionAll, type_vars, init=T)
+  (CD₀, AD₀)
 end
 
 """ Abstract type for C-sets.
@@ -144,7 +162,7 @@ function AbstractCSetType(pres::Presentation{Schema})
   AbstractCSet{CatDescType(pres)}
 end
 
-""" Generate a data type for C-sets from a presentation of a category C.
+""" Generate a type for C-sets from a presentation of a category C.
 
 In addition to the category, you can specify which morphisms are (uniquely)
 indexed using the keyword argument `index` (or `unique_index`). By default, no

--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -110,6 +110,19 @@ function ACSetType(pres::Presentation{Schema}; index=[], unique_index=[])
   foldr(UnionAll, type_vars, init=T)
 end
 
+function ACSetDataTable(::Type{X}, ob₀::Symbol) where
+    {CD<:CatDesc, AD<:AttrDesc{CD}, X<:AbstractACSet{CD,AD}}
+  @assert ob₀ ∈ CD.ob
+  attrs₀ = [ i for (i,j) in enumerate(AD.adom) if CD.ob[j] == ob₀ ]
+  adom = Tuple(ones(Int, length(attrs₀)))
+  CD₀ = CatDesc{(ob₀,),(),(),()}
+  AD₀ = AttrDesc{CD₀,AD.data,AD.attr[attrs₀],adom,AD.acodom[attrs₀]}
+
+  type_vars = map(TypeVar, AD.data)
+  T = ACSet{CD₀,AD₀,Tuple{type_vars...},(),()}
+  foldr(UnionAll, type_vars, init=T)
+end
+
 """ Abstract type for C-sets.
 
 The special case of `AbstractAttributedCSet` with no data attributes.

--- a/src/categorical_algebra/StructuredCospans.jl
+++ b/src/categorical_algebra/StructuredCospans.jl
@@ -14,6 +14,7 @@ using StaticArrays: StaticVector, SVector
 
 using ...GAT, ..FreeDiagrams, ..Limits, ..FinSets, ..CSets
 import ..FreeDiagrams: apex, legs, feet, left, right
+using ...CSetDataStructures: ACSetDataTable
 import ..CSets: force
 using ...Theories: Category, CatDesc, AttrDesc
 import ...Theories: dom, codom, compose, ⋅, id, otimes, ⊗, munit, braid, σ,
@@ -199,14 +200,11 @@ function OpenACSetTypes(::Type{X}, ob₀::Symbol) where
     {CD<:CatDesc, AD<:AttrDesc{CD}, X<:AbstractACSet{CD,AD}}
   @assert ob₀ ∈ CD.ob
   type_vars = map(TypeVar, AD.data)
-  attrs₀ = [ i for (i,j) in enumerate(AD.adom) if CD.ob[j] == ob₀ ]
-  L = if isempty(attrs₀)
-    FinSetDiscreteACSet{ob₀, X{type_vars...}}
+  L = if any(CD.ob[j] == ob₀ for (i,j) in enumerate(AD.adom))
+    A = ACSetDataTable(X, ob₀)
+    DiscreteACSet{A{type_vars...}, X{type_vars...}}
   else
-    adom = Tuple(ones(Int, length(attrs₀)))
-    CD₀ = CatDesc{(ob₀,),(),(),()}
-    AD₀ = AttrDesc{CD₀,AD.data,AD.attr[attrs₀],adom,AD.acodom[attrs₀]}
-    DiscreteACSet{ACSet{CD₀,AD₀,Tuple{type_vars...},(),()}, X{type_vars...}}
+    FinSetDiscreteACSet{ob₀, X{type_vars...}}
   end
   (foldr(UnionAll, type_vars, init=StructuredCospanOb{L}),
    foldr(UnionAll, type_vars, init=StructuredCospan{L}))

--- a/src/categorical_algebra/StructuredCospans.jl
+++ b/src/categorical_algebra/StructuredCospans.jl
@@ -14,7 +14,6 @@ using StaticArrays: StaticVector, SVector
 
 using ...GAT, ..FreeDiagrams, ..Limits, ..FinSets, ..CSets
 import ..FreeDiagrams: apex, legs, feet, left, right
-using ...CSetDataStructures: ACSetDataTable
 import ..CSets: force
 using ...Theories: Category, CatDesc, AttrDesc
 import ...Theories: dom, codom, compose, ⋅, id, otimes, ⊗, munit, braid, σ,
@@ -201,7 +200,7 @@ function OpenACSetTypes(::Type{X}, ob₀::Symbol) where
   @assert ob₀ ∈ CD.ob
   type_vars = map(TypeVar, AD.data)
   L = if any(CD.ob[j] == ob₀ for (i,j) in enumerate(AD.adom))
-    A = ACSetDataTable(X, ob₀)
+    A = ACSetTableType(X, ob₀, union_all=true)
     DiscreteACSet{A{type_vars...}, X{type_vars...}}
   else
     FinSetDiscreteACSet{ob₀, X{type_vars...}}


### PR DESCRIPTION
Instead of computing the pushout of junctions in FinSet, we compute the pushout in a category Attr-C-Set where C = {Junction}, which can also be interpreted as a slice category in Set over the product of all the attribute types.

This PR should resolve #288 in the simplest way possible given the machinery we currently possess.