### PR TITLE
Upgrade Documenter to fix slow build times

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -8,3 +8,6 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 SCS = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 TikzPictures = "37f6aa50-8035-52d0-81c2-5a1d08754b2d"
+
+[compat]
+Documenter = "^0.25.3"


### PR DESCRIPTION
Upgrade to latest version of Documenter to get https://github.com/JuliaDocs/Documenter.jl/pull/1440. Closes #247.