### PR TITLE
The UWD algebra of structured multicospans

### DIFF
--- a/src/categorical_algebra/StructuredCospans.jl
+++ b/src/categorical_algebra/StructuredCospans.jl
@@ -130,7 +130,7 @@ begin
   end
 
   munit(::Type{StructuredCospanOb{L}}) where L =
-    StructuredCospanOb{L}(ob(initial(dom(L))))
+    StructuredCospanOb{L}(ob(initial(first(dom(L)))))
 
   function braid(a::StructuredCospanOb{L}, b::StructuredCospanOb{L}) where L
     x, y = L(a.ob), L(b.ob)
@@ -213,6 +213,9 @@ end
 """
 abstract type AbstractDiscreteACSet{X <: AbstractACSet} end
 
+codom(::Type{<:AbstractDiscreteACSet{X}}) where
+  {CD, AD, X<:AbstractACSet{CD,AD}} = (X, ACSetTransformation{CD,AD})
+
 StructuredCospan{L}(x::AbstractACSet, f::FinFunction{Int},
                     g::FinFunction{Int}) where {L<:AbstractDiscreteACSet} =
   StructuredCospan{L}(x, Cospan(f, g))
@@ -233,7 +236,7 @@ that object. Instead of instantiating this type directly, you should use
 """
 struct FinSetDiscreteACSet{ob₀, X} <: AbstractDiscreteACSet{X} end
 
-dom(::Type{<:FinSetDiscreteACSet}) = FinSet{Int}
+dom(::Type{<:FinSetDiscreteACSet}) = (FinSet{Int}, FinFunction{Int})
 
 """ A functor L: C₀-Set → C-Set giving the discrete C-set for C₀.
 
@@ -243,7 +246,8 @@ forgetting the rest of C. Data attributes of the chosen object are preserved.
 """
 struct DiscreteACSet{A <: AbstractACSet, X} <: AbstractDiscreteACSet{X} end
 
-dom(::Type{<:DiscreteACSet{A}}) where A = A
+dom(::Type{<:DiscreteACSet{A}}) where {CD, AD, A<:AbstractACSet{CD,AD}} =
+  (A, ACSetTransformation{CD,AD})
 
 function StructuredMulticospan{L}(x::AbstractACSet,
                                   cospan::Multicospan{<:FinSet{Int}}) where

--- a/src/categorical_algebra/StructuredCospans.jl
+++ b/src/categorical_algebra/StructuredCospans.jl
@@ -292,20 +292,6 @@ function (::Type{L})(a::AbstractACSet) where {A,X,L<:DiscreteACSet{A,X}}
   x
 end
 
-""" Apply right adjoint R: C-Set → FinSet to object.
-"""
-function right(::Type{L}, x::X) where {ob₀,X,L<:FinSetDiscreteACSet{ob₀,X}}
-  FinSet(nparts(x, ob₀))
-end
-
-""" Apply right adjoint R: C-Set → C₀-Set to object.
-"""
-function right(::Type{L}, x::X) where {A,X,L<:DiscreteACSet{A,X}}
-  a = A()
-  copy_parts_only!(a, x)
-  a
-end
-
 """ Apply left adjoint L: FinSet → C-Set to morphism.
 """
 function (::Type{L})(f::FinFunction{Int}) where

--- a/src/wiring_diagrams/Algebras.jl
+++ b/src/wiring_diagrams/Algebras.jl
@@ -8,6 +8,22 @@ using Compat: isnothing
 using ...CategoricalAlgebra
 using ..UndirectedWiringDiagrams
 
+""" Compose morphisms according to UWD.
+
+The morphisms corresponding to the boxes, and optionally also the objects
+corresponding to the junctions, are given by dictionaries indexed by
+box/junction attributes. The default attributes are those compatible with the
+`@relation` macro.
+"""
+function oapply(composite::UndirectedWiringDiagram, hom_map::AbstractDict,
+                ob_map::Union{AbstractDict,Nothing}=nothing;
+                hom_attr::Symbol=:name, ob_attr::Symbol=:variable)
+  homs = [ hom_map[name] for name in subpart(composite, hom_attr) ]
+  obs = isnothing(ob_map) ? nothing :
+    [ ob_map[name] for name in subpart(composite, ob_attr) ]
+  oapply(composite, homs, obs)
+end
+
 # UWD algebra of structured multicospans
 ########################################
 

