### PR TITLE
Optimize getters and setters for C-sets

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,7 +12,6 @@ jobs:
       - name: Install dependencies
         run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
       - name: Run benchmarks
-        run: julia -e 'using PkgBenchmark, BenchmarkCI; BenchmarkCI.judge(baseline=BenchmarkConfig())'
-        #run: julia -e 'using BenchmarkCI; BenchmarkCI.judge()'
+        run: julia -e 'using BenchmarkCI; BenchmarkCI.judge()'
       - name: Print results
         run: julia -e 'using BenchmarkCI; BenchmarkCI.displayjudgement()'

--- a/benchmark/Graphs.jl
+++ b/benchmark/Graphs.jl
@@ -182,8 +182,8 @@ g = WeightedGraph{Float64}(n)
 add_edges!(g, 1:(n-1), 2:n, weight=range(0, 1, length=n-1))
 mg = MG.MetaDiGraph(g)
 
-bench["sum-weights"] = @benchmarkable sum(weight($g))
-bench["sum-weights-slow"] = @benchmarkable begin
+bench["sum-weights-vectorized"] = @benchmarkable sum(weight($g))
+bench["sum-weights"] = @benchmarkable begin
   # Slower than above but useful for comparison with MetaGraphs.
   total = 0.0
   for e in edges($g)

--- a/benchmark/Graphs.jl
+++ b/benchmark/Graphs.jl
@@ -224,15 +224,34 @@ bench = SUITE["LabeledGraph"] = BenchmarkGroup()
 end
 const LabeledGraph = ACSetType(TheoryLabeledGraph, index=[:src,:tgt])
 
-n = 10000
-bench["make-labeled-graph"] = @benchmarkable begin
+function discrete_labeled_graph(n)
   g = LabeledGraph{String}()
-  add_vertices!(g, $n, label=("v$i" for i in 1:$n))
+  add_vertices!(g, n, label=("v$i" for i in 1:n))
+  g
 end
-bench["make-labeled-graph-metagraphs"] = @benchmarkable begin
+
+function discrete_labeled_metagraph(n)
   mg = MG.MetaDiGraph()
-  for i in 1:$n
+  for i in 1:n
     MG.add_vertex!(mg, :label, "v$i")
+  end
+  mg
+end
+
+n = 10000
+bench["make-discrete"] = @benchmarkable discrete_labeled_graph($n)
+bench["make-discrete-metagraphs"] = @benchmarkable discrete_labeled_metagraph($n)
+
+g = discrete_labeled_graph(n)
+mg = discrete_labeled_metagraph(n)
+bench["iter-labels"] = @benchmarkable begin
+  for v in vertices($g)
+    label = $g[v,:label]
+  end
+end
+bench["iter-labels-metagraphs"] = @benchmarkable begin
+  for v in MG.vertices($mg)
+    label = MG.get_prop($mg, v, :label)
   end
 end
 

--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -338,9 +338,11 @@ convention differs from DataFrames but note that the alternative interpretation
 of `[:src,:vattr]` as two independent columns does not even make sense, since
 they have different domains (belong to different tables).
 """
-subpart(acs::ACSet, part, name) = view_slice(subpart(acs, name), part)
+@inline subpart(acs::ACSet, part, name) = view_slice(subpart(acs, name), part)
+@inline subpart(acs::ACSet, name::Symbol) = _subpart(acs, Val{name})
+# These accessors must be inlined to ensure that constant names are propagated
+# at compile time, e.g., `subpart(g, :src)` becomes `_subpart(g, Val{:src})`.
 
-subpart(acs::ACSet, name::Symbol) = _subpart(acs, Val{name})
 subpart(acs::ACSet, expr::GATExpr{:generator}) = subpart(acs, first(expr))
 subpart(acs::ACSet, expr::GATExpr{:id}) = parts(acs, first(dom(expr)))
 
@@ -372,7 +374,7 @@ subpart_names(expr::GATExpr{:compose}) =
   end
 end
 
-Base.getindex(acs::ACSet, args...) = subpart(acs, args...)
+@inline Base.getindex(acs::ACSet, args...) = subpart(acs, args...)
 
 @inline view_slice(x::AbstractVector, i) = view(x, i)
 @inline view_slice(x::AbstractVector, i::Int) = x[i]

--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -570,10 +570,13 @@ See also: [`set_subpart!`](@ref).
 """
 set_subparts!(acs::ACSet, part; kw...) = set_subparts!(acs, part, (; kw...))
 
-function set_subparts!(acs::ACSet, part, subparts)
-  for (name, subpart) in pairs(subparts)
-    set_subpart!(acs, part, name, subpart)
-  end
+@generated function set_subparts!(acs::ACSet, part,
+                                  subparts::NamedTuple{names}) where names
+  Expr(:block,
+    map(names) do name
+      :(_set_subpart!(acs, part, Val{$(QuoteNode(name))}, subparts.$name))
+    end...,
+    nothing)
 end
 
 """ Remove part from a C-set.

--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -500,21 +500,23 @@ Both single and vectorized assignment are supported.
 
 See also: [`set_subparts!`](@ref).
 """
