### PR TITLE
Indexed `FinFunction`s and hash joins

### DIFF
--- a/benchmark/FinSets.jl
+++ b/benchmark/FinSets.jl
@@ -1,0 +1,32 @@
+using BenchmarkTools
+const SUITE = BenchmarkGroup()
+
+using Random
+using Catlab.CategoricalAlgebra, Catlab.CategoricalAlgebra.FinSets
+
+bench = SUITE["Limits"] = BenchmarkGroup()
+
+function benchmark_pullback(suite::BenchmarkGroup, name, cospan)
+  for alg in (NestedLoopJoin(), SortMergeJoin(), HashJoin())
+    suite["$name:$(nameof(typeof(alg)))"] =
+      @benchmarkable limit($cospan, alg=$alg)
+  end
+end
+
+m, n = 100, 150
+f, g = FinFunction(ones(Int, m), 1), FinFunction(ones(Int, n), 1)
+benchmark_pullback(bench, "pullback_terminal", Cospan(f, g))
+
+f = FinFunction(identity, FinSet(10000))
+benchmark_pullback(bench, "pullback_identity", Cospan(f, f))
+
+n = 10000
+Random.seed!(1)
+f, g = FinFunction(randperm(n), n), FinFunction(randperm(n), n)
+benchmark_pullback(bench, "pullback_randperm", Cospan(f, g))
+
+k = 1000
+m, n = 9000, 11000
+Random.seed!(1)
+f, g = FinFunction(rand(1:k, m), k), FinFunction(rand(1:k, n), k)
+benchmark_pullback(bench, "pullback_randsparse", Cospan(f, g))

--- a/benchmark/Graphs.jl
+++ b/benchmark/Graphs.jl
@@ -1,7 +1,4 @@
-""" Benchmark Catlab.Graphs against LightGraphs and MetaGraphs.
-"""
-module BenchmarkGraphs
-
+# Benchmark Catlab.Graphs against LightGraphs and MetaGraphs.
 using BenchmarkTools
 const SUITE = BenchmarkGroup()
 
@@ -281,6 +278,4 @@ bench["indexed-lookup-metagraphs"] = @benchmarkable begin
   for i in $σ
     @assert $mg["v$i", :label] == i
   end
-end
-
 end

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,18 @@
+# Catlab.jl benchmarks
+
+This directory contains benchmarks for different parts of Catlab. To run all the
+benchmarks, launch `julia --project=benchmark` and enter:
+
+``` julia
+using PkgBenchmark
+import Catlab
+
+benchmarkpkg(Catlab)
+```
+
+To run a specific set of benchmarks, use the `script` keyword argument, for
+example:
+
+``` julia
+benchmarkpkg(Catlab; script="benchmark/FinSets.jl")
+```

--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -2,6 +2,13 @@ using BenchmarkTools
 
 const SUITE = BenchmarkGroup()
 
-include("Graphs.jl")
+module BenchmarkFinSets
+  include("FinSets.jl")
+end
 
+module BenchmarkGraphs
+  include("Graphs.jl")
+end
+
+SUITE["FinSets"] = BenchmarkFinSets.SUITE
 SUITE["Graphs"] = BenchmarkGraphs.SUITE

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -56,7 +56,9 @@ const FinFunction{S, S′, Dom <: FinSet{S}, Codom <: FinSet{S′}} =
 
 FinFunction(f::Function, dom, codom) =
   SetFunctionCallable(f, FinSet(dom), FinSet(codom))
-FinFunction(f::AbstractVector, args...) =
+FinFunction(f::AbstractVector{Int}) =
+  FinDomFunctionVector(f, FinSet(isempty(f) ? 0 : maximum(f)))
+FinFunction(f::AbstractVector{Int}, args...) =
   FinDomFunctionVector(f, (FinSet(arg) for arg in args)...)
 FinFunction(::typeof(identity), args...) =
   SetFunctionIdentity((FinSet(arg) for arg in args)...)
