### PR TITLE
Bundle legs of structured multicospans

### DIFF
--- a/src/categorical_algebra/FreeDiagrams.jl
+++ b/src/categorical_algebra/FreeDiagrams.jl
@@ -9,7 +9,7 @@ module FreeDiagrams
 export AbstractFreeDiagram, FreeDiagram, FixedShapeFreeDiagram, DiscreteDiagram,
   EmptyDiagram, ObjectPair, Span, Cospan, Multispan, Multicospan,
   SMultispan, SMulticospan, ParallelPair, ParallelMorphisms,
-  ob, hom, dom, codom, apex, legs, feet, left, right,
+  ob, hom, dom, codom, apex, legs, feet, left, right, bundle_legs,
   nv, ne, src, tgt, vertices, edges, has_vertex, has_edge,
   add_vertex!, add_vertices!, add_edge!, add_edges!,
   SquareDiagram, top, bottom
@@ -27,6 +27,9 @@ using ...Graphs.BasicGraphs: TheoryGraph
 """ Abstract type for free diagram of fixed shape.
 """
 abstract type FixedShapeFreeDiagram{Ob} end
+
+# Discrete diagrams
+#------------------
 
 """ Discrete diagram: a diagram whose only morphisms are identities.
 """
@@ -49,6 +52,9 @@ Base.length(d::DiscreteDiagram) = length(d.objects)
 Base.getindex(d::DiscreteDiagram, i) = d.objects[i]
 Base.firstindex(d::DiscreteDiagram) = firstindex(d.objects)
 Base.lastindex(d::DiscreteDiagram) = lastindex(d.objects)
