### PR TITLE
Support any Tables.jl-compliant backend for tables in C-set

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,6 +26,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 
 [compat]
 AutoHashEquals = "0.2"
@@ -43,6 +44,7 @@ Reexport = "0.2"
 Requires = "^1"
 StaticArrays = "0.12"
 StructArrays = "0.4"
+Tables = "^1"
 julia = "1.0"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -25,8 +25,8 @@ Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
-StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 
 [compat]
 AutoHashEquals = "0.2"
@@ -43,8 +43,8 @@ PrettyTables = "0.10"
 Reexport = "0.2"
 Requires = "^1"
 StaticArrays = "0.12"
-StructArrays = "0.4"
 Tables = "^1"
+TypedTables = "^1"
 julia = "1.0"
 
 [extras]

--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -46,23 +46,21 @@ const AbstractACSet = AbstractAttributedCSet
 Instead of filling out the type parameters manually, we recommend using the
 function [`CSetType`](@ref) or [`ACSetType`](@ref) to generate a data type from
 a schema. Nevertheless, the first three type parameters are documented at
-[`AbstractAttributedCSet`](@ref). The remaining type parameters are
-implementation details and should be ignored.
+[`AbstractAttributedCSet`](@ref). The remaining type parameters are an
+implementation detail and should be ignored.
 """
 struct AttributedCSet{CD <: CatDesc, AD <: AttrDesc{CD}, Ts <: Tuple,
                       Idxed, UniqueIdxed, Tables <: NamedTuple,
                       Indices <: NamedTuple} <: AbstractACSet{CD,AD,Ts}
   tables::Tables
   indices::Indices
+
   function AttributedCSet{CD,AD,Ts,Idxed,UniqueIdxed}() where
       {CD <: CatDesc, AD <: AttrDesc{CD}, Ts <: Tuple, Idxed, UniqueIdxed}
     tables = make_tables(CD,AD,Ts)
     indices = make_indices(CD,AD,Ts,Idxed,UniqueIdxed)
     new{CD,AD,Ts,Idxed,UniqueIdxed,typeof(tables),typeof(indices)}(
       tables, indices)
-  end
-  function AttributedCSet{CD}() where {CD <: CatDesc}
-    AttributedCSet{CD,typeof(AttrDesc(CD())),Tuple{}}()
   end
   function AttributedCSet{CD,AD,Ts,Idxed,UniqueIdxed,Tables,Indices}() where
       {CD <: CatDesc, AD <: AttrDesc{CD}, Ts <: Tuple, Idxed, UniqueIdxed,
@@ -73,7 +71,7 @@ struct AttributedCSet{CD <: CatDesc, AD <: AttrDesc{CD}, Ts <: Tuple,
       tables::Tables, indices::Indices) where
       {CD <: CatDesc, AD <: AttrDesc{CD}, Ts <: Tuple, Idxed, UniqueIdxed,
        Tables <: NamedTuple, Indices <: NamedTuple}
-    new{CD,AD,Ts,Idxed,UniqueIdxed,Tables,Indices}(tables,indices)
+    new{CD,AD,Ts,Idxed,UniqueIdxed,Tables,Indices}(tables, indices)
   end
 end
 
@@ -224,7 +222,7 @@ make_struct_array(::Type{<:StructArray{T}}, ::UndefInitializer, n::Int) where
   T <: EmptyTuple = fill(T(()), n)
 
 function Base.:(==)(x1::T, x2::T) where T <: ACSet
-  # The indices are redundant, so need not be compared.
+  # The indices hold redundant information, so need not be compared.
   x1.tables == x2.tables
 end
 

--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -11,8 +11,7 @@ using Compat: isnothing, only
 
 using MLStyle: @match
 using PrettyTables: pretty_table
-import Tables
-using StructArrays: StructArray
+import Tables, TypedTables
 
 using ...Meta, ...Present
 using ...Syntax: GATExpr, args
@@ -63,7 +62,8 @@ function AttributedCSet{CD,AD,Ts,Idxed,UniqueIdxed}(
   AttributedCSet{CD,AD,Ts,Idxed,UniqueIdxed,Tables,Indices}(tables, indices)
 end
 
-function AttributedCSet{CD,AD,Ts,Idxed,UniqueIdxed}(; table_type=StructArray) where
+function AttributedCSet{CD,AD,Ts,Idxed,UniqueIdxed}(;
+    table_type = TypedTables.Table) where
     {CD <: CatDesc, AD <: AttrDesc{CD}, Ts <: Tuple, Idxed, UniqueIdxed}
   tables = make_tables(table_type,CD,AD,Ts)
   indices = make_indices(CD,AD,Ts,Idxed,UniqueIdxed)
@@ -501,13 +501,8 @@ end
   end
 end
 
-function resize_table!(table, n)
-  if Tables.isrowtable(table)
-    resize!(table, n)
-  else
-    map(col -> resize!(col, n), Tables.columns(table))
-  end
-end
+resize_table!(table, n) = map(col -> resize!(col, n), Tables.columns(table))
+resize_table!(table::Vector, n) = resize!(table, n)
 
 """ Mutate subpart of a part in a C-set.
 

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -121,6 +121,12 @@ add_parts!(dds, :X, 3, Φ=[1,1,1])
 rem_part!(dds, :X, 2)
 @test nparts(dds, :X) == 2
 
+dds′ = copy(dds)
+@test tables(dds′).X isa NamedTuple{(:Φ,)}
+@test dds′ == dds
+empty_dds = typeof(dds)()
+@test tables(empty_dds).X isa NamedTuple{(:Φ,)}
+
 # Dendrograms
 #############
 

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -112,6 +112,15 @@ add_parts!(dds, :X, 4, Φ=[3,3,4,4])
 @test incident(dds, 3, :Φ) == [1,2]
 @test incident(dds, 4, :Φ) == [3,4]
 
+# Custom table type supported by Tables.jl, here a named tuple of arrays.
+dds = DDS(table_type=NamedTuple)
+@test tables(dds).X isa NamedTuple{(:Φ,)}
+add_parts!(dds, :X, 3, Φ=[1,1,1])
+@test nparts(dds, :X) == 3
+@test subpart(dds, :Φ) == [1,1,1]
+rem_part!(dds, :X, 2)
+@test nparts(dds, :X) == 2
+
 # Dendrograms
 #############
 
@@ -300,8 +309,8 @@ set_subpart!(lset, 1, :label, :baz)
 
 @test_throws ErrorException set_subpart!(lset, 1, :label, :bar)
 
-# Test out the @acset macro
-#--------------------------
+# @acset macro
+##############
 
 @present TheoryDecGraph(FreeSchema) begin
   E::Ob
@@ -318,10 +327,8 @@ const DecGraph = ACSetType(TheoryDecGraph, index=[:src,:tgt])
 g = @acset DecGraph{String} begin
   V = 4
   E = 4
-
   src = [1,2,3,4]
   tgt = [2,3,4,1]
-
   dec = ["a","b","c","d"]
 end
 


### PR DESCRIPTION
This PR:

- allows any column-based table type compliant with [Tables.jl](https://github.com/JuliaData/Tables.jl) to be used for the tables in a C-set
- switches the default table type to [TypedTables.jl](https://github.com/JuliaData/TypedTables.jl), which closes #330

The following concrete table types are known to work:

- StructArrays (the old default)
- TypedTables (the new default)
- named tuples of arrays (validated in the unit tests)