### PR TITLE
Support for constants in conjunctive queries on ACSets

### DIFF
--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -5,6 +5,7 @@ export FinSet, FinFunction, FinDomFunction, force, is_indexed, preimage,
   JoinAlgorithm, NestedLoopJoin, SortMergeJoin, HashJoin
 
 using Compat: isnothing, only
+using Reexport
 
 using AutoHashEquals
 using DataStructures: OrderedDict, IntDisjointSets, union!, find_root!
@@ -12,8 +13,8 @@ using FunctionWrappers: FunctionWrapper
 import StaticArrays
 using StaticArrays: StaticVector, SVector, SizedVector
 
-using ...Theories, ...CSetDataStructures, ...Graphs, ..FreeDiagrams,
-  ..Limits, ..Sets
+@reexport using ..Sets
+using ...Theories, ...CSetDataStructures, ...Graphs, ..FreeDiagrams, ..Limits
 import ...Theories: dom, codom
 import ..Limits: limit, colimit, universal
 using ..Sets: SetFunctionCallable, SetFunctionIdentity

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -251,7 +251,7 @@ end
 
 function universal(lim::Terminal{<:FinSet{Int}},
                    cone::SMultispan{0,<:FinSet{Int}})
-  FinFunction(ones(Int, length(apex(cone))))
+  ConstantFunction(1, apex(cone), FinSet(1))
 end
 
 function limit(Xs::ObjectPair{<:FinSet{Int}})

--- a/src/categorical_algebra/Sets.jl
+++ b/src/categorical_algebra/Sets.jl
@@ -180,7 +180,7 @@ limit(Xs::EmptyDiagram{<:TypeSet}) =
   Limit(Xs, SMultispan{0}(TypeSet(Nothing)))
 
 universal(lim::Terminal{TypeSet{Nothing}}, span::SMultispan{0,<:SetOb}) =
-  SetFunction(x -> nothing, apex(span), ob(lim))
+  ConstantFunction(nothing, apex(span), ob(lim))
 
 function limit(Xs::ObjectPair{<:TypeSet})
   X1, X2 = Xs

--- a/src/wiring_diagrams/Algebras.jl
+++ b/src/wiring_diagrams/Algebras.jl
@@ -6,8 +6,7 @@ export oapply, query
 using Compat: isnothing
 import TypedTables
 
-using ...Theories, ...CategoricalAlgebra,
-  ...CategoricalAlgebra.Sets, ...CategoricalAlgebra.FinSets
+using ...Theories, ...CategoricalAlgebra, ...CategoricalAlgebra.FinSets
 using ...CSetDataStructures: make_table
 using ..UndirectedWiringDiagrams
 

--- a/src/wiring_diagrams/Algebras.jl
+++ b/src/wiring_diagrams/Algebras.jl
@@ -132,11 +132,12 @@ The query is a undirected wiring diagram whose boxes and ports are assumed to be
 named through attributes `:name` and `:port_name`/`:outer_port_name`. To define
 such a diagram, use the named form of the [`@relation`](@ref) macro.
 