+
+# Spans and cospans
+#------------------
 
 """ Multispan of morphisms in a category.
 
@@ -131,6 +137,24 @@ Base.iterate(cospan::Multicospan, args...) = iterate(cospan.legs, args...)
 Base.eltype(cospan::Multicospan) = eltype(cospan.legs)
 Base.length(cospan::Multicospan) = length(cospan.legs)
 
+""" Bundle together legs of a multi(co)span.
+
+The bundling use the universal property of (co)products, which assumes that
+these (co)limits exist and are implemented.
+"""
+bundle_legs(span::Multispan, indices) =
+  Multispan(apex(span), map(i -> bundle_leg(span, i), indices))
+bundle_legs(cospan::Multicospan, indices) =
+  Multicospan(apex(cospan), map(i -> bundle_leg(cospan, i), indices))
+
+bundle_leg(x::Union{Multispan,Multicospan}, i::Int) = legs(x)[i]
+bundle_leg(x::Union{Multispan,Multicospan}, i::Tuple) = bundle_leg(x, SVector(i))
+bundle_leg(span::Multispan, i::AbstractVector{Int}) = pair(legs(span)[i])
+bundle_leg(cospan::Multicospan, i::AbstractVector{Int}) = copair(legs(cospan)[i])
+
+# Parallel morphisms
+#-------------------
+
 """ Parallel morphims in a category.
 
 [Parallel morphisms](https://ncatlab.org/nlab/show/parallel+morphisms) are just
@@ -179,7 +203,10 @@ Base.lastindex(para::ParallelMorphisms) = lastindex(para.homs)
 allequal(xs::AbstractVector) = all(isequal(x, xs[1]) for x in xs[2:end])
 
 # Commutative squares
-#####################
+#--------------------
+
+# FIXME: Commutative squares are not free diagrams (they commute!) and so do not
+# belong in this module.
 
 """    SquareDiagram(top, bottom, left, right)
 

--- a/src/categorical_algebra/FreeDiagrams.jl
+++ b/src/categorical_algebra/FreeDiagrams.jl
@@ -139,8 +139,13 @@ Base.length(cospan::Multicospan) = length(cospan.legs)
 
 """ Bundle together legs of a multi(co)span.
 
-The bundling use the universal property of (co)products, which assumes that
-these (co)limits exist and are implemented.
+For example, calling `bundle_legs(span, SVector((1,2),(3,4)))` on a multispan
+with four legs gives a span whose left leg bundles legs 1 and 2 and whose right
+leg bundles legs 3 and 4. Note that in addition to bundling, this function can
+also permute legs and discard them.
+
+The bundling is performed using the universal property of (co)products, which
+assumes that these (co)limits exist.
 """
 bundle_legs(span::Multispan, indices) =
   Multispan(apex(span), map(i -> bundle_leg(span, i), indices))

--- a/src/categorical_algebra/StructuredCospans.jl
+++ b/src/categorical_algebra/StructuredCospans.jl
@@ -5,7 +5,7 @@ implementation for attributed C-sets.
 """
 module StructuredCospans
 export StructuredMulticospan, StructuredCospan, StructuredCospanOb,
-  OpenCSetTypes, OpenACSetTypes, bundle_legs
+  OpenCSetTypes, OpenACSetTypes
 
 using Compat: only
 
@@ -13,7 +13,7 @@ using AutoHashEquals
 using StaticArrays: StaticVector, SVector
 
 using ...GAT, ..FreeDiagrams, ..Limits, ..FinSets, ..CSets
-import ..FreeDiagrams: apex, legs, feet, left, right
+import ..FreeDiagrams: apex, legs, feet, left, right, bundle_legs
 import ..CSets: force
 using ...Theories: Category, CatDesc, AttrDesc
 import ...Theories: dom, codom, compose, ⋅, id, otimes, ⊗, munit, braid, σ,
@@ -85,17 +85,9 @@ StructuredCospan{L}(apex, cospan::Cospan) where L =
 left(cospan::StructuredCospan) = first(legs(cospan))
 right(cospan::StructuredCospan) = last(legs(cospan))
 
-""" Bundle together legs of (structured) multicospan.
-"""
 bundle_legs(cospan::StructuredMulticospan{L}, indices) where L =
   StructuredMulticospan{L}(bundle_legs(cospan.cospan, indices),
                            map(i -> bundle_feet(cospan, i), indices))
-bundle_legs(cospan::Multicospan, indices) =
-  Multicospan(apex(cospan), map(i -> bundle_leg(cospan, i), indices))
-
-bundle_leg(cospan, i::Int) = legs(cospan)[i]
-bundle_leg(cospan, i::Tuple) = bundle_leg(cospan, SVector(i))
-bundle_leg(cospan, i::AbstractVector{Int}) = copair(legs(cospan)[i])
 
 bundle_feet(cospan, i::Int) = feet(cospan)[i]
 bundle_feet(cospan, i::Tuple) = bundle_feet(cospan, SVector(i))

--- a/src/categorical_algebra/StructuredCospans.jl
+++ b/src/categorical_algebra/StructuredCospans.jl
@@ -5,7 +5,7 @@ implementation for attributed C-sets.
 """
 module StructuredCospans
 export StructuredMulticospan, StructuredCospan, StructuredCospanOb,
-  OpenCSetTypes, OpenACSetTypes
+  OpenCSetTypes, OpenACSetTypes, bundle_legs
 
 using Compat: only
 
@@ -84,6 +84,22 @@ StructuredCospan{L}(apex, cospan::Cospan) where L =
 
 left(cospan::StructuredCospan) = first(legs(cospan))
 right(cospan::StructuredCospan) = last(legs(cospan))
+
+""" Bundle together legs of (structured) multicospan.
+"""
+bundle_legs(cospan::StructuredMulticospan{L}, indices) where L =
+  StructuredMulticospan{L}(bundle_legs(cospan.cospan, indices),
+                           map(i -> bundle_feet(cospan, i), indices))
+bundle_legs(cospan::Multicospan, indices) =
+  Multicospan(apex(cospan), map(i -> bundle_leg(cospan, i), indices))
+
+bundle_leg(cospan, i::Int) = legs(cospan)[i]
+bundle_leg(cospan, i::Tuple) = bundle_leg(cospan, SVector(i))
+bundle_leg(cospan, i::AbstractVector{Int}) = copair(legs(cospan)[i])
+
+bundle_feet(cospan, i::Int) = feet(cospan)[i]
+bundle_feet(cospan, i::Tuple) = bundle_feet(cospan, SVector(i))
+bundle_feet(cospan, i::AbstractVector{Int}) = ob(coproduct(feet(cospan)[i]))
 
 # Hypergraph category of structured cospans
 ###########################################

--- a/test/categorical_algebra/FreeDiagrams.jl
+++ b/test/categorical_algebra/FreeDiagrams.jl
@@ -2,6 +2,7 @@ module TestFreeDiagrams
 using Test
 
 using Catlab.Theories, Catlab.CategoricalAlgebra
+using Catlab.CategoricalAlgebra.FinSets: FinSet, FinFunction
 
 A, B, C, D = Ob(FreeCategory, :A, :B, :C, :D)
 
@@ -65,6 +66,11 @@ diagram = FreeDiagram(span)
 @test src(diagram) == [1,1,1]
 @test tgt(diagram) == [2,3,4]
 
+span = Multispan([ id(FinSet(2)) for i in 1:3 ])
+span = bundle_legs(span, [1, (2,3)])
+@test apex(span) == FinSet(2)
+@test codom.(legs(span)) == [FinSet(2), FinSet(4)]
+
 # Cospans.
 f, g = Hom(:f, A, C), Hom(:g, B, C)
 cospan = Cospan(f,g)
@@ -92,6 +98,11 @@ diagram = FreeDiagram(cospan)
 @test hom(diagram) == [f,g,h]
 @test src(diagram) == [1,2,3]
 @test tgt(diagram) == [4,4,4]
+
+cospan = Multicospan([FinFunction([i],3) for i in 1:3])
+cospan = bundle_legs(cospan, [(1,3), 2])
+@test apex(cospan) == FinSet(3)
+@test legs(cospan) == [FinFunction([1,3], 3), FinFunction([2], 3)]
 
 # Parallel pairs.
 f, g = Hom(:f, A, B), Hom(:g, A, B)

--- a/test/categorical_algebra/StructuredCospans.jl
+++ b/test/categorical_algebra/StructuredCospans.jl
@@ -25,6 +25,11 @@ h0 = Graph(4)
 add_edges!(h0, [1,2,3], [3,3,4])
 h = OpenGraph(h0, FinFunction([1,2],4), FinFunction([4],4))
 
+# Structured multicospans.
+g′ = OpenGraph(g0, FinFunction([1],4), FinFunction([3],4), FinFunction([4],4))
+@test feet(g′) == fill(FinSet(1), 3)
+@test bundle_legs(g′, [1, (2,3)]) == g
+
 # Category
 #---------
 


### PR DESCRIPTION
Adds a function `bundle_legs` that combines the legs of multispans, multicospans, or structured multicospans using (co)products.