### PR TITLE
Multi-experiment Regression

### DIFF
--- a/experiments/MultiExperimentRegression/Project.toml
+++ b/experiments/MultiExperimentRegression/Project.toml
@@ -4,5 +4,6 @@ authors = ["Unknown "]
 version = "0.1.0"
 
 [deps]
+AlgebraicPetri = "4f99eebe-17bf-4e98-b6a1-2c4f205a959b"
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"

--- a/experiments/MultiExperimentRegression/Project.toml
+++ b/experiments/MultiExperimentRegression/Project.toml
@@ -6,4 +6,8 @@ version = "0.1.0"
 [deps]
 AlgebraicPetri = "4f99eebe-17bf-4e98-b6a1-2c4f205a959b"
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+MCMCChains = "c7f686f2-ff18-58e9-bc7b-31028e88f75d"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+StatsPlots = "f3b207a7-027a-5e70-b257-86293d7955fd"
 Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"

--- a/experiments/MultiExperimentRegression/Project.toml
+++ b/experiments/MultiExperimentRegression/Project.toml
@@ -1,0 +1,8 @@
+name = "MultiExperimentRegression"
+uuid = "901517c1-0af5-43ff-9941-09ced916790a"
+authors = ["Unknown "]
+version = "0.1.0"
+
+[deps]
+Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
+Turing = "fce5fe82-541a-59a6-adf8-730c64b5f9a0"

--- a/experiments/MultiExperimentRegression/src/LVRegression.jl
+++ b/experiments/MultiExperimentRegression/src/LVRegression.jl
@@ -21,4 +21,39 @@ prob1 = ODEProblem(lotka_volterra,u0,(0.0,10.0),p)
 sol = solve(prob1,Tsit5())
 plot(sol)
 
