### PR TITLE
Restrict to LinearOperators v1

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -16,3 +16,6 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
+
+[compat]
+LinearOperators = "1"


### PR DESCRIPTION
LinearOperators.jl v2 just came out, and a few of the GLA tests are failing on it. This PR, meant to be temporary, restricts to v1 until the GLA code is fixed.