### PR TITLE
add theories of co/Presheaf

### DIFF
--- a/src/theories/Category.jl
+++ b/src/theories/Category.jl
@@ -46,11 +46,11 @@ end
   Psh(dom::Ob)::TYPE
 
   # functoriality = covariant action
-  actr(x::Psh(A), f::Hom(A,B))::Psh(B) ⊣ (A::Ob, B::Ob)
+  act(x::Psh(A), f::Hom(A,B))::Psh(B) ⊣ (A::Ob, B::Ob)
 
   # action equations
-  actr(actr(x , f) , g) == actr(x , (f ⋅ g))  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::Psh(A))
-  actr(x , id(A)) == x  ⊣ (A::Ob, x::Psh(A))
+  act(act(x , f) , g) == act(x , (f ⋅ g))  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::Psh(A))
+  act(x , id(A)) == x  ⊣ (A::Ob, x::Psh(A))
 end
 
 @theory Presheaf{Ob,Hom,Psh} <: Category{Ob,Hom} begin
@@ -60,13 +60,12 @@ end
   Psh(codom::Ob)::TYPE
 
   # functoriality = contravariant action
-  actl(f::Hom(A,B), x::Psh(B))::Psh(A) ⊣ (A::Ob, B::Ob)
+  coact(f::Hom(A,B), x::Psh(B))::Psh(A) ⊣ (A::Ob, B::Ob)
 
   # action equations
-  actl(f , actl(g , x)) == actl((f ⋅ g) , x)  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::Psh(C))
-  actl(id(A) , x) == x  ⊣ (A::Ob, x::Psh(A))
+  coact(f , coact(g , x)) == coact((f ⋅ g) , x)  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::Psh(C))
+  coact(id(A) , x) == x  ⊣ (A::Ob, x::Psh(A))
 end
-
 
 # Convenience constructors
 compose(fs::Vector) = foldl(compose, fs)

--- a/src/theories/Category.jl
+++ b/src/theories/Category.jl
@@ -63,9 +63,10 @@ end
   actl(f::Hom(A,B), x::Psh(B))::Psh(A) ⊣ (A::Ob, B::Ob)
 
   # action equations
-  actl(f , actr(g , x)) == actl((f ⋅ g) , x)  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::Psh(C))
+  actl(f , actl(g , x)) == actl((f ⋅ g) , x)  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::Psh(C))
   actl(id(A) , x) == x  ⊣ (A::Ob, x::Psh(A))
 end
+
 
 # Convenience constructors
 compose(fs::Vector) = foldl(compose, fs)

--- a/src/theories/Category.jl
+++ b/src/theories/Category.jl
@@ -39,6 +39,34 @@ We use symbol ⋅ (\\cdot) for diagrammatic composition: f⋅g = compose(f,g).
   id(A) ⋅ f == f ⊣ (A::Ob, B::Ob, f::(A → B))
 end
 
+@theory coPresheaf{Ob,Hom,Psh} <: Category{Ob,Hom} begin
+  # unicode - *decide later*
+
+  # presheaf = object-indexed family
+  Psh(dom::Ob)::TYPE
+
+  # functoriality = covariant action
+  actl(x::Psh(A), f::Hom(A,B))::Psh(B) ⊣ (A::Ob, B::Ob)
+
+  # action equations
+  actl(actl(x , f) , g) == actl(x , (f ⋅ g))  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::Psh(A))
+  actl(x , id(A)) == x  ⊣ (A::Ob, x::Psh(A))
+end
+
+@theory Presheaf{Ob,Hom,Psh} <: Category{Ob,Hom} begin
+  # unicode - *decide later*
+
+  # presheaf = object-indexed family
+  Psh(codom::Ob)::TYPE
+
+  # functoriality = contravariant action
+  actr(x::Psh(B), f::Hom(A,B))::Psh(A) ⊣ (A::Ob, B::Ob)
+
+  # action equations
+  actr(actr(x , f) , g) == actr(x , (f ⋅ g))  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::Psh(C))
+  actr(x , id(A)) == x  ⊣ (A::Ob, x::Psh(A))
+end
+
 # Convenience constructors
 compose(fs::Vector) = foldl(compose, fs)
 compose(f, g, h, fs...) = compose([f, g, h, fs...])

