### PR TITLE
BUILD: Fix error in github actions interpreting |

### DIFF
--- a/.github/workflows/reviewchecklist.yml
+++ b/.github/workflows/reviewchecklist.yml
@@ -14,24 +14,23 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           check_for_duplicate_msg: true
-          msg: |-
-            ### Review Checklist
-
-            Does this PR follow the [development guidelines](https://github.com/AlgebraicJulia/Catlab.jl/wiki/Guidelines-for-PR-writers-and-reviewers)? Following is a *partial* checklist:
-
-            **Tests**
-
-            - [ ] New features and bug fixes have unit tests
-            - [ ] New modules have tests that are ultimately called by the test runner (`test/runtests.jl`)
-            - [ ] Existing tests have not been deleted
-            - [ ] Code coverage &gt;= 90% or reduction justified in PR
-
-            **Documentation**
-
-            - [ ] All exported functions, types, and constants have docstrings, written in complete sentences
-            - [ ] Citations are given for any constructions, algorithms, or code drawn from external sources
-
-            **Other**
-
-            - [ ] Style guidelines are followed, including indent width 2
-            - [ ] Changes breaking backwards compatibility have been approved
+          msg: "### Review Checklist\n
+            \n
+            Does this PR follow the [development guidelines](https://github.com/AlgebraicJulia/Catlab.jl/wiki/Guidelines-for-PR-writers-and-reviewers)? Following is a *partial* checklist:\n
+            \n
+            **Tests**\n
+            \n
+            - [ ] New features and bug fixes have unit tests\n
+            - [ ] New modules have tests that are ultimately called by the test runner (`test/runtests.jl`)\n
+            - [ ] Existing tests have not been deleted\n
+            - [ ] Code coverage &gt;= 90% or reduction justified in PR\n
+            \n
+            **Documentation**\n
+            \n
+            - [ ] All exported functions, types, and constants have docstrings, written in complete sentences\n
+            - [ ] Citations are given for any constructions, algorithms, or code drawn from external sources\n
+            \n
+            **Other**\n
+            \n
+            - [ ] Style guidelines are followed, including indent width 2\n
+            - [ ] Changes breaking backwards compatibility have been approved"

--- a/.github/workflows/reviewchecklist.yml
+++ b/.github/workflows/reviewchecklist.yml
@@ -1,7 +1,7 @@
 name: Review Checklist
 
 on:
-  pull_request_target:
+  pull_request:
     types: [review_requested]
 
 jobs:


### PR DESCRIPTION
The `yml` before this PR is completely valid. I think there is a bug in the Github Actions interpreter where it is getting confused. Hoping that this will fix things.