### PR TITLE
Command-line switch to disable Literate.jl docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,29 +10,32 @@ using Catlab,
   Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.Graphs,
   Catlab.WiringDiagrams, Catlab.Graphics, Catlab.Programs, Catlab.LinearAlgebra
 
-@info "Building Literate.jl docs"
+const no_literate = "--no-literate" in ARGS
+if !no_literate
+  @info "Building Literate.jl docs"
 
-# XXX: Work around old LaTeX distribution in GitHub CI.
-if haskey(ENV, "GITHUB_ACTIONS")
-  import TikzPictures
-  TikzPictures.standaloneWorkaround(true)
-end
+  # XXX: Work around old LaTeX distribution in GitHub CI.
+  if haskey(ENV, "GITHUB_ACTIONS")
+    import TikzPictures
+    TikzPictures.standaloneWorkaround(true)
+  end
 
-# Set Literate.jl config if not being compiled on recognized service.
-config = Dict{String,String}()
-if !(haskey(ENV, "GITHUB_ACTIONS") || haskey(ENV, "GITLAB_CI"))
-  config["nbviewer_root_url"] = "https://nbviewer.jupyter.org/github/AlgebraicJulia/Catlab.jl/blob/gh-pages/dev"
-  config["repo_root_url"] = "https://github.com/AlgebraicJulia/Catlab.jl/blob/master/docs"
-end
+  # Set Literate.jl config if not being compiled on recognized service.
+  config = Dict{String,String}()
+  if !(haskey(ENV, "GITHUB_ACTIONS") || haskey(ENV, "GITLAB_CI"))
+    config["nbviewer_root_url"] = "https://nbviewer.jupyter.org/github/AlgebraicJulia/Catlab.jl/blob/gh-pages/dev"
+    config["repo_root_url"] = "https://github.com/AlgebraicJulia/Catlab.jl/blob/master/docs"
+  end
 
-for (root, dirs, files) in walkdir(literate_dir)
-  out_dir = joinpath(generated_dir, relpath(root, literate_dir))
-  for file in files
-    if last(splitext(file)) == ".jl"
-      Literate.markdown(joinpath(root, file), out_dir;
-        config=config, documenter=true, credit=false)
-      Literate.notebook(joinpath(root, file), out_dir;
-        execute=true, documenter=true, credit=false)
+  for (root, dirs, files) in walkdir(literate_dir)
+    out_dir = joinpath(generated_dir, relpath(root, literate_dir))
+    for file in files
+      if last(splitext(file)) == ".jl"
+        Literate.markdown(joinpath(root, file), out_dir;
+                          config=config, documenter=true, credit=false)
+        Literate.notebook(joinpath(root, file), out_dir;
+                          execute=true, documenter=true, credit=false)
+      end
     end
   end
 end
@@ -48,7 +51,7 @@ makedocs(
   checkdocs   = :none,
   pages       = Any[
     "Catlab.jl" => "index.md",
-    "Vignettes" => Any[
+    "Vignettes" => no_literate ? [] : Any[
       "Wiring diagrams" => Any[
         "generated/wiring_diagrams/wiring_diagram_basics.md",
         "generated/wiring_diagrams/diagrams_and_expressions.md",


### PR DESCRIPTION
The Literate.jl docs require extra dependencies and take a long time to build, so it is sometimes useful to disable them. Usage:

```
julia --project=docs docs/make.jl --no-literate
```

Closes #396.