### PR TITLE
Consistent interface for UWD schedule evaluation

### DIFF
--- a/src/linear_algebra/LinearAlgebra.jl
+++ b/src/linear_algebra/LinearAlgebra.jl
@@ -2,9 +2,11 @@ module LinearAlgebra
 
 using Reexport
 
+include("TensorNetworks.jl")
 include("GLA.jl")
 include("StructuredGLA.jl")
 
+@reexport using .TensorNetworks
 @reexport using .GraphicalLinearAlgebra
 @reexport using .StructuredGraphicalLinearAlgebra
 

--- a/src/linear_algebra/TensorNetworks.jl
+++ b/src/linear_algebra/TensorNetworks.jl
@@ -1,0 +1,201 @@
+""" Tensor networks from the perspective of undirected wiring diagrams.
+"""
+module TensorNetworks
+export RelationDiagram, @tensor_network, @eval_tensor_network,
+  parse_tensor_network, compile_tensor_expr
+
+using Compat
+using MLStyle: @match
+
+using ...CategoricalAlgebra.CSets
+using ...WiringDiagrams.UndirectedWiringDiagrams
+import ...WiringDiagrams: oapply
+using ...Programs.RelationalPrograms: RelationDiagram
+
+# Evaluation
+############
+
+""" Contract tensors according to UWD.
+"""
+function oapply(d::UndirectedWiringDiagram,
+                tensors::AbstractVector{<:AbstractArray})
+  @assert nboxes(d) == length(tensors)
+  contract_tensor_network(tensors,
+                          [junction(d, ports(d, b)) for b in boxes(d)],
+                          junction(d, ports(d, outer=true), outer=true))
+end
+
+""" Generalized contraction of two tensors of arbitrary rank.
+
+This function includes matrix multiplication, tensor product, and trace as
+special cases. The interface similar to that of the `ncon` ("Network
+CONtractor") function in:
+
+- the [NCON package](https://arxiv.org/abs/1402.0939) for MATLAB
+- the Julia package [TensorOperations.jl](https://github.com/Jutho/TensorOperations.jl)
+
+except that the outer junctions are represented explictly by a third argument
+rather than implicitly by using negative numbers in the second argument.
+"""
+function contract_tensor_network((A, B), (jA, jB), j_out)
+  njunc = maximum(Iterators.flatten((jA, jB, j_out)))
+  jA, jB, j_out = Tuple(jA), Tuple(jB), Tuple(j_out)
+  jsizes = fill(-1, njunc)
+  for (i,j) in enumerate(jA); jsizes[j] = size(A, i) end
+  for (i,j) in enumerate(jB); jsizes[j] = size(B, i) end
+  jsizes = Tuple(jsizes)
+
+  C = zeros(eltype(A), Tuple(jsizes[j] for j in j_out))
+  for index in CartesianIndices(jsizes)
+    C[(index[j] for j in j_out)...] +=
+      A[(index[j] for j in jA)...] * B[(index[j] for j in jB)...]
+  end
+  return C
+end
+
+# Parsing and code generation
+#############################
+
+""" Construct an undirected wiring diagram using tensor notation.
+
+The tensor syntax is compatible with that used by packages like
+[TensorOperations.jl](https://github.com/Jutho/TensorOperations.jl) and
+[TensorCast.jl](https://github.com/mcabbott/TensorCast.jl). For example, the
+wiring diagram for composite of two matrices (or two binary relations) is
+constructed by
+
+```julia
+@tensor_network (i,j,k) C[i,k] := A[i,j] * B[j,k]
+```
+
+The leading context, or list of variables, may be omitted, in which case it is
+inferred from the variables used in the tensor expression. So, in this example,
+an equivalent macro call is
+
+```julia
+@tensor_network C[i,k] := A[i,j] * B[j,k]
+```
+
+See also: [`@eval_tensor_network`](@ref), the "inverse" to this macro.
+"""
+macro tensor_network(exprs...)
+  :(parse_tensor_network($((QuoteNode(expr) for expr in exprs)...)))
+end
+
+""" Parse an undirected wiring diagram from a tensor expression.
+
+For more information, see the corresponding macro [`@tensor_network`](@ref).
+"""
+function parse_tensor_network(context::Expr, expr::Expr)
+  all_vars = @match context begin
+    Expr(:tuple, args...) => collect(Symbol, args)
+    Expr(:vect, args...) => collect(Symbol, args)
+  end
+  parse_tensor_network(expr, all_vars=all_vars)
+end
+
+function parse_tensor_network(expr::Expr; all_vars=nothing)
+  # Parse tensor expression.
+  (outer_name, outer_vars), body = @match expr begin
+    Expr(:(=), outer, body) => (parse_tensor_term(outer), body)
+    Expr(:(:=), outer, body) => (parse_tensor_term(outer), body)
+    _ => error("Tensor expression $expr must be an assignment, either = or :=")
+  end
+  names_and_vars = map(parse_tensor_term, @match body begin
+    Expr(:call, :(*), args...) => args
+    1 => [] # No terms
+    arg => [arg] # One term
+  end)
+
+  # Check compatibility of used variables with declared variables.
+  used_vars = unique!(reduce(vcat, ([[outer_vars]; last.(names_and_vars)])))
+  if isnothing(all_vars)
+    all_vars = sort!(used_vars)
+  else
+    used_vars ⊆ all_vars || error("One of variables $used_vars is not declared")
+  end
+
+  # Construct the undirected wiring diagram.
+  d = RelationDiagram{Symbol}(length(outer_vars))
+  add_junctions!(d, length(all_vars), variable=all_vars)
+  set_junction!(d, ports(d, outer=true),
+                incident(d, outer_vars, :variable), outer=true)
+  for (name, vars) in names_and_vars
+    box = add_box!(d, length(vars), name=name)
+    set_junction!(d, ports(d, box), incident(d, vars, :variable))
+  end
+  return d
+end
+
+function parse_tensor_term(expr)
+  @match expr begin
+    Expr(:ref, name::Symbol, args...) => (name, collect(Symbol, args))
+    name::Symbol => (name, Symbol[]) # Scalar
+    _ => error("Invalid syntax in term $expr in tensor expression")
+  end
+end
+
+""" Evaluate a tensor network using another macro.
+
+This macro takes two arguments: an undirected wiring diagram and a macro call
+supporting the tensor contraction notation that is de facto standard among Julia
+tensor packages. For example, to evaluate a tensor network using the `@tullio`
+macro, use:
+
+```julia
+A = @eval_tensor_network diagram @tullio
+```
+
+The following macros should work:
+
+- `@tensor` from
+  [TensorOperations.jl](https://github.com/Jutho/TensorOperations.jl).
+- `@tullio` from [Tullio.jl](https://github.com/mcabbott/Tullio.jl)
+- `@einsum` from [Einsum.jl](https://github.com/ahwillia/Einsum.jl)
+- `@ein` from [OMEinsum.jl](https://github.com/under-Peter/OMEinsum.jl)
+
+However, the macros `@cast` and `@reduce` from
+[TensorCast.jl](https://github.com/mcabbott/TensorCast.jl) will *not* work
+because they do not support implicit summation.
+
+See also: [`@tensor_network`](@ref), the "inverse" to this macro.
+"""
+macro eval_tensor_network(diagram, tensor_macro)
+  # XXX: We cannot use `GeneralizedGenerated.mk_function` here because packages
+  # like Tullio generate code with type parameters, which GG does not allow.
+  compile_expr = :(compile_tensor_expr($(esc(diagram)),
+    assign_op=:(:=), assign_name=gensym("out")))
+  Expr(:call, esc(:eval),
+       :(_eval_tensor_network($compile_expr, $(QuoteNode(tensor_macro)))))
+end
+function _eval_tensor_network(tensor_expr, macro_expr)
+  @match macro_expr begin
+    Expr(:macrocall, args...) => Expr(:macrocall, args..., tensor_expr)
+    _ => error("Expression $macro_expr is not a macro call")
+  end
+end
+
+""" Generate tensor expression from undirected wiring diagram.
+
+This function is used to implement [`@eval_tensor_network`](@ref) but may be
+useful in its own right.
+"""
+function compile_tensor_expr(d::UndirectedWiringDiagram;
+    assign_op::Symbol=:(=), assign_name::Symbol=:out)
+  vars = j -> subpart(d, j, :variable)
+  outer_vars = vars(junction(d, ports(d, outer=true), outer=true))
+  terms = map(boxes(d)) do box
+    ref_expr(subpart(d, box, :name), vars(junction(d, ports(d, box))))
+  end
+  lhs = ref_expr(assign_name, outer_vars)
+  rhs = if isempty(terms); 1
+    elseif length(terms) == 1; first(terms)
+    else Expr(:call, :(*), terms...) end
+  Expr(assign_op, lhs, rhs)
+end
+
+function ref_expr(name::Symbol, vars)
+  isempty(vars) ? name : Expr(:ref, name, vars...)
+end
+
+end

