### PR TITLE
Reference Semagrams in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,5 +78,7 @@ of the project.
 
 **Graphical user interface**: Catlab does not provide a wiring diagram editor
 or other graphical user interface. It is primarily a programming library, not a
-user-facing application. However, it could be used as the backend for such an
-application.
+user-facing application. However, there is another project in the AlgebraicJulia
+ecosystem, [Semagrams.jl](https://github.com/AlgebraicJulia/Semagrams.jl)
+which does provide graphical user interfaces for interacting with wiring
+diagrams, Petri nets, and the like.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -51,8 +51,10 @@ of the project.
 
 **Graphical user interface**: Catlab does not provide a wiring diagram editor
 or other graphical user interface. It is primarily a programming library, not a
-user-facing application. However, it could be used as the backend for such an
-application.
+user-facing application. However, there is another project in the AlgebraicJulia
+ecosystem, [Semagrams.jl](https://github.com/AlgebraicJulia/Semagrams.jl)
+which does provide graphical user interfaces for interacting with wiring
+diagrams, Petri nets, and the like.
 
 ### What is a GAT?
 


### PR DESCRIPTION
In the README, it says that Catlab is not meant to be a graphical editor; I edited this to say that Catlab *is* the backend to a graphical editor, however!