### PR TITLE
Remove vertices and edges from graphs

### DIFF
--- a/src/graphs/BasicGraphs.jl
+++ b/src/graphs/BasicGraphs.jl
@@ -185,6 +185,19 @@ function add_edges!(g::AbstractReflexiveGraph, srcs::AbstractVector{Int},
   add_parts!(g, :E, n; src=srcs, tgt=tgts, kw...)
 end
 
+function rem_vertices!(g::AbstractReflexiveGraph, vs; keep_edges::Bool=false)
+  es = if keep_edges
+    sort(refl(g, vs))
+  else
+    unique!(sort!(reduce(vcat, [incident(g, vs, :src); incident(g, vs, :tgt)])))
+  end
+  rem_parts!(g, :E, es)
+  rem_parts!(g, :V, vs)
+end
+
+rem_edge!(g::AbstractReflexiveGraph, e::Int) = rem_part!(g, :E, e)
+rem_edges!(g::AbstractReflexiveGraph, es) = rem_parts!(g, :E, es)
+
 # Symmetric reflexive graphs
 ############################
 

--- a/src/graphs/BasicGraphs.jl
+++ b/src/graphs/BasicGraphs.jl
@@ -7,6 +7,7 @@ half-edge graphs.
 module BasicGraphs
 export AbstractGraph, Graph, nv, ne, src, tgt, edges, vertices,
   has_edge, has_vertex, add_edge!, add_edges!, add_vertex!, add_vertices!,
+  rem_edge!, rem_edges!, rem_vertex!, rem_vertices!,
   neighbors, inneighbors, outneighbors, all_neighbors,
   AbstractSymmetricGraph, SymmetricGraph, inv,
   AbstractReflexiveGraph, ReflexiveGraph, refl,
@@ -17,8 +18,9 @@ export AbstractGraph, Graph, nv, ne, src, tgt, edges, vertices,
 using Compat: only
 
 import Base: inv
-import LightGraphs: SimpleGraph, SimpleDiGraph, nv, ne, src, dst,
-  edges, vertices, has_edge, has_vertex, add_edge!, add_vertex!, add_vertices!,
+import LightGraphs: SimpleGraph, SimpleDiGraph,
+  nv, ne, src, dst, edges, vertices, has_edge, has_vertex,
+  add_edge!, add_vertex!, add_vertices!, rem_edge!, rem_vertex!, rem_vertices!,
   neighbors, inneighbors, outneighbors, all_neighbors
 
 using ...Present, ...CSetDataStructures
@@ -69,6 +71,22 @@ function add_edges!(g::AbstractGraph, srcs::AbstractVector{Int},
   @assert (n = length(srcs)) == length(tgts)
   add_parts!(g, :E, n; src=srcs, tgt=tgts, kw...)
 end
+
+rem_vertex!(g::AbstractGraph, v::Int) = rem_vertices!(g, v:v)
+
+function rem_vertices!(g::AbstractGraph, vs; keep_edges::Bool=false)
+  if !keep_edges
+    es = [incident(g, vs, :src); incident(g, vs, :tgt)]
+    rem_edges!(g, unique!(sort!(reduce(vcat, es, init=Int[]))))
+  end
+  rem_parts!(g, :V, vs)
+end
+
+rem_edge!(g::AbstractGraph, e::Int) = rem_part!(g, :E, e)
+rem_edge!(g::AbstractGraph, src::Int, tgt::Int) =
+  rem_edge!(g, first(edges(g, src, tgt)))
+
+rem_edges!(g::AbstractGraph, es) = rem_parts!(g, :E, es)
 
 neighbors(g::AbstractGraph, v::Int) = outneighbors(g, v)
 inneighbors(g::AbstractGraph, v::Int) = subpart(g, incident(g, v, :tgt), :src)

--- a/test/graphs/BasicGraphs.jl
+++ b/test/graphs/BasicGraphs.jl
@@ -36,7 +36,7 @@ g = Graph(4)
 add_edges!(g, [1,2,3], [2,3,4])
 @test LightGraphs.DiGraph(g) == LightGraphs.path_digraph(4)
 
-rem_edge!(g, 3)
+rem_edge!(g, 3, 4)
 @test ne(g) == 2
 @test src(g) == [1,2]
 @test tgt(g) == [2,3]
@@ -68,6 +68,14 @@ add_edges!(g, [1,2,3], [2,3,4])
 lg = LightGraphs.DiGraph(4)
 map((src, tgt) -> add_edge!(lg, src, tgt), [1,2,3,2,3,4], [2,3,4,1,2,3])
 @test LightGraphs.DiGraph(g) == lg
+
+rem_edge!(g, 3, 4)
+@test ne(g) == 4
+@test neighbors(g, 3) == [2]
+@test neighbors(g, 4) == []
+rem_vertex!(g, 2)
+@test nv(g) == 3
+@test ne(g) == 0
 
 # Reflexive graphs
 ##################

--- a/test/graphs/BasicGraphs.jl
+++ b/test/graphs/BasicGraphs.jl
@@ -36,6 +36,14 @@ g = Graph(4)
 add_edges!(g, [1,2,3], [2,3,4])
 @test LightGraphs.DiGraph(g) == LightGraphs.path_digraph(4)
 
+rem_edge!(g, 3)
+@test ne(g) == 2
+@test src(g) == [1,2]
+@test tgt(g) == [2,3]
+rem_vertex!(g, 2)
+@test nv(g) == 3
+@test ne(g) == 0
+
 # Symmetric graphs
 ##################
 

--- a/test/graphs/BasicGraphs.jl
+++ b/test/graphs/BasicGraphs.jl
@@ -144,4 +144,13 @@ lg = LightGraphs.Graph(4)
 map((src, tgt) -> add_edge!(lg, src, tgt), [1,2,3], [2,3,4])
 @test LightGraphs.Graph(g) == lg
 
+rem_edge!(g, 3, 4)
+@test Set(zip(vertex(g), vertex(g,inv(g)))) == Set([(1,2),(2,1),(2,3),(3,2)])
+add_edge!(g, 3, 4)
+rem_edge!(g, last(half_edges(g)))
+@test Set(zip(vertex(g), vertex(g,inv(g)))) == Set([(1,2),(2,1),(2,3),(3,2)])
+rem_vertex!(g, 2)
+@test nv(g) == 3
+@test isempty(half_edges(g))
+
 end

--- a/test/graphs/BasicGraphs.jl
+++ b/test/graphs/BasicGraphs.jl
@@ -127,6 +127,14 @@ add_edge!(g, 1, 3)
 @test tgt(g, 4:5) == [3,1]
 @test inv(g, 4:5) == [5,4]
 
+g = SymmetricReflexiveGraph(4)
+add_edges!(g, [1,2,3], [2,3,4])
+rem_edge!(g, 3, 4)
+@test ne(g) == 8
+rem_vertex!(g, 2)
+@test nv(g) == 3
+@test ne(g) == 3
+
 # Half-edge graphs
 ##################
 

--- a/test/graphs/BasicGraphs.jl
+++ b/test/graphs/BasicGraphs.jl
@@ -96,6 +96,19 @@ add_edge!(g, 1, 3)
 @test src(g, 4:6) == [1,2,1]
 @test tgt(g, 4:6) == [2,3,3]
 
+g = ReflexiveGraph(4)
+add_edges!(g, [1,2,3], [2,3,4])
+rem_edge!(g, 3, 4)
+@test ne(g) == 6
+@test src(g, 5:6) == [1,2]
+@test tgt(g, 5:6) == [2,3]
+rem_vertex!(g, 2)
+@test nv(g) == 3
+@test ne(g) == 3
+@test refl(g) == [1,2,3]
+@test src(g) == [1,2,3]
+@test tgt(g) == [1,2,3]
+
 # Symmetric reflexive graphs
 ############################
 


### PR DESCRIPTION
Sequel to #293. Implements `rem_vertex!`, `rem_vertices!`, `rem_edge!`, and `rem_edges!` for the four core graph types (graphs, symmetric graphs, reflexive graphs, and symmetric reflexive graphs), as well as for half-edge graphs.

This completes the implementation of the basic operations of the LightGraphs API.