### PR TITLE
Convenient Macro for Creating ACSets

### DIFF
--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -803,6 +803,14 @@ function deletesorted!(a::AbstractVector, x)
 end
 
 """ More convenient syntax for declaring an ACSet
+
+Example:
+@acset Graph begin
+  V = 2
+  E = 2
+  src = [1,2]
+  tgt = [2,1]
+end
 """
 
 macro acset(head, body)
@@ -810,7 +818,11 @@ macro acset(head, body)
   Expr(:call, esc(:eval), expr)
 end
 
-""" TODO: Add well-formedness checks to this
+"""
+TODO: Well-formedness check
+TODO: Could also rely on a @generated function that took in a "flat" named tuple
+TODO: Alternative syntax for @acset input based on CSV
+TODO: Actual CSV input
 """
 function init_acset(T::Type{<:ACSet{CD,AD,Ts}},body) where {CD <: CatDesc, AD <: AttrDesc{CD}, Ts <: Tuple}
   body = strip_lines(body)

--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -5,7 +5,7 @@ export AbstractACSet, ACSet, AbstractCSet, CSet, Schema, FreeSchema,
   AbstractACSetType, ACSetType, ACSetTableType, AbstractCSetType, CSetType,
   tables, parts, nparts, has_part, subpart, has_subpart, incident,
   add_part!, add_parts!, set_subpart!, set_subparts!, rem_part!, rem_parts!,
-  copy_parts!, copy_parts_only!, disjoint_union, @acset, init_acset
+  copy_parts!, copy_parts_only!, disjoint_union, @acset
 
 using Compat: isnothing, only
 
@@ -831,10 +831,10 @@ function init_acset(T::Type{<:ACSet{CD,AD,Ts}},body) where {CD <: CatDesc, AD <:
     acs = $(T)()
   end
   for elem in body.args
-    @assert elem.head == :(=)
-    @assert length(elem.args) == 2
-    lhs = elem.args[1]
-    rhs = elem.args[2]
+    lhs, rhs = @match elem begin
+      Expr(:(=), lhs, rhs) => (lhs,rhs)
+      _ => error("Every line of `@acset` must be an assignment")
+    end
     if lhs in CD.ob
       push!(code.args, :(add_parts!(acs, $(Expr(:quote, lhs)), $(rhs))))
     elseif lhs in CD.hom || lhs in AD.attr

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -294,4 +294,33 @@ set_subpart!(lset, 1, :label, :baz)
 
 @test_throws ErrorException set_subpart!(lset, 1, :label, :bar)
 
+# Test out the @acset macro
+#--------------------------
+
+@present TheoryDecGraph(FreeSchema) begin
+  E::Ob
+  V::Ob
+  src::Hom(E,V)
+  tgt::Hom(E,V)
+
+  X::Data
+  dec::Attr(E,X)
+end
+
+const DecGraph = ACSetType(TheoryDecGraph, index=[:src,:tgt])
+
+g = @acset DecGraph{String} begin
+  V = 4
+  E = 4
+
+  src = [1,2,3,4]
+  tgt = [2,3,4,1]
+
+  dec = ["a","b","c","d"]
+end
+
+@test nparts(g,:V) == 4
+@test subpart(g,:,:src) == [1,2,3,4]
+@test incident(g,1,:src) == [1]
+
 end


### PR DESCRIPTION
Right now this is very basic; I plan to add data validation and possibly new syntaxes later on. Currently,
``` julia
g = @acset Graph begin
  V = 2
  E = 2
  src = [1,2]
  tgt = [2,1]
end
```
works, but this will not successfully reject most ill-formed ACSets.