@@ -89,8 +91,8 @@ the form ``{1,...,n}``.
   codom::Codom
 end
 
-FinDomFunctionVector(f::AbstractVector{Int}) =
-  FinDomFunctionVector(f, FinSet(isempty(f) ? 0 : maximum(f)))
+FinDomFunctionVector(f::AbstractVector{T′}) where T′ =
+  FinDomFunctionVector(f, TypeSet{T′}())
 
 function FinDomFunctionVector(f::AbstractVector, dom::FinSet{Int}, codom)
   length(f) == length(dom) ||

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -2,7 +2,7 @@
 """
 module FinSets
 export FinSet, FinFunction, FinDomFunction, force,
-  IndexedFinFunction, IndexedFinDomFunction, preimage,
+  IndexedFinFunction, IndexedFinDomFunction, is_indexed, preimage,
   JoinAlgorithm, NestedLoopJoin, SortMergeJoin
 
 using Compat: isnothing, only
@@ -169,9 +169,16 @@ force(f::IndexedFinDomFunction) = f
 
 (f::IndexedFinDomFunction)(x) = f.func[x]
 
+""" Whether the given function is indexed, i.e., supports preimages.
+"""
+is_indexed(f::IndexedFinDomFunction) = true
+is_indexed(f::SetFunction) = false
+is_indexed(f::SetFunctionIdentity) = true
+
 """ The preimage (inverse image) of the value y in the codomain.
 """
 preimage(f::IndexedFinDomFunction, y) = get_preimage_index(f.index, y)
+preimage(f::SetFunctionIdentity, y) = SVector(y)
 
 @inline get_preimage_index(index::AbstractDict, y) = get(index, y, 1:0)
 @inline get_preimage_index(index::AbstractVector, y) = index[y]

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -14,7 +14,6 @@ using StaticArrays: StaticVector, SVector, SizedVector
 
 using ...Theories, ..FreeDiagrams, ..Limits, ..Sets
 import ...Theories: dom, codom
-using ...CSetDataStructures: insertsorted!, set_data_index!
 import ..Limits: limit, colimit, universal
 using ..Sets: SetFunctionCallable, SetFunctionIdentity
 
@@ -169,7 +168,7 @@ function IndexedFinDomFunction(f::AbstractVector{T}, codom::SetOb{T};
   if isnothing(index)
     index = Dict{T,Vector{Int}}()
     for (i, x) in enumerate(f)
-      set_data_index!(index, x, i)
+      push!(get!(index, x) do; Int[] end, i)
     end
   end
   IndexedFinDomFunction(f, index, codom)
@@ -200,7 +199,7 @@ preimage(f::SetFunctionIdentity, y) = SVector(y)
 """ Indexed function between finite sets of type `FinSet{Int}`.
 
 Indexed functions store both the forward map ``f: X → Y``, as a vector of
-integers, and the backward map ``f: Y → X⁻¹``, as a vector of sorted vectors of
+integers, and the backward map ``f: Y → X⁻¹``, as a vector of vectors of
 integers, accessible through the [`preimage`](@ref) function. The backward map
 is called the *index*. If it is not supplied through the keyword argument
 `index`, it is computed when the object is constructed.
@@ -220,7 +219,7 @@ function IndexedFinFunction(f::AbstractVector{Int}, codom; index=nothing)
   if isnothing(index)
     index = [ Int[] for j in codom ]
     for (i, j) in enumerate(f)
-      insertsorted!(index[j], i)
+      push!(index[j], i)
     end
   elseif length(index) != length(codom)
     error("Index length $(length(index)) does not match codomain $codom")

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -51,8 +51,12 @@ f = FinFunction([1,3,4], 5)
 # Indexed functions
 ###################
 
+@test !is_indexed(FinFunction([1,3,2]))
+@test !is_indexed(FinDomFunction([:a,:c,:b]))
+
+# Indexed functions between finite sets.
 f = IndexedFinFunction([1,2,1,3], 5)
