### PR TITLE
Implement DWDs using ACSets, v2

### DIFF
--- a/src/graphics/GraphvizGraphs.jl
+++ b/src/graphics/GraphvizGraphs.jl
@@ -38,10 +38,8 @@ function parse_graphviz(doc::AbstractDict)::AbstractPropertyGraph
     props = Dict{Symbol,Any}(
       Symbol(k) => node[k] for k in node_keys if haskey(node, k))
     props[:position] = parse_point(node["pos"])
-    props[:size] = 72*SVector(
-      parse(Float64, node["width"]),
-      parse(Float64, node["height"])
-    )
+    props[:size] = 72*SVector(parse(Float64, node["width"]),
+                              parse(Float64, node["height"]))
     add_vertex!(graph, props)
   end
 

--- a/src/graphics/WiringDiagramLayouts.jl
+++ b/src/graphics/WiringDiagramLayouts.jl
@@ -472,10 +472,11 @@ end
 """
 function layout_outer_ports!(diagram::WiringDiagram, opts::LayoutOptions; kw...)
   original_value = x -> x isa PortLayout ? x.value : x # XXX: This is ugly.
-  diagram.input_ports = map(original_value, input_ports(diagram))
-  diagram.output_ports = map(original_value, output_ports(diagram))
-  diagram.input_ports, diagram.output_ports =
-    layout_outer_ports(diagram, opts; kw...)
+  set_input_ports!(diagram, map(original_value, input_ports(diagram)))
+  set_output_ports!(diagram, map(original_value, output_ports(diagram)))
+  in_ports, out_ports = layout_outer_ports(diagram, opts; kw...)
+  set_input_ports!(diagram, in_ports)
+  set_output_ports!(diagram, out_ports)
   diagram
 end
 

--- a/src/graphics/YFilesWiringDiagrams.jl
+++ b/src/graphics/YFilesWiringDiagrams.jl
@@ -99,12 +99,12 @@ function parse_yfiles_diagram(BoxValue::Type, WireValue::Type, xdoc::XMLDocument
     box_layout = if pop!(vprops(graph, v), :input, false)
       # Special case: diagram inputs.
       ports, coord_map = infer_output_ports(graph, v)
-      diagram.input_ports = ports
+      add_input_ports!(diagram, ports)
       BoxLayout(input_id(diagram), Dict(), coord_map)
     elseif pop!(vprops(graph, v), :output, false)
       # Special case: diagram outputs.
       ports, coord_map = infer_input_ports(graph, v)
-      diagram.output_ports = ports
+      add_output_ports!(diagram, ports)
       BoxLayout(output_id(diagram), coord_map, Dict())
     else
       # Generic case: a box.
@@ -116,7 +116,7 @@ function parse_yfiles_diagram(BoxValue::Type, WireValue::Type, xdoc::XMLDocument
     end
     push!(boxes, box_layout)
   end
-  
+
   # Add wires to diagram.
   for edge in edges(graph)
     wire_data = eprops(graph, edge)

--- a/src/programs/ParseJuliaPrograms.jl
+++ b/src/programs/ParseJuliaPrograms.jl
@@ -97,10 +97,10 @@ function parse_wiring_diagram(pres::Presentation, call::Expr0, body::Expr)::Wiri
 
   # Add outgoing wires for return values.
   out_ports = normalize_arguments((value,))
-  diagram.output_ports = [
+  add_output_ports!(diagram, [
     # XXX: Inferring the output port types is not reliable.
     port_value(diagram, first(ports)) for ports in out_ports
-  ]
+  ])
   add_wires!(diagram, [
     port => Port(v_out, InputPort, i)
     for (i, ports) in enumerate(out_ports) for port in ports

--- a/src/wiring_diagrams/Algorithms.jl
+++ b/src/wiring_diagrams/Algorithms.jl
@@ -19,7 +19,7 @@ import ..DirectedWiringDiagrams: set_box
 Returns a list of box IDs, excluding the outer box's input and output IDs.
 """
 function topological_sort(d::WiringDiagram)::AbstractVector{Int}
