### PR TITLE
Benchmark counting triangles in a graph

### DIFF
--- a/benchmark/Graphs.jl
+++ b/benchmark/Graphs.jl
@@ -60,6 +60,18 @@ end
 @inline Graphs.has_edge(g::LG.AbstractGraph, args...) = LG.has_edge(g, args...)
 @inline Graphs.neighbors(g::LG.AbstractGraph, args...) = LG.neighbors(g, args...)
 
+""" Number of triangles in a graph.
+"""
+function ntriangles(g::T) where T
+  triangle = T(3)
+  add_edges!(triangle, [1,2,1], [2,3,3])
+  count = 0
+  homomorphisms(triangle, g) do α;
+    count += 1; return false
+  end
+  count
+end
+
 function lg_connected_components_projection(g)
   label = Vector{Int}(undef, LG.nv(g))
   LG.connected_components!(label, g)
@@ -112,6 +124,11 @@ clbench["star-graph-components"] =
 lgbench["star-graph-components"] =
   @benchmarkable lg_connected_components_projection($lg)
 
+n = 100
+g = wheel_graph(Graph, n)
+lg = LG.DiGraph(g)
+clbench["wheel-graph-triangles"] = @benchmarkable ntriangles($g)
+
 # Symmetric graphs
 ##################
 
@@ -158,6 +175,12 @@ clbench["star-graph-components"] =
   @benchmarkable connected_component_projection($g)
 lgbench["star-graph-components"] =
   @benchmarkable lg_connected_components_projection($lg)
+
+n = 100
+g = wheel_graph(SymmetricGraph, n)
+lg = LG.Graph(g)
+clbench["wheel-graph-triangles"] = @benchmarkable ntriangles($g)
+lgbench["wheel-graph-triangles"] = @benchmarkable sum(LG.triangles($lg))
 
 # Weighted graphs
 #################

--- a/benchmark/Graphs.jl
+++ b/benchmark/Graphs.jl
@@ -83,9 +83,9 @@ function ntriangles(g::T, ::TriangleHomomorphism) where T
   count
 end
 function ntriangles(g, ::TriangleQuery)
-  length(query(g, triangle_query))
+  length(query(g, ntriangles_query))
 end
-const triangle_query = @relation (v1=v1, v2=v2, v3=v3) begin
+const ntriangles_query = @relation (;) begin
   E(src=v1, tgt=v2)
   E(src=v2, tgt=v3)
   E(src=v1, tgt=v3)

--- a/src/graphs/GraphGenerators.jl
+++ b/src/graphs/GraphGenerators.jl
@@ -1,5 +1,5 @@
 module GraphGenerators
-export path_graph, cycle_graph, complete_graph, star_graph
+export path_graph, cycle_graph, complete_graph, star_graph, wheel_graph
 
 using ...CSetDataStructures, ..BasicGraphs
 using ...CSetDataStructures: hom
@@ -38,10 +38,23 @@ function complete_graph(::Type{T}, n::Int; V=(;)) where T <: AbstractACSet
 end
 
 """ Star graph on ``n`` vertices.
+
+In the directed case, the edges point outward.
 """
 function star_graph(::Type{T}, n::Int) where T <: AbstractACSet
   g = T()
   add_vertices!(g, n)
+  add_edges!(g, fill(n,n-1), 1:(n-1))
+  g
+end
+
+""" Wheel graph on ``n`` vertices.
+
+In the directed case, the outer cycle is directed and the spokes point outward.
+"""
+function wheel_graph(::Type{T}, n::Int) where T <: AbstractACSet
+  g = cycle_graph(T, n-1)
+  add_vertex!(g)
   add_edges!(g, fill(n,n-1), 1:(n-1))
   g
 end

--- a/test/graphs/GraphGenerators.jl
+++ b/test/graphs/GraphGenerators.jl
@@ -2,6 +2,7 @@ module TestGraphGenerators
 using Test
 
 using Catlab.Graphs.BasicGraphs, Catlab.Graphs.GraphGenerators
+using Catlab.CategoricalAlgebra: homomorphisms
 
 # Path graphs
 #------------
@@ -40,5 +41,19 @@ g = star_graph(Graph, n)
 @test length(unique(src(g,e) for e in edges(g))) == 1
 g = star_graph(SymmetricGraph, n)
 @test (nv(g), ne(g)) == (n, 2(n-1))
+
+# Wheel graphs
+#-------------
+
+g = wheel_graph(Graph, n)
+@test (nv(g), ne(g)) == (n, 2(n-1))
+triangle = Graph(3)
+add_edges!(triangle, [1,2,1], [2,3,3])
+@test length(homomorphisms(triangle, g)) == n-1
+
+g = wheel_graph(SymmetricGraph, n)
+@test (nv(g), ne(g)) == (n, 4(n-1))
+triangle = cycle_graph(SymmetricGraph, 3)
+@test length(homomorphisms(triangle, g)) == 6(n-1) # == 3! * (n-1)
 
 end

--- a/test/wiring_diagrams/Algebras.jl
+++ b/test/wiring_diagrams/Algebras.jl
@@ -62,6 +62,10 @@ paths2 = @relation (start=start, stop=stop) begin
   E(src=start, tgt=mid)
   E(src=mid, tgt=stop)
 end
+count_paths2 = @relation (;) begin
+  E(src=start, tgt=mid)
+  E(src=mid, tgt=stop)
+end
 
 # Graph underlying a commutative squares.
 square = Graph(4)
@@ -75,11 +79,13 @@ add_vertices!(squares2, 2)
 add_edges!(squares2, [2,4,5], [5,6,6])
 result = query(squares2, paths2)
 @test tuples(columns(result)...) == [(1,4), (1,4), (1,5), (2,6), (2,6), (3,6)]
+@test length(query(squares2, count_paths2)) == 6
 
 result = query(squares2, paths2, (start=1,))
 @test tuples(columns(result)...) == [(1,4), (1,4), (1,5)]
 result = query(squares2, paths2, (start=1, stop=4))
 @test result == Table((start=[1,1], stop=[4,4]))
+@test length(query(squares2, count_paths2, (start=1, stop=4))) == 2
 
 cycles3 = @relation (edge1=e, edge2=f, edge3=g) where (e,f,g,u,v,w) begin
   E(_id=e, src=u, tgt=v)


### PR DESCRIPTION
Benchmark counting triangles in a graph via

- C-set homomorphism search based on backtracking search
- conjunctive query using FinSet limits

The third commit gives a 10-20x speed improvement to the homomorphism search method.

Both methods are much slower than LightGraph's dedicated procedure for counting triangles. That is not surprising given the big difference in generality between the algorithms. Still, I think that large performance improvements are on the table, particularly for the CSP algorithm which I suspect is much slower than it should be.