-@test f isa FinFunction{Int,Int}
+@test is_indexed(f)
 @test force(f) === f
 @test (dom(f), codom(f)) == (FinSet(4), FinSet(5))
 @test f(1) == 1
@@ -63,8 +67,12 @@ f = IndexedFinFunction([1,2,1,3], 5)
 g = FinFunction(5:-1:1)
 @test compose(f,g) == FinFunction([5,4,5,3])
 
+@test is_indexed(id(FinSet(3)))
+@test preimage(id(FinSet(3)), 2) == [2]
+
+# Indexed functions out of finite sets.
 k = IndexedFinDomFunction([:a,:b,:a,:c])
-@test k isa FinDomFunction{Int}
+@test is_indexed(k)
 @test (dom(k), codom(k)) == (FinSet(4), TypeSet(Symbol))
 @test k(1) == :a
 @test preimage(k, :a) == [1,3]

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -180,13 +180,11 @@ tuples(lim::AbstractLimit) =
   sort!([ Tuple(map(π -> π(i), legs(lim))) for i in ob(lim) ])
 
 f, g = FinFunction([3,1,1,5,2],5), FinFunction([4,1,1,3,2],5)
-lim = pullback(f, g, alg=NestedLoopJoin())
-@test ob(lim) == FinSet(6)
-@test tuples(lim) == [(1,4), (2,2), (2,3), (3,2), (3,3), (5,5)]
-
-lim = pullback(f, g, alg=SortMergeJoin())
-@test ob(lim) == FinSet(6)
-@test tuples(lim) == [(1,4), (2,2), (2,3), (3,2), (3,3), (5,5)]
+for Alg in (NestedLoopJoin, SortMergeJoin, HashJoin)
+  lim = pullback(f, g, alg=Alg())
+  @test ob(lim) == FinSet(6)
+  @test tuples(lim) == [(1,4), (2,2), (2,3), (3,2), (3,3), (5,5)]
+end
 
 # General limits
 #---------------

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -10,8 +10,8 @@ using Catlab.CategoricalAlgebra.Sets, Catlab.CategoricalAlgebra.FinSets
 f = FinFunction([1,3,4], 5)
 g = FinFunction([1,1,2,2,3], 3)
 h = FinFunction([3,1,2], 3)
-@test dom(f) == FinSet(3)
-@test codom(f) == FinSet(5)
+@test (dom(f), codom(f)) == (FinSet(3), FinSet(5))
+@test force(f) === f
 @test codom(FinFunction([1,3,4])) == FinSet(4)
 
 # Evaluation.
@@ -20,13 +20,6 @@ rot3(x) = (x % 3) + 1
 @test map(FinFunction(rot3, 3, 3), 1:3) == [2,3,1]
 @test map(id(FinSet(3)), 1:3) == [1,2,3]
 
-# Pretty-print.
-@test sprint(show, FinSet(3)) == "FinSet(3)"
-@test sprint(show, f) == "FinFunction($([1,3,4]), 3, 5)"
-@test sprint(show, FinFunction(rot3, 3, 3)) ==
-  "FinFunction(rot3, FinSet(3), FinSet(3))"
-@test sprint(show, id(FinSet(3))) == "FinFunction(identity, FinSet(3))"
-
 # Composition.
 @test compose(f,g) == FinFunction([1,2,2], 3)
 @test compose(g,h) == FinFunction([3,3,1,1,2], 3)
@@ -34,28 +27,12 @@ rot3(x) = (x % 3) + 1
 @test compose(id(dom(f)), f) == f
 @test compose(f, id(codom(f))) == f
 
-# Functions out of finite sets
-##############################
+# Indexing.
+@test !is_indexed(f)
+@test is_indexed(id(FinSet(3)))
+@test preimage(id(FinSet(3)), 2) == [2]
 
