### PR TITLE
ENH: add function for visualizing CPortGraphs

### DIFF
--- a/src/graphics/GraphvizWiringDiagrams.jl
+++ b/src/graphics/GraphvizWiringDiagrams.jl
@@ -13,6 +13,7 @@ using StaticArrays
 import ...Theories: HomExpr
 using ...WiringDiagrams, ...WiringDiagrams.WiringDiagramSerialization
 using ...CategoricalAlgebra.CSets, ...Graphs, ..GraphvizGraphs
+import ...CategoricalAlgebra: migrate!
 import ..Graphviz
 import ..GraphvizGraphs: to_graphviz
 using ..WiringDiagramLayouts: BoxLayout, PortLayout, WirePoint,
@@ -94,7 +95,7 @@ function to_graphviz(f::WiringDiagram;
       port_map[Port(v,kind,i)] = node_id
     end
   end
-  
+
   # Invisible nodes for incoming and outgoing wires.
   if outer_ports
     gv_box = graphviz_outer_box(f;
@@ -103,7 +104,7 @@ function to_graphviz(f::WiringDiagram;
     update_port_map!(input_id(f), OutputPort, gv_box.input_ports)
     update_port_map!(output_id(f), InputPort, gv_box.output_ports)
   end
-  
+
   # Visible nodes for boxes.
   default_attrs = default_directed_graphviz_attrs
   cell_attrs = merge(default_attrs.cell, Graphviz.as_attributes(cell_attrs))
@@ -115,7 +116,7 @@ function to_graphviz(f::WiringDiagram;
     update_port_map!(v, InputPort, gv_box.input_ports)
     update_port_map!(v, OutputPort, gv_box.output_ports)
   end
-  
+
   # Edges.
   for (i, wire) in enumerate(wires(f))
     source, target = wire.source, wire.target
@@ -138,7 +139,7 @@ function to_graphviz(f::WiringDiagram;
     edge = Graphviz.Edge(port_map[source], port_map[target]; attrs...)
     push!(stmts, edge)
   end
-  
+
   # Graph.
   Graphviz.Digraph(graph_name, stmts; prog="dot",
     graph_attrs=merge(default_attrs.graph, Graphviz.as_attributes(graph_attrs),
@@ -172,7 +173,7 @@ function graphviz_box(box::AbstractBox, node_id;
     comment = node_label(box.value),
     label = html_label,
   )
-  
+
   # Input and output ports.
   graphviz_port = (kind::PortKind, port::Int) -> begin
     Graphviz.NodeID(node_id, port_name(kind, port),
@@ -180,7 +181,7 @@ function graphviz_box(box::AbstractBox, node_id;
   end
   inputs = [ graphviz_port(InputPort, i) for i in 1:nin ]
   outputs = [ graphviz_port(OutputPort, i) for i in 1:nout ]
-  
+
   GraphvizBox([node], inputs, outputs)
 end
 
@@ -278,7 +279,7 @@ function graphviz_outer_box(f::WiringDiagram;
     push!(stmts, graphviz_outer_ports(OutputPort, noutputs;
       anchor=anchor, orientation=orientation))
   end
-  
+
   # Input and output ports.
   inputs = map(1:ninputs) do i
     Graphviz.NodeID(port_node_name(InputPort, i),
@@ -288,7 +289,7 @@ function graphviz_outer_box(f::WiringDiagram;
     Graphviz.NodeID(port_node_name(OutputPort, i),
                     port_anchor(InputPort, orientation))
   end
-  
+
   GraphvizBox(stmts, inputs, outputs)
 end
 
@@ -471,7 +472,7 @@ function to_graphviz_property_graph(d::UndirectedWiringDiagram;
       end
     end
   end
-  
+
   return graph
 end
 
@@ -530,7 +531,7 @@ function graphviz_layout(diagram::WiringDiagram, graph::PropertyGraph)
   bounds, pad = get_gprop(graph, :bounds), get_gprop(graph, :pad)
   diagram_size = bounds + 2*pad
   transform_point(p) = SVector(1,-1) .* (p - diagram_size/2)
-  
+
   # Assumes vertices are in same order as created by `to_graphviz`:
   # 1. Input ports of outer box
   nin, nout = length(input_ports(diagram)), length(output_ports(diagram))
@@ -540,14 +541,14 @@ function graphviz_layout(diagram::WiringDiagram, graph::PropertyGraph)
     pos = transform_point(attrs[:position])
     PortLayout(; value=value, position=pos, normal=-main_dir)
   end
-  
+
   # 2. Output ports of outer box
   outputs = map(enumerate(output_ports(diagram))) do (i, value)
     attrs = vprops(graph, nin + i)
     pos = transform_point(attrs[:position])
     PortLayout(; value=value, position=pos, normal=main_dir)
   end
-  
+
   # 3. Inner boxes
   # TODO: Use port positions from Graphviz layout. Obtain these from either
   # the HTML label or, more likely, an incident edge.
@@ -564,9 +565,9 @@ function graphviz_layout(diagram::WiringDiagram, graph::PropertyGraph)
       BoxLayout(; value=box.value, shape=shape, position=pos, size=size),
       layout_linear_ports(InputPort, input_ports(box), size, orientation),
       layout_linear_ports(OutputPort, output_ports(box), size, orientation)
-    ))    
+    ))
   end
-  
+
   # Add wires using spline points from Graphviz edge layout.
   function map_port(node::Int, portname::Union{String,Nothing})
     if node <= nin
@@ -597,11 +598,11 @@ function graphviz_layout(diagram::WiringDiagram, graph::PropertyGraph)
   layout
 end
 
-""" Lay out ports linearly, equispaced along a rectangular box. 
+""" Lay out ports linearly, equispaced along a rectangular box.
 
 FIXME: Should this be in `WiringDiagramLayouts` as an alternative layout method?
 """
-function layout_linear_ports(port_kind::PortKind, port_values::Vector, 
+function layout_linear_ports(port_kind::PortKind, port_values::Vector,
                              box_size::StaticVector{2}, orientation::LayoutOrientation)
   n = length(port_values)
   sign = port_sign(port_kind, orientation)
@@ -622,5 +623,65 @@ inverse_rank_dir(rank_dir::String) = @match rank_dir begin
   "LR" => LeftToRight
   "RL" => RightToLeft
 end
+
+function to_graphviz(cp::CPortGraph; kw...)::Graphviz.Graph
+  to_graphviz(property_graph(cp; kw...))
+end
+
+""" Draw a circular port graph using Graphviz.
+
+Creates a Graphviz graph. Ports are currently not respected in the image, but
+the port index for each box can be displayed to provide clarification.
+
+# Arguments
+- `graph_name="G"`: name of Graphviz graph
+- `prog="neato"`: Graphviz program, usually "neato" or "fdp"
+- `box_labels=false`: whether to label boxes with their number
+- `port_labels=false`: whether to label ports with their number
+- `graph_attrs=Dict()`: top-level graph attributes
+- `node_attrs=Dict()`: top-level node attributes
+- `edge_attrs=Dict()`: top-level edge attributes
+
+# TODO:
+The lack of ports might be able to be resolved by introducing an extra node per
+port which is connected to its box with an edge of length 0.
+"""
+
+function property_graph(cp::CPortGraph;
+    graph_name::String="G", prog::String="neato",
+    box_labels::Bool=false, port_labels::Bool=false,
+    graph_attrs::AbstractDict=Dict(), node_attrs::AbstractDict=Dict(),
+    edge_attrs::AbstractDict=Dict())
+  default_attrs = default_undirected_graphviz_attrs
+
+  # Generate a map from the global index of a port to the box-specific index
+  port2box = Array{Tuple{Int, Int}}(undef, nparts(cp, :Port))
+  for (b, p) in enumerate(incident(cp, 1:nparts(cp, :Box), :box))
+    port2box[p] .= [(b, i) for i in 1:length(p)]
+  end
+
+  g′ = Graphs.Graph()
+
+  add_parts!(g′, :V, nparts(cp, :Box))
+  add_parts!(g′, :E, nparts(cp, :Wire), src=cp[cp[:src], :box], tgt=cp[cp[:tgt], :box])
+
+  node_labeler(v) = box_labels ? Dict(:id => "box$v", :label => string(v)) :
+                                 Dict(:id => "box$v")
+
+  edge_labeler(e) =
+    port_labels ? Dict(:taillabel => string(port2box[cp[e, :src]][2]),
+                       :headlabel => string(port2box[cp[e, :tgt]][2]),
+                       :id => "edge$e") :
+                  Dict(:id => "edge$e")
+
+  Graphs.PropertyGraph{Any}(g′, node_labeler, edge_labeler;
+    name = graph_name,
+		prog = prog,
+		node = merge(default_attrs.node, node_attrs),
+    graph = merge(default_attrs.graph, Graphviz.as_attributes(graph_attrs)),
+		edge = merge(default_attrs.edge, Graphviz.as_attributes(edge_attrs))
+)
+end
+
 
 end

--- a/src/graphics/GraphvizWiringDiagrams.jl
+++ b/src/graphics/GraphvizWiringDiagrams.jl
@@ -624,10 +624,6 @@ inverse_rank_dir(rank_dir::String) = @match rank_dir begin
   "RL" => RightToLeft
 end
 
-function to_graphviz(cp::CPortGraph; kw...)::Graphviz.Graph
-  to_graphviz(property_graph(cp; kw...))
-end
-
 """ Draw a circular port graph using Graphviz.
 
 Creates a Graphviz graph. Ports are currently not respected in the image, but
@@ -646,8 +642,11 @@ the port index for each box can be displayed to provide clarification.
 The lack of ports might be able to be resolved by introducing an extra node per
 port which is connected to its box with an edge of length 0.
 """
+function to_graphviz(cp::CPortGraph; kw...)::Graphviz.Graph
+  to_graphviz(to_graphviz_property_graph(cp; kw...))
+end
 
-function property_graph(cp::CPortGraph;
+function to_graphviz_property_graph(cp::CPortGraph;
     graph_name::String="G", prog::String="neato",
     box_labels::Bool=false, port_labels::Bool=false,
     graph_attrs::AbstractDict=Dict(), node_attrs::AbstractDict=Dict(),
@@ -662,8 +661,9 @@ function property_graph(cp::CPortGraph;
 
   g′ = Graphs.Graph()
 
-  add_parts!(g′, :V, nparts(cp, :Box))
-  add_parts!(g′, :E, nparts(cp, :Wire), src=cp[cp[:src], :box], tgt=cp[cp[:tgt], :box])
+  migrate!(g′, cp, Dict(:V=>:Box, :E=>:Wire),
+                   Dict(:src => [:src, :box],
+                        :tgt => [:tgt, :box]))
 
   node_labeler(v) = box_labels ? Dict(:id => "box$v", :label => string(v)) :
                                  Dict(:id => "box$v")

--- a/test/graphics/GraphvizWiringDiagrams.jl
+++ b/test/graphics/GraphvizWiringDiagrams.jl
@@ -3,7 +3,8 @@ module TestGraphvizWiringDiagrams
 using Test
 import JSON
 
-using Catlab.Theories, Catlab.WiringDiagrams, Catlab.Graphics
+using Catlab.Theories, Catlab.WiringDiagrams, Catlab.Graphics,
+      Catlab.CategoricalAlgebra
 using Catlab.Programs: @relation
 import Catlab.Graphics: Graphviz
 using Catlab.Graphics.WiringDiagramLayouts: position, normal
@@ -121,5 +122,50 @@ values(xs) = map(x -> x.value, xs)
 positions = map(position, boxes(layout))
 @test positions[1][1] < positions[2][1]
 @test positions[1][2] < positions[3][2]
+
+# CPG drawing
+#############
+
+# Cycle CPG
+d = @acset CPortGraph begin
+  Box = 4
+  Port = 4
+  Wire = 4
+  box = [1,2,3,4]
+  src = [1,2,3,4]
+  tgt = [2,3,4,1]
+end
+
+# Star CPG
+d2 = @acset CPortGraph begin
+  Box = 4
+  Port = 6
+  Wire = 3
+  box = [1,1,1,2,3,4]
+  src = [1,2,3]
+  tgt = [4,5,6]
+end
+
+graph = to_graphviz(d)
+@test stmts(graph, Graphviz.Node, :id) ==
+  ["box1", "box2", "box3", "box4"]
+@test length(stmts(graph, Graphviz.Edge)) == 4
+
+graph = to_graphviz(d2)
+@test stmts(graph, Graphviz.Node, :id) ==
+  ["box1", "box2", "box3", "box4"]
+@test length(stmts(graph, Graphviz.Edge)) == 3
+
+# Box and port labels
+#--------------------
+graph = to_graphviz(d, port_labels=true, box_labels=true)
+@test stmts(graph, Graphviz.Edge, :taillabel) == fill("1", 4)
+@test stmts(graph, Graphviz.Edge, :headlabel) == fill("1", 4)
+@test stmts(graph, Graphviz.Node, :label) == ["1", "2", "3" ,"4"]
+
+graph = to_graphviz(d2, port_labels=true, box_labels=true)
+@test stmts(graph, Graphviz.Edge, :taillabel) == ["1", "2", "3"]
+@test stmts(graph, Graphviz.Edge, :headlabel) == ["1", "1", "1"]
+@test stmts(graph, Graphviz.Node, :label) == ["1", "2", "3" ,"4"]
 
 end


### PR DESCRIPTION
Provides visualization tooling for CPortGraphs. An example of how a star CPortGraph is visualized is provided below.

```julia
to_graphviz(pg, edge_attrs=Dict(:len => "1.0"), port_labels=true, box_labels=true)
```

<img width="239" alt="image" src="https://user-images.githubusercontent.com/19711695/125096377-16199b00-e0a3-11eb-8c8b-a0d08fdf753e.png">