-  topological_sort(internal_graph(d; id_only = true))
+  topological_sort(internal_graph(d))
 end
 
 # Normalization
@@ -135,9 +135,9 @@ wires. Typical choices are:
 In both cases, this algorithm has the property that if there is a permutation
 with no crossings, it will find it.
 """
-function crossing_minimization_by_sort(d::WiringDiagram, vs::Vector{Int};
-    sources::Vector{Int}=Int[], targets::Vector{Int}=Int[],
-    statistic::Function=mean)::Vector{Int}
+function crossing_minimization_by_sort(d::WiringDiagram, vs::AbstractVector{Int};
+    sources::AbstractVector{Int}=Int[], targets::AbstractVector{Int}=Int[],
+    statistic::Function=mean)::AbstractVector{Int}
   @assert allunique(vs) && allunique(sources) && allunique(targets)
   if isempty(sources) && isempty(targets)
     # Degenerate case: nothing to sort, so preserve original order.
@@ -160,7 +160,7 @@ end
 
 """ Make function mapping ports to logical coordinates.
 """
-function port_coords(d::WiringDiagram, vs::Vector{Int}, kind::PortKind)
+function port_coords(d::WiringDiagram, vs::AbstractVector{Int}, kind::PortKind)
   get_ports = kind == InputPort ? input_ports : output_ports
   index = Dict(vs[i] => i for i in eachindex(vs))
   sizes = [ length(get_ports(d,v)) for v in vs ]

--- a/src/wiring_diagrams/Algorithms.jl
+++ b/src/wiring_diagrams/Algorithms.jl
@@ -19,7 +19,7 @@ import ..DirectedWiringDiagrams: set_box
 Returns a list of box IDs, excluding the outer box's input and output IDs.
 """
 function topological_sort(d::WiringDiagram)::AbstractVector{Int}
-  filter(v -> v ∉ outer_ids(d), topological_sort(graph(d)))
+  topological_sort(internal_graph(d; id_only = true))
 end
 
 # Normalization