-k = FinDomFunction([:a,:b,:c,:d,:e])
-@test dom(k) == FinSet(5)
-@test codom(k) == TypeSet(Symbol)
-@test k(3) == :c
-@test collect(k) == [:a,:b,:c,:d,:e]
-@test sprint(show, k) ==
-  "FinDomFunction($([:a,:b,:c,:d,:e]), FinSet(5), TypeSet(Symbol))"
-
-f = FinFunction([1,3,4], 5)
-@test compose(f,k) == FinDomFunction([:a,:c,:d])
-
-# Indexed functions
-###################
-
-@test !is_indexed(FinFunction([1,3,2]))
-@test !is_indexed(FinDomFunction([:a,:c,:b]))
-
-# Indexed functions between finite sets.
-f = IndexedFinFunction([1,2,1,3], 5)
+f = FinFunction([1,2,1,3], 5, index=true)
 @test is_indexed(f)
 @test force(f) === f
 @test (dom(f), codom(f)) == (FinSet(4), FinSet(5))
@@ -67,17 +44,40 @@ f = IndexedFinFunction([1,2,1,3], 5)
 g = FinFunction(5:-1:1)
 @test compose(f,g) == FinFunction([5,4,5,3])
 
-@test is_indexed(id(FinSet(3)))
-@test preimage(id(FinSet(3)), 2) == [2]
+# Pretty-print.
+sshow(args...) = sprint(show, args...)
+@test sshow(FinSet(3)) == "FinSet(3)"
+@test sshow(FinFunction(rot3, 3, 3)) ==
+  "FinFunction(rot3, FinSet(3), FinSet(3))"
+@test sshow(id(FinSet(3))) == "FinFunction(identity, FinSet(3))"
+@test sshow(FinFunction([1,3,4], 5)) == "FinFunction($([1,3,4]), 3, 5)"
+@test sshow(FinFunction([1,3,4], 5, index=true)) ==
+  "FinFunction($([1,3,4]), 3, 5, index=true)"
 
-# Indexed functions out of finite sets.
-k = IndexedFinDomFunction([:a,:b,:a,:c])
+# Functions out of finite sets
+##############################
+
+k = FinDomFunction([:a,:b,:c,:d,:e])
+@test (dom(k), codom(k)) == (FinSet(5), TypeSet(Symbol))
+@test k(3) == :c
+@test collect(k) == [:a,:b,:c,:d,:e]
+@test sshow(k) ==
+  "FinDomFunction($([:a,:b,:c,:d,:e]), FinSet(5), TypeSet(Symbol))"
+
+f = FinFunction([1,3,4], 5)
+@test compose(f,k) == FinDomFunction([:a,:c,:d])
+
+# Indexing.
+@test !is_indexed(k)
+k = FinDomFunction([:a,:b,:a,:c], index=true)
 @test is_indexed(k)
 @test (dom(k), codom(k)) == (FinSet(4), TypeSet(Symbol))
 @test k(1) == :a
 @test preimage(k, :a) == [1,3]
 @test preimage(k, :c) == [4]
 @test isempty(preimage(k, :d))
+@test sshow(k) ==
+  "FinDomFunction($([:a,:b,:a,:c]), FinSet(4), TypeSet(Symbol), index=true)"
 
 f = FinFunction([1,3,2], 4)
 @test compose(f,k) == FinDomFunction([:a,:a,:b])

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -12,6 +12,7 @@ g = FinFunction([1,1,2,2,3], 3)
 h = FinFunction([3,1,2], 3)
 @test dom(f) == FinSet(3)
 @test codom(f) == FinSet(5)
+@test codom(FinFunction([1,3,4])) == FinSet(4)
 
 # Evaluation.
 rot3(x) = (x % 3) + 1
@@ -36,17 +37,16 @@ rot3(x) = (x % 3) + 1
 # Functions out of finite sets
 ##############################
 
-SymbolSet = TypeSet{Symbol}()
-k = FinDomFunction([:a,:b,:c,:d,:e], SymbolSet)
+k = FinDomFunction([:a,:b,:c,:d,:e])
 @test dom(k) == FinSet(5)
