### PR TITLE
Abbreviated presentation syntax for generators of same type

### DIFF
--- a/src/core/Present.jl
+++ b/src/core/Present.jl
@@ -39,6 +39,11 @@ function Presentation{Name}(syntax::Module) where Name
 end
 Presentation(syntax::Module) = Presentation{Symbol}(syntax)
 
+function Base.:(==)(pres1::Presentation, pres2::Presentation)
+  pres1.syntax == pres2.syntax && pres1.generators == pres2.generators &&
+    pres1.equations == pres2.equations
+end
+
 function Base.copy(pres::Presentation{T,Name}) where {T,Name}
   Presentation{T,Name}(pres.syntax, map(copy, pres.generators),
                        copy(pres.generator_name_index), copy(pres.equations))
@@ -143,6 +148,8 @@ function translate_statement(expr::Expr)::Expr
   @match expr begin
     Expr(:(::), name::Symbol, type_expr) =>
       translate_generator(name, type_expr)
+    Expr(:(::), Expr(:tuple, names...), type_expr) =>
+      Expr(:block, (translate_generator(name, type_expr) for name in names)...)
     Expr(:(::), type_expr) =>
       translate_generator(nothing, type_expr)
     Expr(:(:=), name::Symbol, def_expr) =>

--- a/test/core/Present.jl
+++ b/test/core/Present.jl
@@ -85,7 +85,7 @@ secretary = Hom(:secretary, Department, Employee)
   compose(secretary, works_in) => id(Department),
 ]
 
-# Check generators with compound type arguments.
+# Generators with compound type arguments.
 @present C(FreeSymmetricMonoidalCategory) begin
   A::Ob
   B::Ob
@@ -108,6 +108,19 @@ X = Ob(FreeCategory, :X)
 Φ = Hom(:Φ, X, X)
 @test generators(TheoryDDS, :Ob) == [X]
 @test generators(TheoryDDS, :Hom) == [Φ]
+
+# Abbreviated syntax.
+@present TheoryGraph(FreeCategory) begin
+  V::Ob
+  E::Ob
+  src::Hom(E,V)
+  tgt::Hom(E,V)
+end
+@present TheoryGraph′(FreeCategory) begin
+  (V, E)::Ob
+  (src, tgt)::Hom(E,V)
+end
+@test TheoryGraph == TheoryGraph′
 
 # Serialization
 ###############


### PR DESCRIPTION
Now, instead of writing

```julia
@present TheoryGraph(FreeCategory) begin
  V::Ob
  E::Ob
  src::Hom(E,V)
  tgt::Hom(E,V)
end
```

you can also write

```julia
@present TheoryGraph(FreeCategory) begin
  (V, E)::Ob
  (src, tgt)::Hom(E,V)
end
```

This should improve the readability of large presentations with lots of objects.