@@ -49,7 +49,7 @@ The main difference is the possibility of zero or many function outputs.
 """
 function normalize_copy!(d::WiringDiagram)
   # Compute equivalence classes of boxes (without modifying the diagram).
-  sets = IntDisjointSets(nboxes(d)+2)
+  sets = DisjointSets{Int}(vcat([input_id(d),output_id(d)], box_ids(d)))
   initial = filter(box_ids(d)) do v
     all(u == input_id(d) for u in inneighbors(d,v))
   end
@@ -74,7 +74,7 @@ function normalize_copy!(d::WiringDiagram)
   d
 end
 
-function merge_if_congruent!(d::WiringDiagram, sets::IntDisjointSets, v1::Int, v2::Int)
+function merge_if_congruent!(d::WiringDiagram, sets::DisjointSets{Int}, v1::Int, v2::Int)
   if v1 == v2 || (!in_same_set(sets, v1, v2) && is_congruent(d, sets, v1, v2))
     union!(sets, v1, v2)
     for out1 in filter(v -> v != output_id(d), outneighbors(d, v1))
@@ -85,7 +85,7 @@ function merge_if_congruent!(d::WiringDiagram, sets::IntDisjointSets, v1::Int, v
   end
 end
 
-function is_congruent(d::WiringDiagram, sets::IntDisjointSets, v1::Int, v2::Int)::Bool
+function is_congruent(d::WiringDiagram, sets::DisjointSets{Int}, v1::Int, v2::Int)::Bool
   box(d, v1) == box(d, v2) && all(eachindex(input_ports(box(d,v1)))) do port
     wires1, wires2 = in_wires(d,v1,port), in_wires(d,v2,port)
     n1, n2 = length(wires1), length(wires2)
@@ -110,7 +110,7 @@ function normalize_delete!(d::WiringDiagram)
       push!(unused, v)
     end
   end
-  rem_boxes!(d, unused)
+  rem_boxes!(d, sort(collect(unused)))
   d
 end
 

--- a/src/wiring_diagrams/Expressions.jl
+++ b/src/wiring_diagrams/Expressions.jl
@@ -19,16 +19,15 @@ using ...Syntax: syntax_module
 using ...Graphs, ..DirectedWiringDiagrams, ..UndirectedWiringDiagrams,
   ..MonoidalDirectedWiringDiagrams, ..MonoidalUndirectedWiringDiagrams
 using ..WiringDiagramAlgorithms: crossing_minimization_by_sort
-using ..DirectedWiringDiagrams: WiringDiagramGraphUnionAll
+using ..DirectedWiringDiagrams: WiringDiagramGraph
 
 
 function graph_with_outer_ids(d::WiringDiagram)
-  g = graph(d; id_only = true)
+  g = graph(d)
   return g, incident(g, input_id(d), :box)[1], incident(g, output_id(d), :box)[1]
 end
 
-box_id(g::WiringDiagramGraphUnionAll{Int,Int}, v::Int) = subpart(g, v, :box)
-box_id(g::WiringDiagramGraphUnionAll{Int, Int}, vs::Array{Int}) = copy(subpart(g, vs, :box))
+box_id(g::WiringDiagramGraph, v) = subpart(g, v, :box)
 
 # Expression -> Diagram
 #######################
@@ -84,7 +83,8 @@ function to_hom_expr(Ob::Type, Hom::Type, d::WiringDiagram)
 
   # Initial reduction: Add junction nodes to ensure any wiring layer between two
   # boxes is a permutation.
-  d = add_junctions(d)
+  #d = add_junctions(d) XXX: This core dumps on Julia 1.0?!
+  d = add_junctions!(copy(d))
 
   # Dispatch special case: no boxes.
   if nboxes(d) == 0

--- a/src/wiring_diagrams/GraphML.jl
+++ b/src/wiring_diagrams/GraphML.jl
@@ -24,7 +24,6 @@ using LightXML
 
 using ...Graphs
 using ..DirectedWiringDiagrams, ..WiringDiagramSerialization
-import ..DirectedWiringDiagrams: PortData
 
 # Data types
 ############
@@ -50,6 +49,8 @@ struct ReadState
   PortValue::Type
   WireValue::Type
 end
+
+const PortData = NamedTuple{(:kind,:port),Tuple{PortKind,Int}}
 
 # Serialization
 ###############
@@ -293,10 +294,10 @@ function parse_graphml_ports(state::ReadState, xnode::XMLElement)
     value = convert_from_graphml_data(state.PortValue, data)
     if port_kind == "input"
       push!(input_ports, value)
-      ports[(xnode_id, xport_name)] = PortData(InputPort, length(input_ports))
+      ports[(xnode_id, xport_name)] = (kind=InputPort, port=length(input_ports))
     elseif port_kind == "output"
       push!(output_ports, value)
-      ports[(xnode_id, xport_name)] = PortData(OutputPort, length(output_ports))
+      ports[(xnode_id, xport_name)] = (kind=OutputPort, port=length(output_ports))
     else
       error("Invalid port kind: $portkind")
     end

--- a/src/wiring_diagrams/JSON.jl
+++ b/src/wiring_diagrams/JSON.jl
@@ -22,9 +22,9 @@ using DataStructures: OrderedDict
 import JSON
 
 using ..DirectedWiringDiagrams, ..WiringDiagramSerialization
-import ..DirectedWiringDiagrams: PortData
 
 const JSONObject = OrderedDict{String,Any}
+const PortData = NamedTuple{(:kind,:port),Tuple{PortKind,Int}}
 
 # Serialization
 ###############
@@ -176,10 +176,10 @@ function parse_json_ports(PortValue::Type, node::AbstractDict)
     value = parse_json_graph_data(PortValue, port)
     if port_kind == "input"
       push!(input_ports, value)
-      ports[(node_id, port_id)] = PortData(InputPort, length(input_ports))
+      ports[(node_id, port_id)] = (kind=InputPort, port=length(input_ports))
     elseif port_kind == "output"
       push!(output_ports, value)
-      ports[(node_id, port_id)] = PortData(OutputPort, length(output_ports))
+      ports[(node_id, port_id)] = (kind=OutputPort, port=length(output_ports))
     else
       error("Invalid port kind: $portkind")
     end

--- a/src/wiring_diagrams/MonoidalDirected.jl
+++ b/src/wiring_diagrams/MonoidalDirected.jl
@@ -21,7 +21,7 @@ import ...Theories: dom, codom, id, compose, ⋅, ∘,
 import ...Syntax: functor, head
 using ...CSetDataStructures, ...Graphs
 using ..DirectedWiringDiagrams
-import ..DirectedWiringDiagrams: Box, WiringDiagram, input_ports, output_ports
+import ..DirectedWiringDiagrams: Box, WiringDiagram, input_ports, output_ports, value
 import ..UndirectedWiringDiagrams: add_junctions!, junction_diagram
 
 # Categorical interface
@@ -373,11 +373,14 @@ struct Junction{Op,Value} <: AbstractBox
   output_ports::Vector
   Junction{Op}(value::Value, inputs::Vector, outputs::Vector) where {Op,Value} =
     new{Op,Value}(value, inputs, outputs)
+  Junction{Op, Value}(value::Value, inputs::Vector, outputs::Vector) where {Op,Value} =
+    new{Op,Value}(value, inputs, outputs)
 end
 
 Junction(args...) = Junction{nothing}(args...)
-Junction{Op}(value, ninputs::Int, noutputs::Int) where Op =
+Junction{Op}(value, ninputs::Int, noutputs::Int) where Op = 
   Junction{Op}(value, repeat([value], ninputs), repeat([value], noutputs))
+Junction{Op, Value}(box::Box) where {Op,Value}= Junction{Op, Value}(value(box), input_ports(box), output_ports(box))
 
 head(junction::Junction{Op}) where Op = Op
 
@@ -508,18 +511,20 @@ end
 """ Merge adjacent junction nodes into single junctions.
 """
 function merge_junctions(d::WiringDiagram; op=nothing)
-  g = graph(d)
-  junction_vs = filter(v -> box(d,v) isa Junction{op}, vertices(g))
-  junction_es = filter(edges(g)) do e
-    s, t = box(d, src(g, e)), box(d, tgt(g, e))
-    s isa Junction{op} && t isa Junction{op} && s.value == t.value
+  junction_graph = Graph(nparts(d.diagram, :Box))
+  for w in parts(d.diagram, :Wire)
+    src_box = subpart(d.diagram, w, [:src, :out_port_box])
+    tgt_box = subpart(d.diagram, w, [:tgt, :in_port_box])
+    if subpart(d.diagram, src_box, :box_type) <: Junction &&
+      subpart(d.diagram, tgt_box, :box_type) <: Junction &&
+      subpart(d.diagram, src_box, :value) == subpart(d.diagram, tgt_box, :value)
+
+      add_edge!(junction_graph, src_box, tgt_box)
+    end
   end
-  junction_graph = Graph()
-  copy_parts!(junction_graph, g, V=junction_vs, E=junction_es)
-  components = [ [junction_vs[v] for v in component]
-    for component in connected_components(junction_graph)
-    if length(component) > 1 ]
-  values = [ box(d, first(component)).value for component in components ]
+
+  components = filter(c -> length(c) > 1, connected_components(junction_graph))
+  values = [ subpart(d.diagram, first(component), :value) for component in components ]
   encapsulate(d, components;
     discard_boxes=true, values=values, make_box=Junction{op})
 end
@@ -547,10 +552,13 @@ Represents unary operations on boxes in wiring diagrams.
 struct BoxOp{op} <: AbstractBox
   box::AbstractBox
 end
+BoxOp{op}(value::Value, inputs::Vector, outputs::Vector) where {op,Value} =
+BoxOp{op}(Box{Value}(value, outputs, inputs))
 
 head(::BoxOp{Op}) where Op = Op
 input_ports(op::BoxOp) = input_ports(op.box)
 output_ports(op::BoxOp) = output_ports(op.box)
+value(op::BoxOp) = value(op.box)
 
 Base.:(==)(op1::BoxOp, op2::BoxOp) =
   head(op1) == head(op2) && op1.box == op2.box
@@ -570,6 +578,8 @@ dual_ports(ports::Ports{T}) where T = Ports{T}(dual_ports(collect(ports)))
 #---------
 
 const DaggerBox = BoxOp{:dagger}
+DaggerBox(value::Value, inputs::Vector, outputs::Vector) where Value =
+  DaggerBox(Box{Value}(value, outputs, inputs))
 
 input_ports(dagger::DaggerBox) = output_ports(dagger.box)
 output_ports(dagger::DaggerBox) = input_ports(dagger.box)
@@ -580,6 +590,8 @@ dagger(junction::Junction{Op}) where Op = Junction{Op}(
   junction.value, output_ports(junction), input_ports(junction))
 
 const MateBox = BoxOp{:mate}
+MateBox(value::Value, inputs::Vector, outputs::Vector) where Value = 
+  MateBox(Box{Value}(value, dual_ports(outputs), dual_ports(inputs)))
 
 input_ports(mate::MateBox) = dual_ports(output_ports(mate.box))
 output_ports(mate::MateBox) = dual_ports(input_ports(mate.box))

--- a/test/wiring_diagrams/Directed.jl
+++ b/test/wiring_diagrams/Directed.jl
@@ -88,8 +88,7 @@ rem_boxes!(d_copy, [fv,gv])
 gr = graph(d)
 @test length(vertices(gr)) == nboxes(d) + 2
 @test length(edges(gr)) == nwires(d)
-@test sort!(subpart(gr, :wire)) == sort!(wires(d))
-@test subpart(gr, :box) == [box(d, b) for b in box_ids(d) ∪ outer_ids(d)]
+@test subpart(gr, :box) == box_ids(d) ∪ outer_ids(d)
 
 @test Set(all_neighbors(d, fv)) == Set([input_id(d), gv])
 @test Set(all_neighbors(d, gv)) == Set([fv, output_id(d)])

--- a/test/wiring_diagrams/Directed.jl
+++ b/test/wiring_diagrams/Directed.jl
@@ -4,6 +4,7 @@ using Test
 using Catlab.WiringDiagrams.DirectedWiringDiagrams
 import Catlab.WiringDiagrams.DirectedWiringDiagrams: validate_ports
 using Catlab.WiringDiagrams.MonoidalDirectedWiringDiagrams: compose
+using Catlab.Graphs, Catlab.CategoricalAlgebra
 
 # For testing purposes, check equality of port symbols.
 function validate_ports(source_port::Symbol, target_port::Symbol)
@@ -84,6 +85,12 @@ rem_boxes!(d_copy, [fv,gv])
 @test nwires(d) == 3
 
 # Graph properties.
+gr = graph(d)
+@test length(vertices(gr)) == nboxes(d) + 2
+@test length(edges(gr)) == nwires(d)
+@test sort!(subpart(gr, :wire)) == sort!(wires(d))
+@test subpart(gr, :box) == [box(d, b) for b in box_ids(d) ∪ outer_ids(d)]
+
 @test Set(all_neighbors(d, fv)) == Set([input_id(d), gv])
 @test Set(all_neighbors(d, gv)) == Set([fv, output_id(d)])
 @test neighbors(d, fv) == [gv]

--- a/test/wiring_diagrams/Directed.jl
+++ b/test/wiring_diagrams/Directed.jl
@@ -4,7 +4,7 @@ using Test
 using Catlab.WiringDiagrams.DirectedWiringDiagrams
 import Catlab.WiringDiagrams.DirectedWiringDiagrams: validate_ports
 using Catlab.WiringDiagrams.MonoidalDirectedWiringDiagrams: compose
-using Catlab.Graphs, Catlab.CategoricalAlgebra
+using Catlab.Graphs, Catlab.CategoricalAlgebra.CSets
 
 # For testing purposes, check equality of port symbols.
 function validate_ports(source_port::Symbol, target_port::Symbol)
@@ -71,12 +71,39 @@ add_wire!(d, (gv,1) => (output_id(d),1))
 @test nwires(d) == 3
 @test has_wire(d, fv, gv)
 @test has_wire(d, (fv,1) => (gv,1))
+@test has_wire(d, input_id(d), fv) && !has_wire(d, input_id(d), gv)
+@test has_wire(d, gv, output_id(d)) && !has_wire(d, fv, output_id(d))
+@test !has_wire(d, input_id(d), output_id(d))
 @test_throws ErrorException add_wire!(d, (gv,1) => (fv,1))
 @test wires(d) == map(Wire, [
   (input_id(d),1) => (fv,1),
   (fv,1) => (gv,1),
   (gv,1) => (output_id(d),1),
 ])
+
+d_orig = copy(d)
+add_wires!(d, [fill((input_id(d),1) => (fv,1), 2);
+               fill((fv,1) => (gv,1), 2);
+               fill((gv,1) => (output_id(d),1), 2)])
+rem_wire!(d, (fv,1) => (gv,1))
+@test nwires(d, fv, gv) == 2
+rem_wires!(d, fv, gv)
+@test nwires(d, fv, gv) == 0
+rem_wire!(d, (input_id(d),1) => (fv,1))
+@test nwires(d, input_id(d), fv) == 2
+rem_wires!(d, input_id(d), fv)
+@test nwires(d, input_id(d), fv) == 0
+rem_wire!(d, (gv,1) => (output_id(d),1))
+@test nwires(d, gv, output_id(d)) == 2
+rem_wires!(d, gv, output_id(d))
+@test nwires(d, gv, output_id(d)) == 0
+d = WiringDiagram(A, A)
+add_wires!(d, fill((input_id(d),1) => (output_id(d),1), 3))
+rem_wire!(d, (input_id(d),1) => (output_id(d),1))
+@test nwires(d, input_id(d), output_id(d)) == 2
+rem_wires!(d, input_id(d), output_id(d))
+@test nwires(d, input_id(d), output_id(d)) == 0
+d = d_orig
 
 # Shallow copies.
 d_copy = copy(d)
@@ -85,16 +112,20 @@ rem_boxes!(d_copy, [fv,gv])
 @test nwires(d) == 3
 
 # Graph properties.
-gr = graph(d)
-@test length(vertices(gr)) == nboxes(d) + 2
-@test length(edges(gr)) == nwires(d)
-@test subpart(gr, :box) == box_ids(d) ∪ outer_ids(d)
+d_graph = graph(d)
+@test length(vertices(d_graph)) == nboxes(d) + 2
+@test length(edges(d_graph)) == nwires(d)
+@test subpart(d_graph, :box) == box_ids(d) ∪ outer_ids(d)
 
 @test Set(all_neighbors(d, fv)) == Set([input_id(d), gv])
 @test Set(all_neighbors(d, gv)) == Set([fv, output_id(d)])
 @test neighbors(d, fv) == [gv]
 @test outneighbors(d, fv) == [gv]
+@test outneighbors(d, input_id(d)) == [fv]
+@test isempty(outneighbors(d, output_id(d)))
 @test inneighbors(d, gv) == [fv]
+@test inneighbors(d, output_id(d)) == [gv]
+@test isempty(inneighbors(d, input_id(d)))
 @test wires(d, input_id(d)) == [ Wire((input_id(d),1) => (fv,1)) ]
 @test wires(d, fv) == map(Wire, [
   ((input_id(d),1) => (fv,1)),
@@ -104,12 +135,6 @@ gr = graph(d)
 @test out_wires(d, Port(fv,OutputPort,1)) == [ Wire((fv,1) => (gv,1)) ]
 @test in_wires(d, gv) == [ Wire((fv,1) => (gv,1)) ]
 @test in_wires(d, Port(gv,InputPort,1)) == [ Wire((fv,1) => (gv,1)) ]
-
-rem_wires!(d, fv, gv)
-@test nwires(d) == 2
-@test !has_wire(d, fv, gv)
-rem_wire!(d, (input_id(d),1) => (fv,1))
-@test wires(d) == [ Wire((gv,1) => (output_id(d),1)) ]
 
 # Induced subgraph.
 d = WiringDiagram(A,D)


### PR DESCRIPTION
Reimplements directed wiring diagrams to be C-sets for suitable schema C. The core imperative interface is unchanged but it's implementation is different.