--- a/src/wiring_diagrams/Algebras.jl
+++ b/src/wiring_diagrams/Algebras.jl
@@ -1,6 +1,7 @@
 """ Algebras of the operads of wiring diagrams.
 """
 module WiringDiagramAlgebras
+export oapply
 
 using ...CategoricalAlgebra
 using ..UndirectedWiringDiagrams
@@ -8,11 +9,13 @@ using ..UndirectedWiringDiagrams
 # UWD algebra of structured multicospans
 ########################################
 
-""" Compose structured multicospans according to undirected wiring diagram.
+""" Compose structured multicospans according to UWD.
 
-In this way, structured multicospans are an algebra of the operad of UWDs.
+This function makes structured multicospans into an algebra of the operad of
+undirected wiring diagrams.
 """
-function (composite::UndirectedWiringDiagram)(cospans::AbstractVector{SCosp}) where
+function oapply(composite::UndirectedWiringDiagram,
+                cospans::AbstractVector{SCosp}) where
     {Ob, Hom, Cosp <: Multicospan{Ob,<:AbstractVector{Hom}},
      L, SCosp <: StructuredMulticospan{L,Cosp}}
   # Create free diagram whose generating graph is a bipartite graph of the UWD's
@@ -35,7 +38,7 @@ function (composite::UndirectedWiringDiagram)(cospans::AbstractVector{SCosp}) wh
   colim = colimit(diagram)
   outer_legs = legs(colim)[jmap[junction(composite, outer=true)]]
   cospan = Multicospan(ob(colim), outer_legs)
-  feet = [ right(L, dom(leg)) for leg in outer_legs ]
+  feet = map(leg -> right(L, dom(leg)), outer_legs)
   StructuredMulticospan{L}(cospan, feet)
 end
 

--- a/src/wiring_diagrams/Algebras.jl
+++ b/src/wiring_diagrams/Algebras.jl
@@ -17,13 +17,11 @@ This function makes structured multicospans into an algebra of the operad of
 undirected wiring diagrams.
 """
 function oapply(composite::UndirectedWiringDiagram,
-                cospans::AbstractVector{SCosp},
-                junction_feet::Union{AbstractVector,Nothing}=nothing) where
-    {Ob, Hom, Cosp <: Multicospan{Ob,<:AbstractVector{Hom}},
-     L, SCosp <: StructuredMulticospan{L,Cosp}}
+                cospans::AbstractVector{<:StructuredMulticospan{L}},
+                junction_feet::Union{AbstractVector,Nothing}=nothing) where L
   @assert nboxes(composite) == length(cospans)
   if isnothing(junction_feet)
-    junction_feet = Vector{dom(L)}(undef, njunctions(composite))
+    junction_feet = Vector{first(dom(L))}(undef, njunctions(composite))
   else
     @assert njunctions(composite) == length(junction_feet)
   end