--- a/src/programs/RelationalPrograms.jl
+++ b/src/programs/RelationalPrograms.jl
@@ -295,7 +295,7 @@ The following macros should work:
 - `@einsum` from [Einsum.jl](https://github.com/ahwillia/Einsum.jl)
 - `@ein` from [OMEinsum.jl](https://github.com/under-Peter/OMEinsum.jl)
 
-However,, the macros `@cast` and `@reduce` from
+However, the macros `@cast` and `@reduce` from
 [TensorCast.jl](https://github.com/mcabbott/TensorCast.jl) will *not* work
 because they do not support implicit summation.
 

--- a/src/programs/RelationalPrograms.jl
+++ b/src/programs/RelationalPrograms.jl
@@ -2,8 +2,7 @@
 """
 module RelationalPrograms
 export RelationDiagram, UntypedRelationDiagram, TypedRelationDiagram,
-  @relation, @tensor_network, @eval_tensor_network,
-  parse_relation_diagram, parse_tensor_network, compile_tensor_expr
+  @relation, parse_relation_diagram
 
 using Compat
 using MLStyle: @match
@@ -66,9 +65,8 @@ function RelationDiagram{Name}(ports::AbstractVector{T};
   return d
 end
 
-
-# Relations
-###########
+# Relation macro
+################
 
 """ Construct an undirected wiring diagram using relation notation.
 
@@ -192,151 +190,6 @@ function parse_relation_call(call)
   else
     error("Relation call $call mixes named and unnamed arguments")
   end
-end
-
-# Tensor networks
-#################
-
-""" Construct an undirected wiring diagram using tensor notation.
-
-The tensor syntax is compatible with that used by packages like
-[TensorOperations.jl](https://github.com/Jutho/TensorOperations.jl) and
-[TensorCast.jl](https://github.com/mcabbott/TensorCast.jl). For example, the
-wiring diagram for composite of two matrices (or two binary relations) is
-constructed by
-
-```julia
-@tensor_network (i,j,k) C[i,k] := A[i,j] * B[j,k]
-```
-
-The leading context, or list of variables, may be omitted, in which case it is
-inferred from the variables used in the tensor expression. So, in this example,
-an equivalent macro call is
-
-```julia
-@tensor_network C[i,k] := A[i,j] * B[j,k]
-```
-
-See also: [`@eval_tensor_network`](@ref), the "inverse" to this macro.
-"""
-macro tensor_network(exprs...)
-  :(parse_tensor_network($((QuoteNode(expr) for expr in exprs)...)))
-end
-
-""" Parse an undirected wiring diagram from a tensor expression.
-
-For more information, see the corresponding macro [`@tensor_network`](@ref).
-"""
-function parse_tensor_network(context::Expr, expr::Expr)
-  all_vars = @match context begin
-    Expr(:tuple, args...) => collect(Symbol, args)
-    Expr(:vect, args...) => collect(Symbol, args)
-  end
-  parse_tensor_network(expr, all_vars=all_vars)
-end
-
-function parse_tensor_network(expr::Expr; all_vars=nothing)
-  # Parse tensor expression.
-  (outer_name, outer_vars), body = @match expr begin
-    Expr(:(=), outer, body) => (parse_tensor_term(outer), body)
-    Expr(:(:=), outer, body) => (parse_tensor_term(outer), body)
-    _ => error("Tensor expression $expr must be an assignment, either = or :=")
-  end
-  names_and_vars = map(parse_tensor_term, @match body begin
-    Expr(:call, :(*), args...) => args
-    1 => [] # No terms
-    arg => [arg] # One term
-  end)
-
-  # Check compatibility of used variables with declared variables.
-  used_vars = unique!(reduce(vcat, ([[outer_vars]; last.(names_and_vars)])))
-  if isnothing(all_vars)
-    all_vars = sort!(used_vars)
-  else
-    used_vars ⊆ all_vars || error("One of variables $used_vars is not declared")
-  end
-
-  # Construct the undirected wiring diagram.
-  d = RelationDiagram{Symbol}(length(outer_vars))
-  add_junctions!(d, length(all_vars), variable=all_vars)
-  set_junction!(d, ports(d, outer=true),
-                incident(d, outer_vars, :variable), outer=true)
-  for (name, vars) in names_and_vars
-    box = add_box!(d, length(vars), name=name)
-    set_junction!(d, ports(d, box), incident(d, vars, :variable))
-  end
-  return d
-end
-
-function parse_tensor_term(expr)
-  @match expr begin
-    Expr(:ref, name::Symbol, args...) => (name, collect(Symbol, args))
-    name::Symbol => (name, Symbol[]) # Scalar
-    _ => error("Invalid syntax in term $expr in tensor expression")
-  end
-end
-
-""" Evaluate a tensor network using another macro.
-
-This macro takes two arguments: an undirected wiring diagram and a macro call
-supporting the tensor contraction notation that is de facto standard among Julia
-tensor packages. For example, to evaluate a tensor network using the `@tullio`
-macro, use:
-
-```julia
-A = @eval_tensor_network diagram @tullio
-```
-
-The following macros should work:
-
-- `@tensor` from
-  [TensorOperations.jl](https://github.com/Jutho/TensorOperations.jl).
-- `@tullio` from [Tullio.jl](https://github.com/mcabbott/Tullio.jl)
-- `@einsum` from [Einsum.jl](https://github.com/ahwillia/Einsum.jl)
-- `@ein` from [OMEinsum.jl](https://github.com/under-Peter/OMEinsum.jl)
-
-However, the macros `@cast` and `@reduce` from
-[TensorCast.jl](https://github.com/mcabbott/TensorCast.jl) will *not* work
-because they do not support implicit summation.
-
-See also: [`@tensor_network`](@ref), the "inverse" to this macro.
-"""
-macro eval_tensor_network(diagram, tensor_macro)
-  # XXX: We cannot use `GeneralizedGenerated.mk_function` here because packages
-  # like Tullio generate code with type parameters, which GG does not allow.
-  compile_expr = :(compile_tensor_expr($(esc(diagram)),
-    assign_op=:(:=), assign_name=gensym("out")))
-  Expr(:call, esc(:eval),
-       :(_eval_tensor_network($compile_expr, $(QuoteNode(tensor_macro)))))
-end
-function _eval_tensor_network(tensor_expr, macro_expr)
-  @match macro_expr begin
-    Expr(:macrocall, args...) => Expr(:macrocall, args..., tensor_expr)
-    _ => error("Expression $macro_expr is not a macro call")
-  end
-end
-
-""" Generate tensor expression from undirected wiring diagram.
-
-This function is used to implement [`@eval_tensor_network`](@ref) but may be
-useful in its own right.
-"""
-function compile_tensor_expr(d::UndirectedWiringDiagram;
-    assign_op::Symbol=:(=), assign_name::Symbol=:out)
-  vars = j -> subpart(d, j, :variable)
-  outer_vars = vars(junction(d, ports(d, outer=true), outer=true))
-  terms = map(boxes(d)) do box
-    ref_expr(subpart(d, box, :name), vars(junction(d, ports(d, box))))
-  end
-  lhs = ref_expr(assign_name, outer_vars)
-  rhs = if isempty(terms); 1
-    elseif length(terms) == 1; first(terms)
-    else Expr(:call, :(*), terms...) end
-  Expr(assign_op, lhs, rhs)
-end
-
-function ref_expr(name::Symbol, vars)
-  isempty(vars) ? name : Expr(:ref, name, vars...)
 end
 
 end

--- a/src/wiring_diagrams/Algebras.jl
+++ b/src/wiring_diagrams/Algebras.jl
@@ -24,45 +24,6 @@ function oapply(composite::UndirectedWiringDiagram, hom_map::AbstractDict,
   oapply(composite, homs, obs)
 end
 
-# Tensors
-#########
-
-function oapply(d::UndirectedWiringDiagram,
-                tensors::AbstractVector{<:AbstractArray})
-  @assert nboxes(d) == length(tensors)
-  contract_tensor_network(tensors,
-                          [junction(d, ports(d, b)) for b in boxes(d)],
-                          junction(d, ports(d, outer=true), outer=true))
-end
-
-""" Generalized contraction of two tensors of arbitrary rank.
-
-This function includes matrix multiplication, tensor product, and trace as
-special cases. The interface similar to that of the `ncon` ("Network
-CONtractor") function in:
-
-- the [NCON package](https://arxiv.org/abs/1402.0939) for MATLAB
-- the Julia package [TensorOperations.jl](https://github.com/Jutho/TensorOperations.jl)
-
-except that the outer junctions are represented explictly by a third argument
-rather than implicitly by using negative numbers in the second argument.
-"""
-function contract_tensor_network((A, B), (jA, jB), j_out)
-  njunc = maximum(Iterators.flatten((jA, jB, j_out)))
-  jA, jB, j_out = Tuple(jA), Tuple(jB), Tuple(j_out)
-  jsizes = fill(-1, njunc)
-  for (i,j) in enumerate(jA); jsizes[j] = size(A, i) end
-  for (i,j) in enumerate(jB); jsizes[j] = size(B, i) end
-  jsizes = Tuple(jsizes)
-
-  C = zeros(eltype(A), Tuple(jsizes[j] for j in j_out))
-  for index in CartesianIndices(jsizes)
-    C[(index[j] for j in j_out)...] +=
-      A[(index[j] for j in jA)...] * B[(index[j] for j in jB)...]
-  end
-  return C
-end
-
 # Structured multicospans
 #########################
 

--- a/src/wiring_diagrams/Algebras.jl
+++ b/src/wiring_diagrams/Algebras.jl
@@ -1,4 +1,4 @@
-""" Algebras of the operads of wiring diagrams.
+""" Algebras of operads of wiring diagrams.
 """
 module WiringDiagramAlgebras
 export oapply
@@ -24,8 +24,47 @@ function oapply(composite::UndirectedWiringDiagram, hom_map::AbstractDict,
   oapply(composite, homs, obs)
 end
 
-# UWD algebra of structured multicospans
-########################################
+# Tensors
+#########
+
+function oapply(d::UndirectedWiringDiagram,
+                tensors::AbstractVector{<:AbstractArray})
+  @assert nboxes(d) == length(tensors)
+  contract_tensor_network(tensors,
+                          [junction(d, ports(d, b)) for b in boxes(d)],
+                          junction(d, ports(d, outer=true), outer=true))
+end
+
+""" Generalized contraction of two tensors of arbitrary rank.
+
+This function includes matrix multiplication, tensor product, and trace as
+special cases. The interface similar to that of the `ncon` ("Network
+CONtractor") function in:
+
+- the [NCON package](https://arxiv.org/abs/1402.0939) for MATLAB
+- the Julia package [TensorOperations.jl](https://github.com/Jutho/TensorOperations.jl)
+
+except that the outer junctions are represented explictly by a third argument
+rather than implicitly by using negative numbers in the second argument.
+"""
+function contract_tensor_network((A, B), (jA, jB), j_out)
+  njunc = maximum(Iterators.flatten((jA, jB, j_out)))
+  jA, jB, j_out = Tuple(jA), Tuple(jB), Tuple(j_out)
+  jsizes = fill(-1, njunc)
+  for (i,j) in enumerate(jA); jsizes[j] = size(A, i) end
+  for (i,j) in enumerate(jB); jsizes[j] = size(B, i) end
+  jsizes = Tuple(jsizes)
+
+  C = zeros(eltype(A), Tuple(jsizes[j] for j in j_out))
+  for index in CartesianIndices(jsizes)
+    C[(index[j] for j in j_out)...] +=
+      A[(index[j] for j in jA)...] * B[(index[j] for j in jB)...]
+  end
+  return C
+end
+
+# Structured multicospans
+#########################
 
 """ Compose structured multicospans according to UWD.
 

--- a/src/wiring_diagrams/ScheduleUndirected.jl
+++ b/src/wiring_diagrams/ScheduleUndirected.jl
@@ -104,7 +104,7 @@ eval_schedule(schedule, generators::AbstractVector) =
 eval_schedule(f, schedule::AbstractScheduledUWD, generators::AbstractVector) =
   eval_schedule(f, to_nested_diagram(schedule), generators)
 
-function eval_schedule(f, d::AbstractNestedUWD, generators::AbstractVector{T}) where T
+function eval_schedule(f, d::AbstractNestedUWD, generators::AbstractVector)
   # Evaluate `f` after constructing UWD for the composite.
   function do_eval(values, juncs, outer_junc)
     # Create diagram, adding boxes and ports.
@@ -129,7 +129,8 @@ function eval_schedule(f, d::AbstractNestedUWD, generators::AbstractVector{T}) w
   # Mutually recursively evaluate children of composite `c`.
   function eval_children(c::Int)
     bs, cs = box_children(d, c), children(d, c)
-    values = T[ generators[bs]; map(eval_composite, cs) ]
+    values = isempty(cs) ? generators[bs] : # XXX: Avoid Any[].
+      [ generators[bs]; map(eval_composite, cs) ]
     juncs = [ [junction(d, ports(d, b)) for b in bs];
               [composite_junction(d, composite_ports(d, c′)) for c′ in cs] ]
     (values, juncs)

--- a/test/linear_algebra/LinearAlgebra.jl
+++ b/test/linear_algebra/LinearAlgebra.jl
@@ -1,5 +1,9 @@
 using Test
 
+@testset "TensorNetworks" begin
+  include("TensorNetworks.jl")
+end
+
 @testset "GraphicalLinearAlgebra" begin
   include("GLA.jl")
   include("StructuredGLA.jl")

--- a/test/linear_algebra/TensorNetworks.jl
+++ b/test/linear_algebra/TensorNetworks.jl
@@ -43,7 +43,7 @@ set_junction!(d, 1:2, outer=true)
 
 macro roundtrip_tensor(tensor)
   quote
-    compiled = compile_tensor_expr(@tensor_network($tensor),
+    compiled = gen_tensor_notation(@tensor_network($tensor),
                                    assign_op=:(=), assign_name=:out)
     @test compiled == $(QuoteNode(tensor))
   end

--- a/test/linear_algebra/TensorNetworks.jl
+++ b/test/linear_algebra/TensorNetworks.jl
@@ -1,6 +1,8 @@
 module TestTensorNetworks
 using Test
 
+using LinearAlgebra: tr
+
 using Catlab.CategoricalAlgebra.CSets, Catlab.WiringDiagrams
 using Catlab.LinearAlgebra.TensorNetworks
 
@@ -51,5 +53,28 @@ end
 @roundtrip_tensor out[i,j,k] = A[i,ℓ] * B[j,ℓ] * C[k,ℓ]
 @roundtrip_tensor out = u[i] * A[i,j] * v[j]
 @roundtrip_tensor out[j] = α * a[i] * B[i,j]
+
+# Evaluation
+############
+
+# Binary matrix multiply.
+A, B = randn((3,4)), randn((4,5))
+network = @tensor_network C[i,k] = A[i,j] * B[j,k]
+@test oapply(network, [A,B]) ≈ A*B
+
+# Ternary matrix multiply.
+C = randn((5,6))
+network = @tensor_network D[i,ℓ] = A[i,j] * B[j,k] * C[k,ℓ]
+@test oapply(network, [A,B,C]) ≈ A*B*C
+
+# Trace.
+A = randn((5,5))
+network = @tensor_network out[] = A[i,i]
+@test oapply(network, [A])[] ≈ tr(A)
+
+# Tensor product.
+A, B = randn((3,4)), randn((5,6))
+network = @tensor_network C[i,j,k,ℓ] = A[i,j] * B[k,ℓ]
+@test oapply(network, [A,B]) ≈ (reshape(A, (3,4,1,1)) .* reshape(B, (1,1,5,6)))
 
 end

--- a/test/linear_algebra/TensorNetworks.jl
+++ b/test/linear_algebra/TensorNetworks.jl
@@ -1,0 +1,55 @@
+module TestTensorNetworks
+using Test
+
+using Catlab.CategoricalAlgebra.CSets, Catlab.WiringDiagrams
+using Catlab.LinearAlgebra.TensorNetworks
+
+# Parsing and code generation
+#############################
+
+# Parsing
+#--------
+
+parsed = @tensor_network (i,j,k,ℓ) D[i,j,k] = A[i,ℓ] * B[j,ℓ] * C[k,ℓ]
+d = RelationDiagram{Symbol}(3)
+add_box!(d, 2, name=:A); add_box!(d, 2, name=:B); add_box!(d, 2, name=:C)
+add_junctions!(d, 4, variable=[:i,:j,:k,:ℓ])
+set_junction!(d, [1,4,2,4,3,4])
+set_junction!(d, 1:3, outer=true)
+@test parsed == d
+
+parsed = @tensor_network D[i,j,k] = A[i,ℓ] * B[j,ℓ] * C[k,ℓ]
+@test parsed == d
+parsed = @tensor_network D[i,j,k] := A[i,ℓ] * B[j,ℓ] * C[k,ℓ]
+@test parsed == d
+
+# Degenerate case: single term.
+parsed = @tensor_network B[i,j,k] = A[i,j,k]
+d = singleton_diagram(RelationDiagram{Symbol}, 3, name=:A)
+set_subpart!(d, :variable, [:i,:j,:k])
+@test parsed == d
+
+# Degenerate case: no terms.
+parsed = @tensor_network A[i,j] = 1
+d = RelationDiagram{Symbol}(2)
+add_junctions!(d, 2, variable=[:i,:j])
+set_junction!(d, 1:2, outer=true)
+@test parsed == d
+
+# Round trip: parse then compile
+#-------------------------------
+
+macro roundtrip_tensor(tensor)
+  quote
+    compiled = compile_tensor_expr(@tensor_network($tensor),
+                                   assign_op=:(=), assign_name=:out)
+    @test compiled == $(QuoteNode(tensor))
+  end
+end
+
+@roundtrip_tensor out[i,k] = A[i,j] * B[j,k]
+@roundtrip_tensor out[i,j,k] = A[i,ℓ] * B[j,ℓ] * C[k,ℓ]
+@roundtrip_tensor out = u[i] * A[i,j] * v[j]
+@roundtrip_tensor out[j] = α * a[i] * B[i,j]
+
+end

--- a/test/programs/RelationalPrograms.jl
+++ b/test/programs/RelationalPrograms.jl
@@ -5,11 +5,11 @@ using Catlab.CategoricalAlgebra.CSets
 using Catlab.WiringDiagrams.UndirectedWiringDiagrams
 using Catlab.Programs.RelationalPrograms
 
-# Relations
-###########
+# Relation macro
+################
 
-# Untyped relations
-#------------------
+# Untyped
+#--------
 
 parsed = @relation (x,z) where (x,y,z) begin
   R(x,y)
@@ -34,8 +34,8 @@ d1 = @relation (x,y,z) -> (R(x,y); S(y,z))
 d2 = @relation ((x,y,z) where (x,y,z)) -> (R(x,y); S(y,z))
 @test d1 == d2
 
-# Typed relations
-#----------------
+# Typed
+#------
 
 parsed = @relation (x,y,z) where (x::X, y::Y, z::Z, w::W) begin
   R(x,w)
@@ -51,8 +51,8 @@ set_junction!(d, [1,4,2,4,3,4])
 set_junction!(d, [1,2,3], outer=true)
 @test parsed == d
 
-# Untyped relations with named ports
-#-----------------------------------
+# Untyped, named ports
+#---------------------
 
 parsed = @relation (start=u, stop=w) where (u, v, w) begin
   E(src=u, tgt=v)
@@ -67,8 +67,8 @@ set_junction!(d, [1,3], outer=true)
 set_subpart!(d, :port_name, [:src, :tgt, :src, :tgt])
 @test parsed == d
 
-# Typed relations with named ports
-#---------------------------------
+# Typed, named ports
+#-------------------
 
 parsed = @relation (e=e, e′=e′) where (e::Employee, e′::Employee,
                                        d::Department) begin
@@ -83,54 +83,5 @@ set_junction!(d, [1,3,2,3])
 set_junction!(d, [1,2], outer=true)
 set_subpart!(d, :port_name, [:id, :department, :id, :department])
 @test parsed == d
-
-# Tensor networks
-#################
-
-# Parsing
-#--------
-
-parsed = @tensor_network (i,j,k,ℓ) D[i,j,k] = A[i,ℓ] * B[j,ℓ] * C[k,ℓ]
-d = RelationDiagram{Symbol}(3)
-add_box!(d, 2, name=:A); add_box!(d, 2, name=:B); add_box!(d, 2, name=:C)
-add_junctions!(d, 4, variable=[:i,:j,:k,:ℓ])
-set_junction!(d, [1,4,2,4,3,4])
-set_junction!(d, 1:3, outer=true)
-@test parsed == d
-
-parsed = @tensor_network D[i,j,k] = A[i,ℓ] * B[j,ℓ] * C[k,ℓ]
-@test parsed == d
-parsed = @tensor_network D[i,j,k] := A[i,ℓ] * B[j,ℓ] * C[k,ℓ]
-@test parsed == d
-
-# Degenerate case: single term.
-parsed = @tensor_network B[i,j,k] = A[i,j,k]
-d = singleton_diagram(RelationDiagram{Symbol}, 3, name=:A)
-set_subpart!(d, :variable, [:i,:j,:k])
-@test parsed == d
-
-# Degenerate case: no terms.
-parsed = @tensor_network A[i,j] = 1
-d = RelationDiagram{Symbol}(2)
-add_junctions!(d, 2, variable=[:i,:j])
-set_junction!(d, 1:2, outer=true)
-@test parsed == d
-
-# Round trip
-#-----------
-
-# Parse and then compile.
-macro roundtrip_tensor(tensor)
-  quote
-    compiled = compile_tensor_expr(@tensor_network($tensor),
-                                   assign_op=:(=), assign_name=:out)
-    @test compiled == $(QuoteNode(tensor))
-  end
-end
-
-@roundtrip_tensor out[i,k] = A[i,j] * B[j,k]
-@roundtrip_tensor out[i,j,k] = A[i,ℓ] * B[j,ℓ] * C[k,ℓ]
-@roundtrip_tensor out = u[i] * A[i,j] * v[j]
-@roundtrip_tensor out[j] = α * a[i] * B[i,j]
 
 end

--- a/test/wiring_diagrams/ScheduleUndirected.jl
+++ b/test/wiring_diagrams/ScheduleUndirected.jl
@@ -5,9 +5,10 @@ using LinearAlgebra: dot, tr
 
 using Catlab.Theories: codom
 using Catlab.CategoricalAlgebra.CSets
-using Catlab.WiringDiagrams, Catlab.Programs.RelationalPrograms
+using Catlab.WiringDiagrams
 using Catlab.WiringDiagrams.ScheduleUndirectedWiringDiagrams:
   composites, composite_junction, composite_ports, parent, box_parent
+using Catlab.LinearAlgebra.TensorNetworks: @tensor_network
 
 composite_junctions(x::AbstractACSet, c) =
   composite_junction.(Ref(x), composite_ports(x, c))


### PR DESCRIPTION
This PR makes the interface for evaluating scheduled UWDs consistent with that for operad algebras. So now you can implement `oapply` once and use it for both one-shot evaluations and scheduled evaluations.

I also took the opportunity to refactor the accumulating functionality for tensor networks into its own submodule inside `Catlab.LinearAlgebra`. This makes official the operad algebra of tensors over a rig.