### PR TITLE
Speed up dispatch on value types

### DIFF
--- a/src/core/Syntax.jl
+++ b/src/core/Syntax.jl
@@ -439,21 +439,23 @@ function parse_json_sexpr(syntax_module::Module, sexpr;
   theory = GAT.theory(theory_type)
   type_lens = Dict(cons.name => length(cons.params) for cons in theory.types)
 
-  function parse_impl(sexpr::Vector, ::Val{:expr})
+  function parse_impl(sexpr::Vector, ::Type{Val{:expr}})
     name = Symbol(parse_head(symbols ? Symbol(sexpr[1]) : sexpr[1]))
     nargs = length(sexpr) - 1
     args = map(enumerate(sexpr[2:end])) do (i, arg)
       arg_kind = ((i == 1 && get(type_lens, name, nothing) == nargs-1) ||
                   arg isa Union{Bool,Number,Nothing}) ? :value : :expr
-      parse_impl(arg, Val(arg_kind))
+      parse_impl(arg, Val{arg_kind})
     end
     invoke_term(syntax_module, name, args...)
   end
-  parse_impl(x, ::Val{:value}) = parse_value(x)
-  parse_impl(x::String, ::Val{:expr}) = parse_reference(symbols ? Symbol(x) : x)
-  parse_impl(x::String, ::Val{:value}) = parse_value(symbols ? Symbol(x) : x)
+  parse_impl(x, ::Type{Val{:value}}) = parse_value(x)
+  parse_impl(x::String, ::Type{Val{:expr}}) =
+    parse_reference(symbols ? Symbol(x) : x)
+  parse_impl(x::String, ::Type{Val{:value}}) =
+    parse_value(symbols ? Symbol(x) : x)
 
-  parse_impl(sexpr, Val(:expr))
+  parse_impl(sexpr, Val{:expr})
 end
 
 # Pretty-print

--- a/src/graphics/ComposeWiringDiagrams.jl
+++ b/src/graphics/ComposeWiringDiagrams.jl
@@ -132,19 +132,20 @@ end
 """ Draw an atomic box in Compose.jl.
 """
 function render_box(layout::BoxLayout, opts::ComposeOptions)
-  render_box(Val(layout.shape), layout, opts)
+  render_box(Val{layout.shape}, layout, opts)
 end
-function render_box(::Val{:rectangle}, layout::BoxLayout, opts::ComposeOptions)
+function render_box(::Type{Val{:rectangle}}, layout::BoxLayout,
+                    opts::ComposeOptions)
   form = opts.rounded_boxes ? rounded_rectangle() : C.rectangle()
   labeled_box(form, layout, opts)
 end
-render_box(::Val{:circle}, layout::BoxLayout, opts::ComposeOptions) =
+render_box(::Type{Val{:circle}}, layout::BoxLayout, opts::ComposeOptions) =
   labeled_box(C.circle(), layout, opts)
-render_box(::Val{:ellipse}, layout::BoxLayout, opts::ComposeOptions) =
+render_box(::Type{Val{:ellipse}}, layout::BoxLayout, opts::ComposeOptions) =
   labeled_box(C.ellipse(), layout, opts)
-render_box(::Val{:junction}, layout::BoxLayout, opts::ComposeOptions) =
+render_box(::Type{Val{:junction}}, layout::BoxLayout, opts::ComposeOptions) =
   C.compose(C.context(), C.circle(), box_props(layout, opts)...)
-render_box(::Val{:invisible}, ::BoxLayout, ::ComposeOptions) = C.context()
+render_box(::Type{Val{:invisible}}, ::BoxLayout, ::ComposeOptions) = C.context()
 
 function labeled_box(form::C.ComposeNode, layout::BoxLayout, opts::ComposeOptions)
   labeled_form(form, box_label(MIME("text/plain"), layout.value),

--- a/src/graphics/ConvexExternal.jl
+++ b/src/graphics/ConvexExternal.jl
@@ -3,7 +3,7 @@ using .Convex, .SCS
 
 import .WiringDiagramLayouts: has_port_layout_method, solve_isotonic
 
-has_port_layout_method(::Val{:isotonic}) = true
+has_port_layout_method(::Type{Val{:isotonic}}) = true
 
 function solve_isotonic(y::Vector; solver=()->SCS.Optimizer(verbose=false),
                         loss=sumsquares, lower::Number=-Inf, upper::Number=Inf,

--- a/src/graphics/WiringDiagramLayouts.jl
+++ b/src/graphics/WiringDiagramLayouts.jl
@@ -336,10 +336,10 @@ function layout_box(inputs::Vector, outputs::Vector, opts::LayoutOptions;
     isnothing(shape) ? opts.default_box_shape : shape
   end
   style = get(opts.box_styles, value, style)
-  layout_box(Val(shape), inputs, outputs, opts; style=style, value=value, kw...)
+  layout_box(Val{shape}, inputs, outputs, opts; style=style, value=value, kw...)
 end
 
-function layout_box(::Val{:rectangle}, inputs::Vector, outputs::Vector,
+function layout_box(::Type{Val{:rectangle}}, inputs::Vector, outputs::Vector,
                     opts::LayoutOptions; shape::Symbol=:rectangle, kw...)
   size = default_box_size(length(inputs), length(outputs), opts)
   box = Box(BoxLayout(; shape=shape, size=size, kw...),
@@ -348,7 +348,7 @@ function layout_box(::Val{:rectangle}, inputs::Vector, outputs::Vector,
   size_to_fit!(singleton_diagram(box), opts)
 end
 
-function layout_box(::Val{:circle}, inputs::Vector, outputs::Vector,
+function layout_box(::Type{Val{:circle}}, inputs::Vector, outputs::Vector,
                     opts::LayoutOptions; pad::Bool=true, kw...)
   size = default_box_size(1, 1, opts)
   radius = first(size) / 2
@@ -358,7 +358,7 @@ function layout_box(::Val{:circle}, inputs::Vector, outputs::Vector,
   size_to_fit!(singleton_diagram(box), opts)
 end
 
-function layout_box(::Val{:ellipse}, inputs::Vector, outputs::Vector,
+function layout_box(::Type{Val{:ellipse}}, inputs::Vector, outputs::Vector,
                     opts::LayoutOptions; pad::Bool=true, kw...)
   size = default_box_size(length(inputs), length(outputs), opts)
   radii = size / 2
@@ -368,29 +368,29 @@ function layout_box(::Val{:ellipse}, inputs::Vector, outputs::Vector,
   size_to_fit!(singleton_diagram(box), opts)
 end
 
-function layout_box(::Val{:triangle}, inputs::Vector, outputs::Vector,
+function layout_box(::Type{Val{:triangle}}, inputs::Vector, outputs::Vector,
                     opts::LayoutOptions; kw...)
   @assert length(inputs) <= 1 "Cannot use triangle shape with multiple inputs"
-  layout_box(Val(:rectangle), inputs, outputs, opts; shape=:triangle, kw...)
+  layout_box(Val{:rectangle}, inputs, outputs, opts; shape=:triangle, kw...)
 end
-function layout_box(::Val{:invtriangle}, inputs::Vector, outputs::Vector,
+function layout_box(::Type{Val{:invtriangle}}, inputs::Vector, outputs::Vector,
                     opts::LayoutOptions; kw...)
   @assert length(outputs) <= 1 "Cannot use invtriangle shape with multiple outputs"
-  layout_box(Val(:rectangle), inputs, outputs, opts; shape=:invtriangle, kw...)
+  layout_box(Val{:rectangle}, inputs, outputs, opts; shape=:invtriangle, kw...)
 end
 
 # Although `trapezoid` is the standard term in North American English,
 # we use the term `trapezium` because both Graphviz and TikZ do. 
-function layout_box(::Val{:trapezium}, inputs::Vector, outputs::Vector,
+function layout_box(::Type{Val{:trapezium}}, inputs::Vector, outputs::Vector,
                     opts::LayoutOptions; kw...)
-  layout_box(Val(:rectangle), inputs, outputs, opts; shape=:trapezium, kw...)
+  layout_box(Val{:rectangle}, inputs, outputs, opts; shape=:trapezium, kw...)
 end
-function layout_box(::Val{:invtrapezium}, inputs::Vector, outputs::Vector,
+function layout_box(::Type{Val{:invtrapezium}}, inputs::Vector, outputs::Vector,
                     opts::LayoutOptions; kw...)
-  layout_box(Val(:rectangle), inputs, outputs, opts; shape=:invtrapezium, kw...)
+  layout_box(Val{:rectangle}, inputs, outputs, opts; shape=:invtrapezium, kw...)
 end
 
-function layout_box(::Val{:junction}, inputs::Vector, outputs::Vector,
+function layout_box(::Type{Val{:junction}}, inputs::Vector, outputs::Vector,
                     opts::LayoutOptions; visible::Bool=true, pad::Bool=true, kw...)
   nin, nout = length(inputs), length(outputs)
   shape, radius = visible ? (:junction, opts.junction_size) : (:invisible, 0)
@@ -494,17 +494,17 @@ function layout_outer_ports(diagram::WiringDiagram, opts::LayoutOptions;
     end
     method = :fixed
   end
-  layout_outer_ports(diagram, opts, Val(method); kw...)
+  layout_outer_ports(diagram, opts, Val{method}; kw...)
 end
 
 function layout_outer_ports(diagram::WiringDiagram, opts::LayoutOptions,
-                            ::Val{:fixed})
+                            ::Type{Val{:fixed}})
   (layout_linear_ports(InputPort, input_ports(diagram), size(diagram), opts),
    layout_linear_ports(OutputPort, output_ports(diagram), size(diagram), opts))
 end
 
 function layout_outer_ports(diagram::WiringDiagram, opts::LayoutOptions,
-                            ::Val{:isotonic})
+                            ::Type{Val{:isotonic}})
   inputs, outputs = input_ports(diagram), output_ports(diagram)
   diagram_size = diagram.value.size
   port_dir = svector(opts, 0, 1)
@@ -546,9 +546,9 @@ function layout_outer_ports(diagram::WiringDiagram, opts::LayoutOptions,
 end
 solve_isotonic(args...; kw...) = error("Isotonic regression backend not available")
 
-has_port_layout_method(method::Symbol) = has_port_layout_method(Val(method))
-has_port_layout_method(::Val) = false
-has_port_layout_method(::Val{:fixed}) = true
+has_port_layout_method(method::Symbol) = has_port_layout_method(Val{method})
+has_port_layout_method(::Type{<:Val}) = false
+has_port_layout_method(::Type{Val{:fixed}}) = true
 
 layout_port(value; kw...) = PortLayout(; value=value, kw...)
 


### PR DESCRIPTION
As described in #324, dispatching on `::Val{x}` is slower than dispatching on `::Type{Val{x}}` because, I assume, `Val(x)` causes an allocation while `Val{x}` doesn't. On my machine, this change gives a 20x speedup on the benchmark in #324.

@bosonbaas, can you compare on the original benchmark that prompted this issue?