--- a/src/theories/Category.jl
+++ b/src/theories/Category.jl
@@ -39,32 +39,32 @@ We use symbol ⋅ (\\cdot) for diagrammatic composition: f⋅g = compose(f,g).
   id(A) ⋅ f == f ⊣ (A::Ob, B::Ob, f::(A → B))
 end
 
-@theory Copresheaf{Ob,Hom,Psh} <: Category{Ob,Hom} begin
+@theory Copresheaf{Ob,Hom,El} <: Category{Ob,Hom} begin
   # unicode - *decide later*
 
   # presheaf = object-indexed family
-  Psh(dom::Ob)::TYPE
+  El(dom::Ob)::TYPE
 
   # functoriality = covariant action
-  act(x::Psh(A), f::Hom(A,B))::Psh(B) ⊣ (A::Ob, B::Ob)
+  act(x::El(A), f::Hom(A,B))::El(B) ⊣ (A::Ob, B::Ob)
 
   # action equations
-  act(act(x , f) , g) == act(x , (f ⋅ g))  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::Psh(A))
-  act(x , id(A)) == x  ⊣ (A::Ob, x::Psh(A))
+  act(act(x , f) , g) == act(x , (f ⋅ g))  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::El(A))
+  act(x , id(A)) == x  ⊣ (A::Ob, x::El(A))
 end
 
-@theory Presheaf{Ob,Hom,Psh} <: Category{Ob,Hom} begin
+@theory Presheaf{Ob,Hom,El} <: Category{Ob,Hom} begin
   # unicode - *decide later*
 
   # presheaf = object-indexed family
-  Psh(codom::Ob)::TYPE
+  El(codom::Ob)::TYPE
 
   # functoriality = contravariant action
-  coact(f::Hom(A,B), x::Psh(B))::Psh(A) ⊣ (A::Ob, B::Ob)
+  coact(f::Hom(A,B), x::El(B))::El(A) ⊣ (A::Ob, B::Ob)
 
   # action equations
-  coact(f , coact(g , x)) == coact((f ⋅ g) , x)  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::Psh(C))
-  coact(id(A) , x) == x  ⊣ (A::Ob, x::Psh(A))
+  coact(f , coact(g , x)) == coact((f ⋅ g) , x)  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::El(C))
+  coact(id(A) , x) == x  ⊣ (A::Ob, x::El(A))
 end
 
 # Convenience constructors

--- a/src/theories/Category.jl
+++ b/src/theories/Category.jl
@@ -39,18 +39,18 @@ We use symbol ⋅ (\\cdot) for diagrammatic composition: f⋅g = compose(f,g).
   id(A) ⋅ f == f ⊣ (A::Ob, B::Ob, f::(A → B))
 end
 
-@theory coPresheaf{Ob,Hom,Psh} <: Category{Ob,Hom} begin
+@theory Copresheaf{Ob,Hom,Psh} <: Category{Ob,Hom} begin
   # unicode - *decide later*
 
   # presheaf = object-indexed family
   Psh(dom::Ob)::TYPE
 
   # functoriality = covariant action
-  actl(x::Psh(A), f::Hom(A,B))::Psh(B) ⊣ (A::Ob, B::Ob)
+  actr(x::Psh(A), f::Hom(A,B))::Psh(B) ⊣ (A::Ob, B::Ob)
 
   # action equations
-  actl(actl(x , f) , g) == actl(x , (f ⋅ g))  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::Psh(A))
-  actl(x , id(A)) == x  ⊣ (A::Ob, x::Psh(A))
+  actr(actr(x , f) , g) == actr(x , (f ⋅ g))  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::Psh(A))
+  actr(x , id(A)) == x  ⊣ (A::Ob, x::Psh(A))
 end
 
 @theory Presheaf{Ob,Hom,Psh} <: Category{Ob,Hom} begin
@@ -60,11 +60,11 @@ end
   Psh(codom::Ob)::TYPE
 
   # functoriality = contravariant action
-  actr(x::Psh(B), f::Hom(A,B))::Psh(A) ⊣ (A::Ob, B::Ob)
+  actl(f::Hom(A,B), x::Psh(B))::Psh(A) ⊣ (A::Ob, B::Ob)
 
   # action equations