-@test codom(k) == SymbolSet
+@test codom(k) == TypeSet(Symbol)
 @test k(3) == :c
 @test collect(k) == [:a,:b,:c,:d,:e]
 @test sprint(show, k) ==
   "FinDomFunction($([:a,:b,:c,:d,:e]), FinSet(5), TypeSet(Symbol))"
 
 f = FinFunction([1,3,4], 5)
-@test compose(f,k) == FinDomFunction([:a,:c,:d], SymbolSet)
+@test compose(f,k) == FinDomFunction([:a,:c,:d])
 
 # Limits
 ########
@@ -106,8 +106,8 @@ eq = equalizer(f,g)
 @test factorize(eq, FinFunction(Int[])) == FinFunction(Int[])
 
 # Equalizer of functions into non-finite set.
-f = FinDomFunction([:a, :b, :d, :c], TypeSet(Symbol))
-g = FinDomFunction([:c, :b, :d, :a], TypeSet(Symbol))
+f = FinDomFunction([:a, :b, :d, :c])
+g = FinDomFunction([:c, :b, :d, :a])
 eq = equalizer(f,g)
 @test incl(eq) == FinFunction([2,3], 4)
 
@@ -134,8 +134,8 @@ f, g = FinFunction([1,1,2]), FinFunction([3,2,1])
 @test force(pair(lim,f,g) ⋅ proj2(lim)) == g
 
 # Pullback of a cospan into non-finite set.
-f = FinDomFunction([:a, :a, :c, :b], TypeSet(Symbol))
-g = FinDomFunction([:a, :a, :d, :b], TypeSet(Symbol))
+f = FinDomFunction([:a, :a, :c, :b])
+g = FinDomFunction([:a, :a, :d, :b])
 π1, π2 = lim = pullback(f, g)
 @test ob(lim) == FinSet(5)
 @test force(π1) == FinFunction([1,2,1,2,4], 4)

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -48,6 +48,32 @@ k = FinDomFunction([:a,:b,:c,:d,:e])
 f = FinFunction([1,3,4], 5)
 @test compose(f,k) == FinDomFunction([:a,:c,:d])
 
+# Indexed functions
+###################
+
+f = IndexedFinFunction([1,2,1,3], 5)
+@test f isa FinFunction{Int,Int}
+@test force(f) === f
+@test (dom(f), codom(f)) == (FinSet(4), FinSet(5))
+@test f(1) == 1
+@test preimage(f, 1) == [1,3]
+@test preimage(f, 3) == [4]
+@test isempty(preimage(f, 4))
+
+g = FinFunction(5:-1:1)
+@test compose(f,g) == FinFunction([5,4,5,3])
+
+k = IndexedFinDomFunction([:a,:b,:a,:c])
+@test k isa FinDomFunction{Int}
+@test (dom(k), codom(k)) == (FinSet(4), TypeSet(Symbol))
+@test k(1) == :a
+@test preimage(k, :a) == [1,3]
+@test preimage(k, :c) == [4]
+@test isempty(preimage(k, :d))
+
+f = FinFunction([1,3,2], 4)
+@test compose(f,k) == FinDomFunction([:a,:a,:b])
+
 # Limits
 ########
 


### PR DESCRIPTION
This PR:

- Add types for `FinFunction`s and `FinDomFunction`s with indices, so that preimages can be efficiently computed
- Implements the hash join algorithm for binary pullbacks/two-way joins
- Adds benchmarks for three pullback/join algorithms we now support, namely nested loop joins, sort-merge joins, and hash joins

As expected by their asymptotic complexity, both the sort-merge join and hash join are *way* faster than the naive algorithm, the nested loop join. At least in these benchmarks, the hash join is generally a bit faster than the sort-merge join. Note that this includes the time for computing the indices; when used with the pre-indexed functions coming from C-sets, the performance of hash joins should be even better.