@@ -32,7 +30,7 @@ function oapply(composite::UndirectedWiringDiagram,
   # boxes and junctions. Each directed edge goes from a junction vertex to a box
   # vertex, as defined by the UWD's junction map, and the edge is mapped to the
   # corresponding leg of a multicospan.
-  diagram = FreeDiagram{Ob,Hom}()
+  diagram = FreeDiagram{codom(L)...}()
   add_vertices!(diagram, nboxes(composite), ob=map(apex, cospans))
   jmap = add_vertices!(diagram, njunctions(composite))
   for (b, cospan) in zip(boxes(composite), cospans)

--- a/src/wiring_diagrams/Algebras.jl
+++ b/src/wiring_diagrams/Algebras.jl
@@ -1,0 +1,42 @@
+""" Algebras of the operads of wiring diagrams.
+"""
+module WiringDiagramAlgebras
+
+using ...CategoricalAlgebra
+using ..UndirectedWiringDiagrams
+
+# UWD algebra of structured multicospans
+########################################
+
+""" Compose structured multicospans according to undirected wiring diagram.
+
+In this way, structured multicospans are an algebra of the operad of UWDs.
+"""
+function (composite::UndirectedWiringDiagram)(cospans::AbstractVector{SCosp}) where
+    {Ob, Hom, Cosp <: Multicospan{Ob,<:AbstractVector{Hom}},
+     L, SCosp <: StructuredMulticospan{L,Cosp}}
+  # Create free diagram whose generating graph is a bipartite graph of the UWD's
+  # boxes and junctions. Each directed edge goes from a junction vertex to a box
+  # vertex, as defined by the UWD's junction map, and the edge is mapped to the
+  # corresponding leg of a multicospan.
+  @assert nboxes(composite) == length(cospans)
+  diagram = FreeDiagram{Ob,Hom}()
+  add_vertices!(diagram, nboxes(composite), ob=map(apex, cospans))
+  jmap = add_vertices!(diagram, njunctions(composite))
+  for (box, cospan) in zip(boxes(composite), cospans)
+    for (port, leg) in zip(ports(composite, box), legs(cospan))
+      j = jmap[junction(composite, port)]
+      add_edge!(diagram, j, box, hom=leg)
+      set_subparts!(diagram, j, ob=dom(leg))
+    end
+  end
+
+  # The composite multicospan is given by the colimit of this diagram.
+  colim = colimit(diagram)
+  outer_legs = legs(colim)[jmap[junction(composite, outer=true)]]
+  cospan = Multicospan(ob(colim), outer_legs)
+  feet = [ right(L, dom(leg)) for leg in outer_legs ]
+  StructuredMulticospan{L}(cospan, feet)
+end
+
+end

--- a/src/wiring_diagrams/Algebras.jl
+++ b/src/wiring_diagrams/Algebras.jl
@@ -3,6 +3,8 @@
 module WiringDiagramAlgebras
 export oapply
 
+using Compat: isnothing
+
 using ...CategoricalAlgebra
 using ..UndirectedWiringDiagrams
 
@@ -15,31 +17,44 @@ This function makes structured multicospans into an algebra of the operad of
 undirected wiring diagrams.
 """
 function oapply(composite::UndirectedWiringDiagram,
-                cospans::AbstractVector{SCosp}) where
+                cospans::AbstractVector{SCosp},
+                junction_feet::Union{AbstractVector,Nothing}=nothing) where
     {Ob, Hom, Cosp <: Multicospan{Ob,<:AbstractVector{Hom}},
      L, SCosp <: StructuredMulticospan{L,Cosp}}
+  @assert nboxes(composite) == length(cospans)
+  if isnothing(junction_feet)
+    junction_feet = Vector{dom(L)}(undef, njunctions(composite))
+  else
+    @assert njunctions(composite) == length(junction_feet)
+  end
+
   # Create free diagram whose generating graph is a bipartite graph of the UWD's
   # boxes and junctions. Each directed edge goes from a junction vertex to a box
   # vertex, as defined by the UWD's junction map, and the edge is mapped to the
   # corresponding leg of a multicospan.
-  @assert nboxes(composite) == length(cospans)
   diagram = FreeDiagram{Ob,Hom}()
   add_vertices!(diagram, nboxes(composite), ob=map(apex, cospans))
   jmap = add_vertices!(diagram, njunctions(composite))
-  for (box, cospan) in zip(boxes(composite), cospans)
-    for (port, leg) in zip(ports(composite, box), legs(cospan))
-      j = jmap[junction(composite, port)]
-      add_edge!(diagram, j, box, hom=leg)
-      set_subparts!(diagram, j, ob=dom(leg))
+  for (b, cospan) in zip(boxes(composite), cospans)
+    for (p, leg, foot) in zip(ports(composite, b), legs(cospan), feet(cospan))
+      j = junction(composite, p)
+      add_edge!(diagram, jmap[j], b, hom=leg)
+      if isassigned(junction_feet, j)
+        foot′ = junction_feet[j]
+        foot == foot′ || error(
+          "Domains of structured cospans are not equal: $foot != $foot′")
+      else
+        junction_feet[j] = foot
+      end
     end
   end
+  set_subparts!(diagram, jmap, ob=map(L, junction_feet))
 
   # The composite multicospan is given by the colimit of this diagram.
   colim = colimit(diagram)
-  outer_legs = legs(colim)[jmap[junction(composite, outer=true)]]
-  cospan = Multicospan(ob(colim), outer_legs)
-  feet = map(leg -> right(L, dom(leg)), outer_legs)
-  StructuredMulticospan{L}(cospan, feet)
+  outer_js = junction(composite, outer=true)
+  outer_legs, outer_feet = legs(colim)[jmap[outer_js]], junction_feet[outer_js]
+  StructuredMulticospan{L}(Multicospan(ob(colim), outer_legs), outer_feet)
 end
 
 end

--- a/src/wiring_diagrams/WiringDiagrams.jl
+++ b/src/wiring_diagrams/WiringDiagrams.jl
@@ -6,6 +6,7 @@ include("Directed.jl")
 include("Undirected.jl")
 include("MonoidalDirected.jl")
 include("MonoidalUndirected.jl")
+include("Algebras.jl")
 include("Algorithms.jl")
 include("Expressions.jl")
 include("ScheduleUndirected.jl")
@@ -14,6 +15,7 @@ include("ScheduleUndirected.jl")
 @reexport using .UndirectedWiringDiagrams
 @reexport using .MonoidalDirectedWiringDiagrams
 @reexport using .MonoidalUndirectedWiringDiagrams
+@reexport using .WiringDiagramAlgebras
 @reexport using .WiringDiagramAlgorithms
 @reexport using .WiringDiagramExpressions
 @reexport using .ScheduleUndirectedWiringDiagrams

--- a/test/categorical_algebra/StructuredCospans.jl
+++ b/test/categorical_algebra/StructuredCospans.jl
@@ -9,8 +9,6 @@ using Catlab.Graphs.BasicGraphs: TheoryGraph
 ##############################
 
 const OpenGraphOb, OpenGraph = OpenCSetTypes(Graph, :V)
-@test OpenGraphOb <: StructuredCospanOb
-@test OpenGraph <: StructuredCospan
 
 # Directed fork as open graph with one input and two outputs.
 g0 = Graph(4)

--- a/test/wiring_diagrams/Algebras.jl
+++ b/test/wiring_diagrams/Algebras.jl
@@ -19,7 +19,7 @@ h0 = Graph(4)
 add_edges!(h0, [1,2,3], [3,3,4])
 h = OpenGraph(h0, FinFunction([1,2],4), FinFunction([4],4))
 
-# Composition in sequence.
+# Sequential composition.
 seq = @relation (a,c) where (a,b,c) begin
   g(a,b)
   h(b,c)
@@ -35,7 +35,7 @@ k0 = apex(k)
 # Composite graph is isomorphic to that with standard labeling.
 @test [ collect(leg[:V]) for leg in legs(k) ] == [[3], [6]]
 
-# Composition in parallel.
+# Parallel composition.
 para = @relation (a,b,c,d) where (a,b,c,d) begin
   g(a,b)
   h(c,d)
@@ -45,5 +45,11 @@ k = oapply(para, [g, h])
 @test feet(k) == [feet(g); feet(h)]
 k0 = apex(k)
 @test (nv(k0), ne(k0)) == (8, 6)
+
+# Identity for sequential composition.
+seq_id = @relation (a,a) where (a,) begin end
+k = oapply(seq_id, typeof(g)[], [FinSet(3)])
+@test apex(k) == Graph(3)
+@test feet(k) == [FinSet(3), FinSet(3)]
 
 end

--- a/test/wiring_diagrams/Algebras.jl
+++ b/test/wiring_diagrams/Algebras.jl
@@ -1,0 +1,49 @@
+module TestWiringDiagramAlgebras
+using Test
+
+using Catlab.CategoricalAlgebra, Catlab.CategoricalAlgebra.FinSets
+using Catlab.Graphs, Catlab.WiringDiagrams, Catlab.Programs.RelationalPrograms
+
+# UWD algebra of structured multicospans
+########################################
+
+const OpenGraphOb, OpenGraph = OpenCSetTypes(Graph, :V)
+
+# Directed fork as open graph with one input and two outputs.
+g0 = Graph(4)
+add_edges!(g0, [1,2,2], [2,3,4])
+g = OpenGraph(g0, FinFunction([1],4), FinFunction([3,4],4))
+
+# Opposite of previous graph.
+h0 = Graph(4)
+add_edges!(h0, [1,2,3], [3,3,4])
+h = OpenGraph(h0, FinFunction([1,2],4), FinFunction([4],4))
+
+# Composition in sequence.
+seq = @relation (a,c) where (a,b,c) begin
+  g(a,b)
+  h(b,c)
+end
+k = seq([g, h])
+@test length(legs(k)) == 2
+@test feet(k) == [first(feet(g)), last(feet(h))]
+k0 = apex(k)
+@test (nv(k0), ne(k0)) == (6, 6)
+@test sort!(collect(zip(src(k0), tgt(k0)))) == sort!(
+  [(3,1), (1,4), (1,5), (4,2), (5,2), (2,6)])
+# [(1,2), (2,3), (2,4), (3,5), (4,5), (5,6)]
+# Composite graph is isomorphic to that with standard labeling.
+@test [ collect(leg[:V]) for leg in legs(k) ] == [[3], [6]]
+
+# Composition in parallel.
+para = @relation (a,b,c,d) where (a,b,c,d) begin
+  g(a,b)
+  h(c,d)
+end
+k = para([g, h])
+@test length(legs(k)) == 4
+@test feet(k) == [feet(g); feet(h)]
+k0 = apex(k)
+@test (nv(k0), ne(k0)) == (8, 6)
+
+end

--- a/test/wiring_diagrams/Algebras.jl
+++ b/test/wiring_diagrams/Algebras.jl
@@ -24,7 +24,7 @@ seq = @relation (a,c) where (a,b,c) begin
   g(a,b)
   h(b,c)
 end
-k = seq([g, h])
+k = oapply(seq, [g, h])
 @test length(legs(k)) == 2
 @test feet(k) == [first(feet(g)), last(feet(h))]
 k0 = apex(k)
@@ -40,7 +40,7 @@ para = @relation (a,b,c,d) where (a,b,c,d) begin
   g(a,b)
   h(c,d)
 end
-k = para([g, h])
+k = oapply(para, [g, h])
 @test length(legs(k)) == 4
 @test feet(k) == [feet(g); feet(h)]
 k0 = apex(k)

--- a/test/wiring_diagrams/Algebras.jl
+++ b/test/wiring_diagrams/Algebras.jl
@@ -24,7 +24,7 @@ seq = @relation (a,c) where (a,b,c) begin
   g(a,b)
   h(b,c)
 end
-k = oapply(seq, [g, h])
+k = oapply(seq, Dict(:g => g, :h => h))
 @test length(legs(k)) == 2
 @test feet(k) == [first(feet(g)), last(feet(h))]
 k0 = apex(k)
@@ -40,7 +40,7 @@ para = @relation (a,b,c,d) where (a,b,c,d) begin
   g(a,b)
   h(c,d)
 end
-k = oapply(para, [g, h])
+k = oapply(para, Dict(:g => g, :h => h))
 @test length(legs(k)) == 4
 @test feet(k) == [feet(g); feet(h)]
 k0 = apex(k)
@@ -48,7 +48,7 @@ k0 = apex(k)
 
 # Identity for sequential composition.
 seq_id = @relation (a,a) where (a,) begin end
-k = oapply(seq_id, OpenGraph[], [FinSet(3)])
+k = oapply(seq_id, Dict{Symbol,OpenGraph}(), Dict(:a => FinSet(3)))
 @test apex(k) == Graph(3)
 @test feet(k) == [FinSet(3), FinSet(3)]
 

--- a/test/wiring_diagrams/Algebras.jl
+++ b/test/wiring_diagrams/Algebras.jl
@@ -48,7 +48,7 @@ k0 = apex(k)
 
 # Identity for sequential composition.
 seq_id = @relation (a,a) where (a,) begin end
-k = oapply(seq_id, typeof(g)[], [FinSet(3)])
+k = oapply(seq_id, OpenGraph[], [FinSet(3)])
 @test apex(k) == Graph(3)
 @test feet(k) == [FinSet(3), FinSet(3)]
 

--- a/test/wiring_diagrams/WiringDiagrams.jl
+++ b/test/wiring_diagrams/WiringDiagrams.jl
@@ -10,6 +10,10 @@ end
   include("MonoidalUndirected.jl")
 end
 
+@testset "Algebras" begin
+  include("Algebras.jl")
+end
+
 @testset "Algorithms" begin
   include("Algorithms.jl")
 end


### PR DESCRIPTION
Sequel to #315 that realizes structured multicospans as an algebra of the operad of undirected wiring diagrams. This is the fully unbiased alternative to structured cospans as a hypergraph category.

A bit more testing is needed, but with the right machinery in place this is surprisingly easily to implement: just set up the appropriate diagram and compute its colimit!

@mehalter, this should replace the whole pipeline of `@program` -> `to_hom_expr` -> `functor`.