### PR TITLE
Sort-merge algorithm for pullbacks

### DIFF
--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -200,12 +200,12 @@ This is the naive algorithm for computing joins.
 """
 struct NestedLoopJoin <: JoinAlgorithm end
 
-function limit(cospan::Multicospan{<:FinSet{Int}};
+function limit(cospan::Multicospan{<:SetOb,<:FinDomFunction{Int}};
                alg::LimitAlgorithm=NestedLoopJoin())
   limit(cospan, alg)
 end
 
-function limit(cospan::Multicospan{<:FinSet{Int}}, ::NestedLoopJoin)
+function limit(cospan::Multicospan{<:SetOb,<:FinDomFunction{Int}}, ::NestedLoopJoin)
   # A nested-loop join is exactly what you get by composing the above algorithms
   # for products and equalizers, except that we handle the "nested" loops using
   # `CartesianIndices`.
@@ -216,7 +216,7 @@ end
 """
 struct SortMergeJoin <: JoinAlgorithm end
 
-function limit(cospan::Multicospan{<:FinSet{Int}}, ::SortMergeJoin)
+function limit(cospan::Multicospan{<:SetOb,<:FinDomFunction{Int}}, ::SortMergeJoin)
   funcs = map(collect, legs(cospan))
   sorts = map(sortperm, funcs)
   values = similar_mutable(funcs, eltype(apex(cospan)))

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -186,7 +186,9 @@ function universal(lim::Equalizer{<:FinSet{Int}},
   FinFunction(Int[only(searchsorted(ι, h(i))) for i in dom(h)], length(ι))
 end
 
-limit(cospan::Multicospan{<:FinSet{Int}}) = composite_pullback(cospan)
+function limit(cospan::Multicospan{<:FinSet{Int}})
+  limit(cospan, ComposeProductEqualizer())
+end
 
 """ Limit of free diagram of FinSets.
 
@@ -313,7 +315,9 @@ function pass_to_quotient(π::FinFunction{Int,Int}, h::FinFunction{Int,Int})
   FinFunction(q, codom(h))
 end
 
-colimit(span::Multispan{<:FinSet{Int}}) = composite_pushout(span)
+function colimit(span::Multispan{<:FinSet{Int}})
+  colimit(span, ComposeCoproductCoequalizer())
+end
 
 """ Colimit of free diagram of FinSets.
 

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -1,13 +1,15 @@
 """ The category of finite sets and functions, and its skeleton.
 """
 module FinSets
-export FinSet, FinFunction, FinDomFunction, force
+export FinSet, FinFunction, FinDomFunction, force,
+  JoinAlgorithm, NestedLoopJoin, SortMergeJoin
 
 using Compat: only
 
 using AutoHashEquals
 using DataStructures: IntDisjointSets, union!, find_root!
 using FunctionWrappers: FunctionWrapper
+using StaticArrays
 
 using ...Theories, ..FreeDiagrams, ..Limits, ..Sets
 import ...Theories: dom, codom
@@ -186,8 +188,84 @@ function universal(lim::Equalizer{<:FinSet{Int}},
   FinFunction(Int[only(searchsorted(ι, h(i))) for i in dom(h)], length(ι))
 end
 
-function limit(cospan::Multicospan{<:FinSet{Int}})
+""" Algorithm for limit of spans or multispans out of finite sets.
+
+In the context of relational databases, such limits are joins.
+"""
+abstract type JoinAlgorithm <: LimitAlgorithm end
+
+""" [Nested-loop join](https://en.wikipedia.org/wiki/Nested_loop_join) algorithm.
+
+This is the naive algorithm for computing joins.
+"""
+struct NestedLoopJoin <: JoinAlgorithm end
+
+function limit(cospan::Multicospan{<:FinSet{Int}};
+               alg::LimitAlgorithm=NestedLoopJoin())
+  limit(cospan, alg)
+end
+
+function limit(cospan::Multicospan{<:FinSet{Int}}, ::NestedLoopJoin)
+  # A nested-loop join is exactly what you get by composing the above algorithms
+  # for products and equalizers, except that we handle the "nested" loops using
+  # `CartesianIndices`.
   limit(cospan, ComposeProductEqualizer())
+end
+
+""" [Sort-merge join](https://en.wikipedia.org/wiki/Sort-merge_join) algorithm.
+"""
+struct SortMergeJoin <: JoinAlgorithm end
+
+function limit(cospan::Multicospan{<:FinSet{Int}}, ::SortMergeJoin)
+  funcs = map(collect, legs(cospan))
+  sorts = map(sortperm, funcs)
+  values = similar_mutable(funcs, eltype(apex(cospan)))
+  ranges = similar_mutable(funcs, UnitRange{Int})
+
+  function next_range!(i::Int)
+    f, sort = funcs[i], sorts[i]
+    n = length(f)
+    start = last(ranges[i]) + 1
+    ranges[i] = if start <= n
+      val = values[i] = f[sort[start]]
+      stop = start + 1
+      while stop <= n && f[sort[stop]] == val; stop += 1 end
+      start:(stop - 1)
+    else
+      start:n
+    end
+  end
+
+  πs = map(_ -> Int[], funcs)
+  for i in eachindex(ranges)
+    ranges[i] = 0:0
+    next_range!(i)
+  end
+  while !any(isempty, ranges)
+    if all(==(values[1]), values)
+      # TODO: Make more efficient by preallocating larger arrays.
+      for index in CartesianIndices(Tuple(ranges))
+        for i in eachindex(πs)
+          push!(πs[i], sorts[i][index[i]])
+        end
+      end
+      for i in eachindex(ranges)
+        next_range!(i)
+      end
+    else
+      next_range!(last(findmin(values)))
+    end
+  end
+  cone = Multispan(map((π,f) -> FinFunction(π, length(f)), πs, funcs))
+  Limit(cospan, cone)
+end
+
+similar_mutable(x::AbstractVector, T::Type) = similar(x, T)
+
+function similar_mutable(x::StaticVector{N}, T::Type) where N
+  # `similar` always returns an `MVector` but `setindex!(::MVector, args...)`
+  # only works when the element type is a bits-type.
+  isbitstype(T) ? similar(x, T) : SizedVector{N}(Vector{T}(undef, N))
 end
 
 """ Limit of free diagram of FinSets.

--- a/src/categorical_algebra/FreeDiagrams.jl
+++ b/src/categorical_algebra/FreeDiagrams.jl
@@ -168,10 +168,10 @@ morphisms with the same domain and codomain. A (co)limit of this shape is a
 
 For the common special case of two morphisms, see [`ParallelPair`](@ref).
 """
-@auto_hash_equals struct ParallelMorphisms{Ob,Hom,Homs<:AbstractVector{Hom}} <:
-    FixedShapeFreeDiagram{Ob}
-  dom::Ob
-  codom::Ob
+@auto_hash_equals struct ParallelMorphisms{Dom,Codom,Hom,Homs<:AbstractVector{Hom}} <:
+    FixedShapeFreeDiagram{Union{Dom,Codom}}
+  dom::Dom
+  codom::Codom
   homs::Homs
 end
 
@@ -184,7 +184,8 @@ end
 
 A common special case of [`ParallelMorphisms`](@ref).
 """
-const ParallelPair{Ob,Hom} = ParallelMorphisms{Ob,Hom,<:StaticVector{2,Hom}}
+const ParallelPair{Dom,Codom,Hom} =
+  ParallelMorphisms{Dom,Codom,Hom,<:StaticVector{2,Hom}}
 
 function ParallelPair(first, last)
   dom(first) == dom(last) ||
@@ -305,8 +306,8 @@ function FreeDiagram(cospan::Multicospan{Ob,Hom}) where {Ob,Hom}
   return d
 end
 
-function FreeDiagram(para::ParallelMorphisms{Ob,Hom}) where {Ob,Hom}
-  d = FreeDiagram{Ob,Hom}()
+function FreeDiagram(para::ParallelMorphisms{Dom,Codom,Hom}) where {Dom,Codom,Hom}
+  d = FreeDiagram{Union{Dom,Codom},Hom}()
   add_vertices!(d, 2, ob=[dom(para), codom(para)])
   add_edges!(d, fill(1,length(para)), fill(2,length(para)), hom=hom(para))
   return d

--- a/src/categorical_algebra/FreeDiagrams.jl
+++ b/src/categorical_algebra/FreeDiagrams.jl
@@ -205,7 +205,7 @@ Base.getindex(para::ParallelMorphisms, i) = para.homs[i]
 Base.firstindex(para::ParallelMorphisms) = firstindex(para.homs)
 Base.lastindex(para::ParallelMorphisms) = lastindex(para.homs)
 
-allequal(xs::AbstractVector) = all(isequal(x, xs[1]) for x in xs[2:end])
+allequal(xs::AbstractVector) = isempty(xs) || all(==(xs[1]), xs)
 
 # Commutative squares
 #--------------------

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -151,13 +151,13 @@ function universal end
 
 To implement for a type `T`, define the method `limit(::EmptyDiagram{T})`.
 """
-terminal(T::Type) = limit(EmptyDiagram{T}())
+terminal(T::Type; kw...) = limit(EmptyDiagram{T}(); kw...)
 
 """ Initial object.
 
 To implement for a type `T`, define the method `colimit(::EmptyDiagram{T})`.
 """
-initial(T::Type) = colimit(EmptyDiagram{T}())
+initial(T::Type; kw...) = colimit(EmptyDiagram{T}(); kw...)
 
 """ Unique morphism into a terminal object.
 
@@ -180,32 +180,32 @@ create(colim::Initial, A) = universal(colim, SMulticospan{0}(A))
 To implement for a type `T`, define the method `limit(::ObjectPair{T})` and/or
 `limit(::DiscreteDiagram{T})`.
 """
-product(A, B) = limit(ObjectPair(A, B))
-product(As::AbstractVector) = limit(DiscreteDiagram(As))
+product(A, B; kw...) = limit(ObjectPair(A, B); kw...)
+product(As::AbstractVector; kw...) = limit(DiscreteDiagram(As); kw...)
 
 """ Coproduct of objects.
 
 To implement for a type `T`, define the method `colimit(::ObjectPair{T})` and/or
 `colimit(::DiscreteDiagram{T})`.
 """
-coproduct(A, B) = colimit(ObjectPair(A, B))
-coproduct(As::AbstractVector) = colimit(DiscreteDiagram(As))
+coproduct(A, B; kw...) = colimit(ObjectPair(A, B); kw...)
+coproduct(As::AbstractVector; kw...) = colimit(DiscreteDiagram(As); kw...)
 
 """ Equalizer of morphisms with common domain and codomain.
 
 To implement for a type `T`, define the method `limit(::ParallelPair{T})` and/or
 `limit(::ParallelMorphisms{T})`.
 """
-equalizer(f, g) = limit(ParallelPair(f, g))
-equalizer(fs::AbstractVector) = limit(ParallelMorphisms(fs))
+equalizer(f, g; kw...) = limit(ParallelPair(f, g); kw...)
+equalizer(fs::AbstractVector; kw...) = limit(ParallelMorphisms(fs); kw...)
 
 """ Coequalizer of morphisms with common domain and codomain.
 
 To implement for a type `T`, define the method `colimit(::ParallelPair{T})` or
 `colimit(::ParallelMorphisms{T})`.
 """
-coequalizer(f, g) = colimit(ParallelPair(f, g))
-coequalizer(fs::AbstractVector) = colimit(ParallelMorphisms(fs))
+coequalizer(f, g; kw...) = colimit(ParallelPair(f, g); kw...)
+coequalizer(fs::AbstractVector; kw...) = colimit(ParallelMorphisms(fs); kw...)
 
 """ Pullback of a pair of morphisms with common codomain.
 
@@ -213,8 +213,8 @@ To implement for a type `T`, define the method `limit(::Cospan{T})` and/or
 `limit(::Multicospan{T})` or, if you have already implemented products and
 equalizers, rely on the default implementation.
 """
-pullback(f, g) = limit(Cospan(f, g))
-pullback(fs::AbstractVector) = limit(Multicospan(fs))
+pullback(f, g; kw...) = limit(Cospan(f, g); kw...)
+pullback(fs::AbstractVector; kw...) = limit(Multicospan(fs); kw...)
 
 """ Pushout of a pair of morphisms with common domain.
 
@@ -222,8 +222,8 @@ To implement for a type `T`, define the method `colimit(::Span{T})` and/or
 `colimit(::Multispan{T})` or, if you have already implemented coproducts and
 coequalizers, rely on the default implementation.
 """
-pushout(f, g) = colimit(Span(f, g))
-pushout(fs::AbstractVector) = colimit(Multispan(fs))
+pushout(f, g; kw...) = colimit(Span(f, g); kw...)
+pushout(fs::AbstractVector; kw...) = colimit(Multispan(fs); kw...)
 
 """ Pairing of morphisms: universal property of products/pullbacks.
 

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -273,11 +273,11 @@ end
 
 """ Compute pullback as composite of product and equalizer.
 """
-function composite_pullback(cospan::Cospan)
-  f, g = cospan
-  (π1, π2) = prod = product(dom(f), dom(g))
-  (ι,) = eq = equalizer(π1⋅f, π2⋅g)
-  CompositePullback(cospan, Span(ι⋅π1, ι⋅π2), prod, eq)
+function composite_pullback(cospan::Multicospan)
+  prod = product(feet(cospan))
+  (ι,) = eq = equalizer(map(compose, legs(prod), legs(cospan)))
+  cone = Multispan(map(π -> ι⋅π, legs(prod)))
+  CompositePullback(cospan, cone, prod, eq)
 end
 composite_pullback(f, g) = composite_pullback(Cospan(f, g))
 
@@ -299,11 +299,11 @@ end
 
 """ Compute pushout as composite of coproduct and coequalizer.
 """
-function composite_pushout(span::Span)
-  f, g = span
-  (ι1, ι2) = coprod = coproduct(codom(f), codom(g))
-  (π,) = coeq = coequalizer(f⋅ι1, g⋅ι2)
-  CompositePushout(span, Cospan(ι1⋅π, ι2⋅π), coprod, coeq)
+function composite_pushout(span::Multispan)
+  coprod = coproduct(feet(span))
+  (π,) = coeq = coequalizer(map(compose, legs(span), legs(coprod)))
+  cocone = Multicospan(map(ι -> ι⋅π, legs(coprod)))
+  CompositePushout(span, cocone, coprod, coeq)
 end
 composite_pushout(f, g) = composite_pushout(Span(f, g))
 

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -278,8 +278,8 @@ for limits.
 
 See also: [`CompositePushout`](@ref).
 """
-struct CompositePullback{Ob, Diagram<:Multicospan{Ob}, Cone<:Multispan{Ob},
-    Prod<:Product{Ob}, Eq<:Equalizer{Ob}} <: AbstractLimit{Ob,Diagram}
+struct CompositePullback{Ob, Diagram<:Multicospan, Cone<:Multispan{Ob},
+    Prod<:Product, Eq<:Equalizer} <: AbstractLimit{Ob,Diagram}
   diagram::Diagram
   cone::Cone
   prod::Prod
@@ -307,8 +307,8 @@ struct ComposeCoproductCoequalizer <: ColimitAlgorithm end
 
 See also: [`CompositePullback`](@ref).
 """
-struct CompositePushout{Ob, Diagram<:Multispan{Ob}, Cocone<:Multicospan{Ob},
-    Coprod<:Coproduct{Ob}, Coeq<:Coequalizer{Ob}} <: AbstractColimit{Ob,Diagram}
+struct CompositePushout{Ob, Diagram<:Multispan, Cocone<:Multicospan{Ob},
+    Coprod<:Coproduct, Coeq<:Coequalizer} <: AbstractColimit{Ob,Diagram}
   diagram::Diagram
   cocone::Cocone
   coprod::Coprod

--- a/src/categorical_algebra/Sets.jl
+++ b/src/categorical_algebra/Sets.jl
@@ -23,7 +23,7 @@ encompassed by the subtype [`FinSet`](@ref).
 """
 abstract type SetOb{T} end
 
-Base.eltype(::Type{SetOb{T}}) where T = T
+Base.eltype(::Type{<:SetOb{T}}) where T = T
 
 """ A Julia data type regarded as a set.
 """

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -51,9 +51,14 @@ f = FinFunction([1,3,4], 5)
 # Limits
 ########
 
-# Terminal object.
+# Terminal object
+#----------------
+
 @test ob(terminal(FinSet{Int})) == FinSet(1)
 @test delete(terminal(FinSet{Int}), FinSet(3)) == FinFunction([1,1,1])
+
+# Products
+#---------
 
 # Binary product.
 lim = product(FinSet(2), FinSet(3))
@@ -77,14 +82,16 @@ lim = product([FinSet(4), FinSet(3)])
 @test force(pair(lim,[f,g]) ⋅ first(legs(lim))) == f
 @test force(pair(lim,[f,g]) ⋅ last(legs(lim))) == g
 
-# Equalizer.
+# Equalizers
+#-----------
+
 f, g = FinFunction([1,2,4,3]), FinFunction([3,2,4,1])
 eq = equalizer(f,g)
 @test incl(eq) == FinFunction([2,3], 4)
 @test incl(equalizer([f,g])) == incl(eq)
 @test factorize(eq, FinFunction([2,3,2])) == FinFunction([1,2,1])
 
-# Equalizer in case of identical functions.
+# Equalizer of identical functions.
 f = FinFunction([4,2,3,1], 5)
 eq = equalizer(f,f)
 @test incl(eq) == force(id(FinSet(4)))
@@ -98,7 +105,9 @@ eq = equalizer(f,g)
 @test incl(equalizer([f,g])) == incl(eq)
 @test factorize(eq, FinFunction(Int[])) == FinFunction(Int[])
 
-# Pullback.
+# Pullbacks
+#----------
+
 lim = pullback(FinFunction([1,1,3,2],4), FinFunction([1,1,4,2],4))
 @test ob(lim) == FinSet(5)
 @test force(proj1(lim)) == FinFunction([1,2,1,2,4], 4)
@@ -118,7 +127,23 @@ f, g = FinFunction([1,1,2]), FinFunction([3,2,1])
 @test force(pair(lim,f,g) ⋅ proj1(lim)) == f
 @test force(pair(lim,f,g) ⋅ proj2(lim)) == g
 
-# Pullback using generic limit interface
+# Pullback using different algorithms.
+tuples(lim::AbstractLimit) =
+  sort!([ Tuple(map(π -> π(i), legs(lim))) for i in ob(lim) ])
+
+f, g = FinFunction([3,1,1,5,2],5), FinFunction([4,1,1,3,2],5)
+lim = pullback(f, g, alg=NestedLoopJoin())
+@test ob(lim) == FinSet(6)
+@test tuples(lim) == [(1,4), (2,2), (2,3), (3,2), (3,3), (5,5)]
+
+lim = pullback(f, g, alg=SortMergeJoin())
+@test ob(lim) == FinSet(6)
+@test tuples(lim) == [(1,4), (2,2), (2,3), (3,2), (3,3), (5,5)]
+
+# General limits
+#---------------
+
+# Pullback as a general limit.
 f, g = FinFunction([1,1,3,2],4), FinFunction([1,1,4,2],4)
 lim = limit(FreeDiagram([FinSet(4),FinSet(4),FinSet(4)], [(f,1,3),(g,2,3)]))
 @test ob(lim) == FinSet(5)
@@ -134,9 +159,14 @@ h = universal(lim, Multispan([f′, g′, f′⋅f])) # f′⋅f == g′⋅g
 # Colimits
 ##########
 
-# Initial object.
+# Initial object
+#---------------
+
 @test ob(initial(FinSet{Int})) == FinSet(0)
 @test create(initial(FinSet{Int}), FinSet(3)) == FinFunction(Int[], 3)
+
+# Coproducts
+#-----------
 
 # Binary coproduct.
 colim = coproduct(FinSet(2), FinSet(3))
@@ -156,6 +186,9 @@ colim = coproduct([FinSet(2), FinSet(3)])
 
 @test force(first(legs(colim)) ⋅ copair(colim,[f,g])) == f
 @test force(last(legs(colim)) ⋅ copair(colim,[f,g])) == g
+
+# Coequalizers
+#-------------
 
 # Coequalizer from a singleton set.
 f, g = FinFunction([1], 3), FinFunction([3], 3)
@@ -178,6 +211,9 @@ coeq = coequalizer(f,g)
 @test proj(coeq) == FinFunction(fill(1,5))
 @test proj(coequalizer([f,g])) == proj(coeq)
 @test factorize(coeq, FinFunction(fill(3,5))) == FinFunction([3])
+
+# Pushouts
+#---------
 
 # Pushout from the empty set: the degenerate case of the coproduct.
 f, g = FinFunction(Int[], 2), FinFunction(Int[], 3)

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -105,6 +105,12 @@ eq = equalizer(f,g)
 @test incl(equalizer([f,g])) == incl(eq)
 @test factorize(eq, FinFunction(Int[])) == FinFunction(Int[])
 
+# Equalizer of functions into non-finite set.
+f = FinDomFunction([:a, :b, :d, :c], TypeSet(Symbol))
+g = FinDomFunction([:c, :b, :d, :a], TypeSet(Symbol))
+eq = equalizer(f,g)
+@test incl(eq) == FinFunction([2,3], 4)
+
 # Pullbacks
 #----------
 
@@ -126,6 +132,14 @@ lim = pullback(FinFunction([1,1]), FinFunction([1,1,1]))
 f, g = FinFunction([1,1,2]), FinFunction([3,2,1])
 @test force(pair(lim,f,g) ⋅ proj1(lim)) == f
 @test force(pair(lim,f,g) ⋅ proj2(lim)) == g
+
+# Pullback of a cospan into non-finite set.
+f = FinDomFunction([:a, :a, :c, :b], TypeSet(Symbol))
+g = FinDomFunction([:a, :a, :d, :b], TypeSet(Symbol))
+π1, π2 = lim = pullback(f, g)
+@test ob(lim) == FinSet(5)
+@test force(π1) == FinFunction([1,2,1,2,4], 4)
+@test force(π2) == FinFunction([1,1,2,2,4], 4)
 
 # Pullback using different algorithms.
 tuples(lim::AbstractLimit) =


### PR DESCRIPTION
This PR enables limits and colimits to be implemented by different algorithms, via an optional argument `alg`. To compute pullbacks of multicospans, an important primitive for joins on relational databases, we now support the algorithms:

- [Nested-loop join](https://en.wikipedia.org/wiki/Nested_loop_join): the naive algorithm, already implemented as the product-equalizer composite limit
- [Sort-merge join](https://en.wikipedia.org/wiki/Sort-merge_join): sorts the function values to allow a single pass through the data

A future PR will implement indexed `FinFunctions` and the [hash join](https://en.wikipedia.org/wiki/Hash_join) algorithm. We also need to add benchmarks comparing the different algorithms on different pullbacks.

As a followup to #347, this PR also adds support for equalizers and pullbacks of functions with `FinSet{Int}` domain but arbitrary codomain. Given the previous PR, this was just a matter of loosening up type constraints in the `limit` methods.