-This function is a thin wrapper around the [`oapply`](@ref) method for
+This function straightforwardly wraps the [`oapply`](@ref) method for
 multispans, which implements the UWD algebra of multispans.
 """
-function query(X::AbstractACSet, diagram::UndirectedWiringDiagram;
-               table_type::Type=TypedTables.Table)
+function query(X::AbstractACSet, diagram::UndirectedWiringDiagram,
+               params=NamedTuple(); table_type::Type=TypedTables.Table)
+  # For each box in the diagram, extract span from ACSet.
   spans = map(boxes(diagram), subpart(diagram, :name)) do b, name
     apex = FinSet(nparts(X, name))
     legs = map(subpart(diagram, ports(diagram, b), :port_name)) do port_name
@@ -144,6 +145,19 @@ function query(X::AbstractACSet, diagram::UndirectedWiringDiagram;
     end
     Multispan(apex, legs)
   end
+
+  # Add an extra box and corresponding span for each parameter.
+  if !isempty(params)
+    diagram = copy(diagram)
+    spans = vcat(spans, map(collect(pairs(params))) do (var, value)
+      box = add_part!(diagram, :Box, name=:_const)
+      add_part!(diagram, :Port, port_name=:_value,
+                box=box, junction=incident(diagram, var, :variable))
+      SMultispan{1}(ConstantFunction(value, FinSet(1)))
+    end)
+  end
+
+  # Call `oapply` and make a table out of the resulting span.
   outer_names = subpart(diagram, :outer_port_name)
   outer_span = oapply(diagram, spans, Ob=SetOb, Hom=FinDomFunction{Int})
   table = NamedTuple{Tuple(outer_names)}(Tuple(map(collect, outer_span)))

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -72,7 +72,8 @@ term = Graph(1)
 add_edge!(term, 1, 1)
 lim = terminal(Graph)
 @test ob(lim) == term
-@test delete(lim, g) == CSetTransformation((V=fill(1,4), E=fill(1,3)), g, term)
+@test force(delete(lim, g)) ==
+  CSetTransformation((V=fill(1,4), E=fill(1,3)), g, term)
 
 # Products in Graph: unitality.
 lim = product(g, term)

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -2,7 +2,7 @@ module TestCSets
 using Test
 
 using Catlab, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra,
-  Catlab.CategoricalAlgebra.Sets, Catlab.CategoricalAlgebra.FinSets
+  Catlab.CategoricalAlgebra.FinSets
 using Catlab.Graphs.BasicGraphs: TheoryGraph
 
 # FinSets interop

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -2,7 +2,7 @@ module TestFinSets
 using Test
 
 using Catlab.Theories, Catlab.CategoricalAlgebra
-using Catlab.CategoricalAlgebra.Sets, Catlab.CategoricalAlgebra.FinSets
+using Catlab.CategoricalAlgebra.FinSets
 
 # Functions between finite sets
 ###############################

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -95,8 +95,9 @@ f = FinFunction([1,3,2], 4)
 #---------
 
 # Terminal object.
-@test ob(terminal(FinSet{Int})) == FinSet(1)
-@test delete(terminal(FinSet{Int}), FinSet(3)) == FinFunction([1,1,1])
+I = terminal(FinSet{Int})
+@test ob(I) == FinSet(1)
+@test force(delete(I, FinSet(3))) == FinFunction([1,1,1])
 
 # Binary product.
 lim = product(FinSet(2), FinSet(3))

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -69,6 +69,7 @@ f = FinFunction([1,3,4], 5)
 
 # Indexing.
 @test !is_indexed(k)
+@test preimage(k, :c) == [3]
 
 k = FinDomFunction(5:10)
 @test is_indexed(k)
@@ -203,6 +204,12 @@ for Alg in (NestedLoopJoin, SortMergeJoin, HashJoin)
   @test ob(lim) == FinSet(6)
   @test tuples(lim) == reference_tuples
 end
+
+# Pullback involving a constant, which should be handled specially.
+lim = pullback(FinFunction([3], 4), FinFunction([1,3,4,2,3,3]), alg=SmartJoin())
+@test ob(lim)== FinSet(3)
+@test proj1(lim) == ConstantFunction(1, FinSet(3), FinSet(1))
+@test proj2(lim) == FinFunction([2,5,6], 6)
 
 # General limits
 #---------------

--- a/test/categorical_algebra/Sets.jl
+++ b/test/categorical_algebra/Sets.jl
@@ -13,6 +13,12 @@ g = SetFunction(x -> 3x, TypeSet(Int), TypeSet(Int))
 @test codom(f) == TypeSet(Int)
 @test f(1) == 2
 
+# Constants.
+c = ConstantFunction("foo", TypeSet(Int))
+@test dom(c) == TypeSet(Int)
+@test codom(c) == TypeSet(String)
+@test c(1) == "foo"
+
 # Identities.
 X = TypeSet(Int)
 @test dom(id(X)) == X
@@ -24,6 +30,11 @@ h = compose(f,g)
 @test h(1) == 6
 @test compose(id(dom(f)), f) == f
 @test compose(f, id(codom(f))) == f
+
+c = ConstantFunction(5, TypeSet(Int))
+@test compose(c, f) == ConstantFunction(f(5), TypeSet(Int))
+@test compose(f, c) == c
+@test compose(c, c) == c
 
 # Predicated sets
 #################


### PR DESCRIPTION
Sequel to #358 that allows parameters to be set in conjunctive queries of ACSets. By "parameter" I mean a constant value assigned to a junction in the query diagram. Like the rest of the query functionality, this is handled through general machinery for limits of finite-domain functions.