-@inline set_subpart!(acs::ACSet, part::Int, name, subpart) =
+@inline set_subpart!(acs::ACSet, part, name::Symbol, subpart) =
   _set_subpart!(acs, part, Val{name}, subpart)
+@inline set_subpart!(acs::ACSet, name::Symbol, subpart) =
+  _set_subpart!(acs, Val{name}, subpart)
 # Inlined for the same reason as `subpart`.
 
-function set_subpart!(acs::ACSet, part::AbstractVector{Int},
-                      name::Symbol, subpart)
+function _set_subpart!(acs::ACSet, part::AbstractVector{Int},
+                       ::Type{Name}, subpart) where Name
   broadcast(part, subpart) do part, subpart
-    _set_subpart!(acs, part, Val{name}, subpart)
+    _set_subpart!(acs, part, Name, subpart)
   end
 end
 
-set_subpart!(acs::ACSet, ::Colon, name::Symbol, subpart) =
-  set_subpart!(acs, name, subpart)
-set_subpart!(acs::ACSet, name::Symbol, new_subpart) =
-  set_subpart!(acs, 1:length(subpart(acs, name)), name, new_subpart)
+_set_subpart!(acs::ACSet, ::Colon, ::Type{Name}, subpart) where Name =
+  _set_subpart!(acs, Name, subpart)
+_set_subpart!(acs::ACSet, ::Type{Name}, subpart) where Name =
+  _set_subpart!(acs, 1:length(_subpart(acs, Name)), Name, subpart)
 
 @generated function _set_subpart!(acs::ACSet{CD,AD,Ts,Idxed}, part::Int,
     ::Type{Val{name}}, subpart) where {CD,AD,Ts,Idxed,name}

--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -556,6 +556,9 @@ set_subpart!(acs::ACSet, name::Symbol, new_subpart) =
   end
 end
 
+@inline Base.setindex!(acs::ACSet, value, args...) =
+  set_subpart!(acs, args..., value)
+
 """ Mutate subparts of a part in a C-set.
 
 Both single and vectorized assignment are supported.

--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -397,8 +397,9 @@ underlying index, which should not be mutated. To ensure that a fresh copy is
 returned, regardless of whether indexing is enabled, set the keyword argument
 `copy=true`.
 """
-incident(acs::ACSet, part, name::Symbol; copy::Bool=false) =
+@inline incident(acs::ACSet, part, name::Symbol; copy::Bool=false) =
   _incident(acs, part, Val{name}; copy=copy)
+# Inlined for same reason as `subpart`.
 
 function incident(acs::ACSet, part, names::AbstractVector{Symbol};
                   copy::Bool=false)

--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -500,8 +500,9 @@ Both single and vectorized assignment are supported.
 
 See also: [`set_subparts!`](@ref).
 """
-set_subpart!(acs::ACSet, part::Int, name, subpart) =
+@inline set_subpart!(acs::ACSet, part::Int, name, subpart) =
   _set_subpart!(acs, part, Val{name}, subpart)
+# Inlined for the same reason as `subpart`.
 
 function set_subpart!(acs::ACSet, part::AbstractVector{Int},
                       name::Symbol, subpart)

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -173,6 +173,12 @@ X, parent, height = TheoryDendrogram[[:X, :parent, :height]]
 @test d[3, [:parent, :height]] == 10
 @test d[3:5, [:parent, :height]] == [10,20,20]
 @test d[:, :parent] == [4,4,4,5,5]
+d2 = copy(d)
+d2[1, :parent] = 1
+d2[2:3, :parent] = 2:3
+@test d2[1:3, :parent] == 1:3
+d2[1:3, :parent] = 4
+@test d2 == d
 
 # Copying parts.
 d2 = Dendrogram{Int}()


### PR DESCRIPTION
As a sequel to #334, this PR optimizes the basic getters and setters for C-sets (`subpart`, `incident`, `set_subpart(s)!`) by benchmarking the Graphs module against LightGraphs and MetaGraphs.

With these optimizations, the getters and setters can be used elementwise (i.e., in non-vectorized fashion) without loss of performance, at least when the subpart name is hard-coded as a symbolic literal. The main tricks are to `@inline` appropriately and pass types instead of symbols wherever possible. The goal is to ensure that names that *are* constant are treated as constant by the compiler.

In comparison with LightGraphs, we are only occasionally faster but rarely more than 10x slower, at least on this simple set of benchmarks. OTOH, we outperform MetaGraphs in every benchmark. This is especially clear in the benchmarks involving attribute lookups (see esp. weighted graphs), where we achieve a 1000x speedup because we use typed arrays instead of untyped dictionaries.

On the whole, I would say that the fact that we can do this well with such a minimal optimization effort is a validation of our general approach. It's also a testament to the design of the Julia language.