### PR TITLE
Another macro for constructing ACSets!

### DIFF
--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -5,7 +5,7 @@ export AbstractACSet, ACSet, AbstractCSet, CSet, Schema, FreeSchema,
   AbstractACSetType, ACSetType, ACSetTableType, AbstractCSetType, CSetType,
   tables, parts, nparts, has_part, subpart, has_subpart, incident,
   add_part!, add_parts!, set_subpart!, set_subparts!, rem_part!, rem_parts!,
-  copy_parts!, copy_parts_only!, disjoint_union, @acset
+  copy_parts!, copy_parts_only!, disjoint_union, @acset, @present_acset
 
 using Compat: isnothing, only
 
@@ -813,6 +813,9 @@ function deletesorted!(a::AbstractVector, x)
   if found; deleteat!(a, i) end
   found
 end
+ 
+# ACSet Creation Macros
+#######################
 
 """ More convenient syntax for declaring an ACSet
 
@@ -855,6 +858,64 @@ function init_acset(T::Type{<:ACSet{CD,AD,Ts}},body) where {CD <: CatDesc, AD <:
   end
   push!(code.args, :(return acs))
   code
+end
+
+""" Alternative ACSet creation macro
+
+Example usage:
+```julia
+@present_acset Graph begin
+   a::V
+   b::V
+   x::E(src=a,tgt=b)
+end
+```
+"""
+
+macro present_acset(head,body)
+  acset_type, name_attrs = @match head begin
+    Expr(:tuple, acset_type, names...) => (acset_type, names)
+    _ => (head,[])
+  end
+  name_attrs = map(name_attrs) do syntax
+    @match syntax begin
+      Expr(:call, :with_names, ob, attr) => (ob => attr)
+      _ => error("unsupported argument in @present_acset head")
+    end
+  end |> Dict
+  lines = @match strip_lines(body) begin
+    Expr(:block, lines...) => lines
+    _ => error("Must pass in a block to @present_acset body")
+  end
+  quote
+    acs = $(esc(acset_type))()
+    $(Expr(:block, map(line -> convert_line(line, name_attrs), lines)...))
+    acs
+  end
+end
+
+function convert_line(line,name_attrs)
+  @match line begin
+    Expr(:(::), var, expr) => begin
+      ob, args = @match expr begin
+        Expr(:call, ob, args...) => (ob,Array(args))
+        ob::Symbol => (ob,[])
+        _ => error("invalid right hand side in @present_acset body")
+      end
+      vars = @match var begin
+        Expr(:tuple, vars...) => vars
+        _::Symbol => [var]
+        _ => error("invalid left hand side in @present_acset body")
+      end
+      if ob ∈ keys(name_attrs)
+        push!(args,Expr(:kw, name_attrs[ob], Expr(:vect, map(v -> Expr(:quote,v),vars)...)))
+      end
+      quote
+        $(Expr(:tuple, vars...)) = add_parts!(acs, $(Expr(:quote, ob)), $(length(vars)), $(args...))
+      end
+    end
+    _ => error("invalid line type in @present_acset body: must be a :: declaration")
+  end
 end
 
 end

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -315,18 +315,25 @@ end
 
 const DecGraph = ACSetType(TheoryDecGraph, index=[:src,:tgt])
 
-g = @acset DecGraph{String} begin
+g = @acset DecGraph{Symbol} begin
   V = 4
   E = 4
 
   src = [1,2,3,4]
   tgt = [2,3,4,1]
 
-  dec = ["a","b","c","d"]
+  dec = [:a,:b,:c,:d]
 end
 
 @test nparts(g,:V) == 4
 @test subpart(g,:,:src) == [1,2,3,4]
 @test incident(g,1,:src) == [1]
+
+g2 = @present_acset DecGraph{Symbol}, with_names(E,dec) begin
+  (w,x,y,z) :: V
+  (a,b,c,d) :: E(src=[w,x,y,z],tgt=[x,y,z,w])
+end
+
+@test g2 == g
 
 end


### PR DESCRIPTION
I was inspired to write this while reading Sophie Libkind's post; there was a section where she created an acset and I thought "there must be a better way."

Example usage:

``` julia
@present_acset DecGraph{Symbol}, with_names(E,dec) begin
  (w,x,y,z) :: V
  (a,b,c,d) :: E(src=[w,x,y,z],tgt=[x,y,z,w])
end
```

produces the same result as

``` julia
@acset DecGraph{Symbol} begin
  V = 4
  E = 4

  src = [1,2,3,4]
  tgt = [2,3,4,1]

  dec = [:a,:b,:c,:d]
end
```

Each "with_names" argument allows you to capture the symbols used in the macro as attributes in the final ACSet.