### PR TITLE
Remove parts from C-sets

### DIFF
--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -658,8 +658,7 @@ end
 
 """ Look up key in C-set data index.
 """
-get_data_index(d::AbstractDict{K,Int}, k::K) where K =
-  get(d, k, nothing)
+get_data_index(d::AbstractDict{K,Int}, k::K) where K = get(d, k, 0)
 get_data_index(d::AbstractDict{K,<:AbstractVector{Int}}, k::K) where K =
   get(d, k, 1:0)
 

--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -326,7 +326,7 @@ Both single and vectorized access are supported.
 subpart(acs::ACSet, part, name::Symbol) = subpart(acs,name)[part]
 subpart(acs::ACSet, name::Symbol) = _subpart(acs,Val(name))
 
-@generated function _subpart(acs::ACSet{CD,AD,Ts},::Val{name}) where
+@generated function _subpart(acs::ACSet{CD,AD,Ts}, ::Val{name}) where
     {CD,AD,Ts,name}
   if name ∈ CD.hom
     :(acs.tables.$(dom(CD,name)).$name)
@@ -343,10 +343,18 @@ incident(acs::ACSet, part, name::Symbol) = _incident(acs, part, Val(name))
 
 @generated function _incident(acs::ACSet{CD,AD,Ts,Idxed}, part, ::Val{name}) where
     {CD,AD,Ts,Idxed,name}
-  if name ∈ Idxed && name ∈ CD.hom
-    :(acs.indices.$name[part])
-  elseif name ∈ Idxed && name ∈ AD.attr
-    :(get_data_index.(Ref(acs.indices.$name), part))
+  if name ∈ CD.hom
+    if name ∈ Idxed
+      :(acs.indices.$name[part])
+    else
+      :(findall(acs.tables.$(dom(CD,name)).$name .== part))
+    end
+  elseif name ∈ AD.attr
+    if name ∈ Idxed
+      :(get_data_index.(Ref(acs.indices.$name), part))
+    else
+      :(findall(acs.tables.$(dom(AD,name)).$name .== part))
+    end
   else
     throw(KeyError(name))
   end

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -60,6 +60,14 @@ rem_part!(dds, :X, 2)
 rem_part!(dds, :X, 1)
 @test nparts(dds, :X) == 0
 
+dds = DDS()
+add_parts!(dds, :X, 4, Φ=[2,3,3,4])
+@test_throws ErrorException rem_parts!(dds, :X, [4,1])
+rem_parts!(dds, :X, [1,4])
+@test subpart(dds, :Φ) == [1,1]
+@test incident(dds, 1, :Φ) == [1,2]
+@test incident(dds, 2, :Φ) == []
+
 # Pretty printing.
 dds = DDS()
 add_parts!(dds, :X, 3, Φ=[2,3,3])

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -73,6 +73,14 @@ empty_dds = DDS()
 @test subpart(dds, :Φ) == [1,1,1,0]
 @test incident(dds, 4, :Φ) == []
 
+# Incidence without indexing.
+UnindexedDDS = CSetType(TheoryDDS)
+dds = UnindexedDDS()
+add_parts!(dds, :X, 4, Φ=[3,3,4,4])
+@test isempty(keys(dds.indices))
+@test incident(dds, 3, :Φ) == [1,2]
+@test incident(dds, 4, :Φ) == [3,4]
+
 # Dendrograms
 #############
 

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -222,6 +222,13 @@ set_subpart!(lset, 1, :label, :baz)
 set_subpart!(lset, 3, :label, :biz)
 @test incident(lset, :foo, :label) == []
 
+# Deletion with indexed data attribute.
+lset = IndexedLabeledSet{Symbol}()
+add_parts!(lset, :X, 3, label=[:foo, :foo, :bar])
+rem_part!(lset, :X, 1)
+@test subpart(lset, :label) == [:bar, :foo]
+@test incident(lset, [:foo, :bar], :label) == [[2], [1]]
+
 # Special case of pretty-print: unitialized data attribute.
 lset = IndexedLabeledSet{Symbol}()
 add_part!(lset, :X)

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -248,12 +248,12 @@ add_parts!(lset, :X, 2, label=[:foo, :bar])
 @test subpart(lset, :, :label) == [:foo, :bar]
 @test incident(lset, :foo, :label) == 1
 @test incident(lset, [:foo,:bar], :label) == [1,2]
-@test incident(lset, :nonkey, :label) == nothing
+@test incident(lset, :nonkey, :label) == 0
 
 set_subpart!(lset, 1, :label, :baz)
 @test subpart(lset, 1, :label) == :baz
 @test incident(lset, :baz, :label) == 1
-@test incident(lset, :foo, :label) == nothing
+@test incident(lset, :foo, :label) == 0
 
 @test_throws ErrorException set_subpart!(lset, 1, :label, :bar)
 

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -46,7 +46,23 @@ set_subpart!(dds, 1, :Φ, 1)
 @test_throws KeyError subpart(dds, 1, :nonsubpart)
 @test_throws KeyError set_subpart!(dds, 1, :nonsubpart, 1)
 
+# Deletion.
+dds = DDS()
+add_parts!(dds, :X, 3, Φ=[2,3,3])
+rem_part!(dds, :X, 2)
+@test nparts(dds, :X) == 2
+@test subpart(dds, :Φ) == [0,2]
+@test incident(dds, 1, :Φ) == []
+@test incident(dds, 2, :Φ) == [2]
+rem_part!(dds, :X, 2)
+@test nparts(dds, :X) == 1
+@test subpart(dds, :Φ) == [0]
+rem_part!(dds, :X, 1)
+@test nparts(dds, :X) == 0
+
 # Pretty printing.
+dds = DDS()
+add_parts!(dds, :X, 3, Φ=[2,3,3])
 s = sprint(show, dds)
 @test startswith(s, "CSet")
 @test occursin("X = 1:3", s)
@@ -68,7 +84,9 @@ empty_dds = DDS()
 @test !isempty(sprint(show, MIME"text/plain"(), empty_dds))
 @test !isempty(sprint(show, MIME"text/html"(), empty_dds))
 
-# Error handling.
+# Incidence after error handling.
+dds = DDS()
+add_parts!(dds, :X, 3, Φ=[1,1,1])
 @test_throws AssertionError add_part!(dds, :X, Φ=5)
 @test subpart(dds, :Φ) == [1,1,1,0]
 @test incident(dds, 4, :Φ) == []


### PR DESCRIPTION
Resolves #196, the last major missing feature in the low-level interface for C-sets. Removal is implemented using the "pop and swap" strategy; see the docstring for more info.