-  actr(actr(x , f) , g) == actr(x , (f ⋅ g))  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::Psh(C))
-  actr(x , id(A)) == x  ⊣ (A::Ob, x::Psh(A))
+  actl(f , actr(g , x)) == actl((f ⋅ g) , x)  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::Psh(C))
+  actl(id(A) , x) == x  ⊣ (A::Ob, x::Psh(A))
 end
 
 # Convenience constructors

--- a/src/theories/Category.jl
+++ b/src/theories/Category.jl
@@ -1,4 +1,5 @@
 export Category, FreeCategory, Ob, Hom, dom, codom, id, compose, ⋅,
+  Copresheaf, Presheaf, El, act, coact,
   Category2, FreeCategory2, Hom2, compose2
 
 import Base: show
@@ -39,34 +40,6 @@ We use symbol ⋅ (\\cdot) for diagrammatic composition: f⋅g = compose(f,g).
   id(A) ⋅ f == f ⊣ (A::Ob, B::Ob, f::(A → B))
 end
 
-@theory Copresheaf{Ob,Hom,El} <: Category{Ob,Hom} begin
-  # unicode - *decide later*
-
-  # presheaf = object-indexed family
-  El(dom::Ob)::TYPE
-
-  # functoriality = covariant action
-  act(x::El(A), f::Hom(A,B))::El(B) ⊣ (A::Ob, B::Ob)
-
-  # action equations
-  act(act(x , f) , g) == act(x , (f ⋅ g))  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::El(A))
-  act(x , id(A)) == x  ⊣ (A::Ob, x::El(A))
-end
-
-@theory Presheaf{Ob,Hom,El} <: Category{Ob,Hom} begin
-  # unicode - *decide later*
-
-  # presheaf = object-indexed family
-  El(codom::Ob)::TYPE
-
-  # functoriality = contravariant action
-  coact(f::Hom(A,B), x::El(B))::El(A) ⊣ (A::Ob, B::Ob)
-
-  # action equations
-  coact(f , coact(g , x)) == coact((f ⋅ g) , x)  ⊣ (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::El(C))
-  coact(id(A) , x) == x  ⊣ (A::Ob, x::El(A))
-end
-
 # Convenience constructors
 compose(fs::Vector) = foldl(compose, fs)
 compose(f, g, h, fs...) = compose([f, g, h, fs...])
@@ -100,6 +73,43 @@ function show(io::IO, ::MIME"text/latex", expr::HomExpr)
   print(io, " \\to ")
   show_latex(io, codom(expr))
   print(io, "\$")
+end
+
+# (Co)presheaf
+##############
+
+""" Theory of *copresheaves*.
+
+Axiomatized as a covariant category action.
+"""
+@theory Copresheaf{Ob,Hom,El} <: Category{Ob,Hom} begin
+  # copresheaf = object-indexed family
+  El(ob::Ob)::TYPE
+
+  # functoriality = covariant action
+  act(x::El(A), f::Hom(A,B))::El(B) ⊣ (A::Ob, B::Ob)
+
+  # action equations
+  act(act(x, f), g) == act(x, (f ⋅ g)) ⊣
+    (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::El(A))
+  act(x, id(A)) == x ⊣ (A::Ob, x::El(A))
+end
+
+""" Theory of *presheaves*.
+
+Axiomatized as a contravariant category action.
+"""
+@theory Presheaf{Ob,Hom,El} <: Category{Ob,Hom} begin
+  # presheaf = object-indexed family
+  El(ob::Ob)::TYPE
+
+  # functoriality = contravariant action
+  coact(f::Hom(A,B), x::El(B))::El(A) ⊣ (A::Ob, B::Ob)
+
+  # action equations
+  coact(f, coact(g, x)) == coact((f ⋅ g), x) ⊣
+    (A::Ob, B::Ob, C::Ob, f::(A → B), g::(B → C), x::El(C))
+  coact(id(A), x) == x ⊣ (A::Ob, x::El(A))
 end
 
 # 2-category


### PR DESCRIPTION
Adding GATs for coPresheaf and Presheaf, as left/right modules of a category.
They are both straightforward. There are possibly some small choices to finalize.
Can also extend both to profunctors, which I'm sure will be useful.