+sol1 = solve(prob1,Tsit5(),saveat=0.1)
+odedata = Array(sol1) + 0.8 * randn(size(Array(sol1)))
+plot(sol1, alpha = 0.3, legend = false); scatter!(sol1.t, odedata')
+
+Turing.setadbackend(:forwarddiff)
+
+@model function fitlv(data, prob1)
+  σ ~ InverseGamma(2, 3) # ~ is the tilde character
+
+  p ~ product_distribution([Uniform(0,5) for i in 1:4])
+  
+  prob = remake(prob1, p=p)
+  predicted = solve(prob,Tsit5(),saveat=0.1)
+
+  for i = 1:length(predicted)
+    data[:,i] ~ MvNormal(predicted[i], σ)
+  end
 end
+
+model = fitlv(odedata, prob1)
+
+# This next command runs 3 independent chains without using multithreading. 
+chain = mapreduce(c -> sample(model, NUTS(.65),1000), chainscat, 1:3)
+
+
+@model function gdemo(x)
+  s ~ InverseGamma(2,3)
+  m ~ Normal(0, sqrt(s))
+
+  for i in eachindex(x)
+    x[i] ~ Normal(m, sqrt(s))
+  end
+end
+
+model = gdemo([missing, missing])
+c = sample(model, HMC(0.01, 5), 500)

--- a/experiments/MultiExperimentRegression/src/LVRegression.jl
+++ b/experiments/MultiExperimentRegression/src/LVRegression.jl
@@ -1,0 +1,24 @@
+module LVRegression
+
+using Turing, Distributions, DifferentialEquations
+
+using MCMCChains, Plots, StatsPlots
+
+using Random
+
+Random.seed!(14);
+
+function lotka_volterra(du,u,p,t)
+  x, y = u
+  α, β, γ, δ  = p
+  du[1] = (α - β*y)x
+  du[2] = (δ*x - γ)y
+end
+
+p = [1.5, 1.0, 3.0, 1.0]
+u0 = [1.0,1.0]
+prob1 = ODEProblem(lotka_volterra,u0,(0.0,10.0),p)
+sol = solve(prob1,Tsit5())
+plot(sol)
+
+end

--- a/experiments/MultiExperimentRegression/src/MultiExperimentRegression.jl
+++ b/experiments/MultiExperimentRegression/src/MultiExperimentRegression.jl
@@ -1,0 +1,29 @@
+module MultiExperimentRegression
+
+using Catlab
+using Catlab.CategoricalAlgebra.FreeDiagrams
+using Turing
+
+const MESpec = Multicospan{FinSet{Int,Int},FinFunction{Int,Int}}
+
+const MEData = Vector{Tuple{Array{Float64,2},Vector{Float64}}}
+
+@model function me_lin_model(a::Float64,b::Float64,spec::MESpec,data::MEData)
+  v ~ InverseGamma(a,b)
+  σ = sqrt(v)
+  M = length(apex(spec))
+  β = Vector{Float64}(undef, M)
+  for i in 1:M
+    β[i] ~ Normal(0,σ)
+  end
+  N = length(legs(spec))
+  for i in 1:N
+    f = legs(spec)[i]
+    (X,y) = data[i]
+    for j in 1:length(y)
+      y[j] ~ Normal(sum(β[f(k)] * x[j,k] for k in dom(f)),σ)
+    end
+  end
+end
+
+end # module

--- a/experiments/MultiExperimentRegression/src/MultiExperimentRegression.jl
+++ b/experiments/MultiExperimentRegression/src/MultiExperimentRegression.jl
@@ -21,7 +21,7 @@ const MEData = Vector{Tuple{Array{Float64,2},Vector{Float64}}}
     f = legs(spec)[i]
     (X,y) = data[i]
     for j in 1:length(y)
-      y[j] ~ Normal(sum(β[f(k)] * x[j,k] for k in dom(f)),σ)
+      y[j] ~ Normal(sum(β[f(k)] * X[j,k] for k in dom(f)),σ)
     end
   end
 end

--- a/experiments/MultiExperimentRegression/src/PetriRegression.jl
+++ b/experiments/MultiExperimentRegression/src/PetriRegression.jl
@@ -1,8 +1,12 @@
 module PetriRegression
 
+using Turing, Distributions, DifferentialEquations
+
+using MCMCChains, Plots, StatsPlots
+
 using AlgebraicPetri
-using Turing
-using DifferentialEquations
+
+using Catlab.CategoricalAlgebra.CSets
 
 struct ReactionData
   dt :: Float64
@@ -14,21 +18,35 @@ end
 
 Turing.setadbackend(:forwarddiff)
 
-@model function fit_rates(net::Petri, data::ReactionData)
+@model function fit_rates(measurements, prob1)
   σ ~ InverseGamma(2,3)
-  vf = vectorfield(net)
-  t0,t1 = 0., size(data.measurements,1) * data.dt
-  p = Vector{Float64}(undef,nt(net))
-  for i in 1:nt(net)
-    p[i] ~ Uniform(data.priors[i]...)
-  end
-  prob = ODEProblem(vf,data.measurements[1,:],(t0,t1),p)
-  predicted = solve(prob,Tsit5(),saveat=data.dt)
+
+  p ~ product_distribution([Uniform(0,10) for i in 1:3])
+
+  prob = remake(prob1,p=p)
+  predicted = solve(prob,Tsit5(),saveat=0.1)
 
   for i = 1:length(predicted)
-    data.measurements[i,:] ~ MvNormal(predicted[i], σ)
+    measurements[:,i] ~ MvNormal(predicted[i], σ)
   end
 end
   
+lv = PetriNet(2,(1,(1,1)),((1,2),(2,2)),(2,()))
+
+u0 = [1.,1.]
+p = [1.,2.,3.]
+prob = ODEProblem(vectorfield(lv),u0,(0.,10.),p)
+sol = solve(prob,Tsit5(),saveat=0.1)
+
+plot(sol)
+
+σ = 0.2
+dt = 0.1
+measurements = Array(sol) + σ * randn(size(Array(sol)))
+plot(sol, alpha=0.5, legend = false); scatter!(sol.t, measurements')
+priors = [(0.,5.),(0.,5.),(0.,5.)]
+
+model = fit_rates(measurements, prob)
+sample(model,HMC(0.1,5),1000)
 
 end

--- a/experiments/MultiExperimentRegression/src/PetriRegression.jl
+++ b/experiments/MultiExperimentRegression/src/PetriRegression.jl
@@ -1,0 +1,12 @@
+module PetriRegression
+
+using AlgebraicPetri
+using Turing
+using DifferentialEquations
+
+struct ReactionData
+  ts :: Vector{Float64}
+  measurements :: Array{Float64,2}
+end
+
+end

--- a/experiments/MultiExperimentRegression/src/PetriRegression.jl
+++ b/experiments/MultiExperimentRegression/src/PetriRegression.jl
@@ -5,8 +5,30 @@ using Turing
 using DifferentialEquations
 
 struct ReactionData
-  ts :: Vector{Float64}
+  dt :: Float64
+  # Measurements of concentrations of each species at each time
   measurements :: Array{Float64,2}
+  # Uniform priors over the rates
+  priors :: Vector{Tuple{Float64,Float64}}
 end
+
+Turing.setadbackend(:forwarddiff)
+
+@model function fit_rates(net::Petri, data::ReactionData)
+  σ ~ InverseGamma(2,3)
+  vf = vectorfield(net)
+  t0,t1 = 0., size(data.measurements,1) * data.dt
+  p = Vector{Float64}(undef,nt(net))
+  for i in 1:nt(net)
+    p[i] ~ Uniform(data.priors[i]...)
+  end
+  prob = ODEProblem(vf,data.measurements[1,:],(t0,t1),p)
+  predicted = solve(prob,Tsit5(),saveat=data.dt)
+
+  for i = 1:length(predicted)
+    data.measurements[i,:] ~ MvNormal(predicted[i], σ)
+  end
+end
+  
 
 end


### PR DESCRIPTION
This is a sketch for doing a single regression across multiple experiments, each of which only test a subset of the parameters.

Currently, we are doing it with linear regression. In principle, we would want to replace the linear regression with regression for the rates of different Petri nets.