### PR TITLE
Haskell-style map function for ACSets

### DIFF
--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -5,11 +5,10 @@ export AbstractACSet, ACSet, AbstractCSet, CSet, Schema, FreeSchema,
   AbstractACSetType, ACSetType, ACSetTableType, AbstractCSetType, CSetType,
   tables, parts, nparts, has_part, subpart, has_subpart, incident,
   add_part!, add_parts!, set_subpart!, set_subparts!, rem_part!, rem_parts!,
-  copy_parts!, copy_parts_only!, disjoint_union, @acset, wrangle_attributes
+  copy_parts!, copy_parts_only!, disjoint_union, @acset
 
 using Compat: isnothing, only
 
-using FunctionWrappers: FunctionWrapper
 using MLStyle: @match
 using ...Meta
 using PrettyTables: pretty_table

--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -861,13 +861,12 @@ end
 """ Map over a data type, in the style of Haskell functors
 """
 
-Base.map(A::Type,B::Type,f::Function,D::Symbol,acs::ACSet) = _map(FunctionWrapper{B,Tuple{A}}(f),Val{D},acs)
+Base.map(B::Type, f::Function, D::Symbol, acs::ACSet) = _map(B, f,Val{D},acs)
 
-@generated function _map(f::FunctionWrapper{B,As}, ::Type{Val{D}}, acs::AT) where
-    {B,As,D,AT<:ACSet}
+@generated function _map(::Type{B}, f::Function, ::Type{Val{D}}, acs::AT) where
+    {B,D,AT<:ACSet}
   # Build the new ACSet type
   CD,AD,Ts,Idxed,UniqIdxed = AT.parameters[1:5]
-  A = As.parameters[1]
   k = data_num(AD, D)
   new_Ts = begin
     arr = [Ts.parameters...]

--- a/src/theories/Schema.jl
+++ b/src/theories/Schema.jl
@@ -1,4 +1,4 @@
-export Schema, FreeSchema, Data, Attr, SchemaExpr, DataExpr, AttrExpr, attrs_by_codom
+export Schema, FreeSchema, Data, Attr, SchemaExpr, DataExpr, AttrExpr
 
 using MLStyle: @match
 

--- a/src/theories/Schema.jl
+++ b/src/theories/Schema.jl
@@ -1,4 +1,4 @@
-export Schema, FreeSchema, Data, Attr, SchemaExpr, DataExpr, AttrExpr
+export Schema, FreeSchema, Data, Attr, SchemaExpr, DataExpr, AttrExpr, attrs_by_codom
 
 using MLStyle: @match
 
@@ -177,6 +177,21 @@ end
 function codom(AD::Type{T}, attr::Union{Int,Symbol}) where
     {CD,Data,Attr,ADom,ACodom,T <: AttrDesc{CD,Data,Attr,ADom,ACodom}}
   Data[codom_num(AD,attr)]
+end
+
+function attrs_by_codom(AD::Type{T}) where
+    {CD,Data,Attr,ADom,ACodom,T <: AttrDesc{CD,Data,Attr,ADom,ACodom}}
+  abc = Dict{Symbol,Array{Symbol}}()
+  for i in eachindex(Attr)
+    a = Attr[i]
+    d = Data[ACodom[i]]
+    if d ∈ keys(abc)
+      push!(abc[d],a)
+    else
+      abc[d] = [a]
+    end
+  end
+  abc
 end
 
 SchemaType(pres::Presentation{Schema}) = (CatDescType(pres),AttrDescType(pres))

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -332,12 +332,41 @@ end
 # Test mapping
 #-------------
 
-f(s::String)::Int = Int(s[1])
+f(s::String) = Int(s[1])
 
-h = map(Int,f,:X,g)
+h1 = map(g, dec = f)
+h2 = map(g, X = f)
 
-@test subpart(h,:src) == subpart(g,:src)
-@test typeof(h).parameters[3] == Tuple{Int}
-@test subpart(h,:dec) == f.(["a","b","c","d"])
+@test h1 == h1
+
+@test subpart(h1,:src) == subpart(g,:src)
+@test typeof(h1).parameters[3] == Tuple{Int}
+@test subpart(h1,:dec) == f.(["a","b","c","d"])
+
+@present TheoryLabelledDecGraph <: TheoryDecGraph begin
+  label::Attr(V,X)
+end
+
+const LabelledDecGraph = ACSetType(TheoryLabelledDecGraph, index=[:src,:tgt])
+
+g = @acset LabelledDecGraph{String} begin
+  V = 4
+  E = 4
+
+  src = [1,2,3,4]
+  tgt = [2,3,4,1]
+
+  dec = ["a","b","c","d"]
+  label = ["w", "x", "y", "z"]
+end
+
+h1 = map(g, X = f)
+@test subpart(h1,:label) == f.(["w","x","y","z"])
+
+h2 = map(g, dec = f, label = i -> 3)
+@test subpart(h2,:dec) == f.(["a","b","c","d"])
+@test subpart(h2,:label) == [3,3,3,3]
+
+@test_throws Any map(g, dec = f)
 
 end

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -329,4 +329,15 @@ end
 @test subpart(g,:,:src) == [1,2,3,4]
 @test incident(g,1,:src) == [1]
 
+# Test mapping
+#-------------
+
+f(s::String)::Int = Int(s[1])
+
+h = map(String,Int,f,:X,g)
+
+@test subpart(h,:src) == subpart(g,:src)
+@test typeof(h).parameters[3] == Tuple{Int}
+@test subpart(h,:dec) == f.(["a","b","c","d"])
+
 end

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -334,7 +334,7 @@ end
 
 f(s::String)::Int = Int(s[1])
 
-h = map(String,Int,f,:X,g)
+h = map(Int,f,:X,g)
 
 @test subpart(h,:src) == subpart(g,:src)
 @test typeof(h).parameters[3] == Tuple{Int}


### PR DESCRIPTION
Pretty simple, basically:

``` julia
map(Int,s -> Int(s[1]),:Weight,g::WeightedGraph{String})::WeightedGraph{Int}
```

All attributes with a given codomain get converted using the supplied function. Partly addresses #335.