### PR TITLE
Generic interface for pushout complements

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -14,9 +14,8 @@ using StaticArrays: SVector
 using Tables
 
 @reexport using ...CSetDataStructures
-
 using ...GAT, ..FreeDiagrams, ..Limits, ..Subobjects, ..Sets, ..FinSets
-import ..Limits: limit, colimit, universal
+import ..Limits: limit, colimit, universal, pushout_complement
 import ..Subobjects: Subobject, SubobjectBiHeytingAlgebra,
   implies, ⟹, subtract, \, negate, ¬, non, ~
 import ..FinSets: FinSet, FinFunction, FinDomFunction, force, as_predicate
@@ -599,6 +598,25 @@ cocone_objects(diagram) = ob(diagram)
 cocone_objects(diagram::BipartiteFreeDiagram) = ob₂(diagram)
 cocone_objects(span::Multispan) = feet(span)
 cocone_objects(para::ParallelMorphisms) = SVector(codom(para))
+
+""" Compute pushout complement of attributed C-sets, if possible.
+
+The pushout complement is constructed pointwise from pushout complements of
+finite sets. If any of the pointwise identification conditions fail in FinSet),
+this method will raise an error. If the dangling condition fails, the resulting
+C-set will be only partially defined. To check these conditions in advance, use
+the function [`valid_dpo`](@ref).
+"""
+function pushout_complement(pair::ComposablePair{<:ACSet})
+  # Compute pushout complements pointwise in FinSet.
+  components = map(pushout_complement, unpack_diagram(pair))
+  k_components, g_components = map(first, components), map(last, components)
+
+  # Reassemble components into natural transformations.
+  g = hom(Subobject(codom(pair), g_components))
+  k = ACSetTransformation(k_components, dom(pair), dom(g))
+  return ComposablePair(k, g)
+end
 
 # Sub-C-sets
 ############

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -545,14 +545,16 @@ end
 
 """ Diagram in C-Set → named tuple of diagrams in FinSet
 """
-unpack_diagram(discrete::DiscreteDiagram{<:StructACSet}) =
+unpack_diagram(discrete::DiscreteDiagram{<:ACSet}) =
   map(DiscreteDiagram, unpack_sets(ob(discrete)))
-unpack_diagram(span::Multispan{<:StructACSet}) =
+unpack_diagram(span::Multispan{<:ACSet}) =
   map(Multispan, fin_sets(apex(span)), unpack_components(legs(span)))
-unpack_diagram(cospan::Multicospan{<:StructACSet}) =
+unpack_diagram(cospan::Multicospan{<:ACSet}) =
   map(Multicospan, fin_sets(apex(cospan)), unpack_components(legs(cospan)))
-unpack_diagram(para::ParallelMorphisms{<:StructACSet}) =
+unpack_diagram(para::ParallelMorphisms{<:ACSet}) =
   map(ParallelMorphisms, unpack_components(hom(para)))
+unpack_diagram(comp::ComposableMorphisms{<:ACSet}) =
+  map(ComposableMorphisms, unpack_components(hom(comp)))
 
 function unpack_diagram(d::Union{FreeDiagram{ACS},BipartiteFreeDiagram{ACS}}) where
     {Ob, S <: SchemaDescType{Ob}, ACS <: StructACSet{S}}

--- a/src/categorical_algebra/DPO.jl
+++ b/src/categorical_algebra/DPO.jl
@@ -2,10 +2,10 @@ module DPO
 export rewrite, rewrite_match, valid_dpo, dangling_condition, id_condition,
   pushout_complement
 
-using ..FinSets, ..CSets, ..Limits, ..Subobjects
+using ..FinSets, ..CSets, ..FreeDiagrams, ..Limits, ..Subobjects
 using ...Theories
 using ...Theories: attr
-
+import ..Limits: pushout_complement
 
 """
     l
@@ -19,12 +19,13 @@ component, define K = G / m(L/l(I)). There is a natural injection g: K↪G. For
 each component, define k as equal to the map l;m (every element in the image in
 G is also in K).
 
-Returns ACSetTransformations k and g such that (m, g) is the pushout of (l, k).
-Elements of K are ordered in the same order as they appear in G.
+Returns a composable pair of ACSet transformations k and g such that (m, g) is
+the pushout of (l, k). Elements of K are ordered in the same order as they
+appear in G.
 """
-function pushout_complement(
-    l::ACSetTransformation{S}, m::ACSetTransformation{S}
-  )::Pair{ACSetTransformation{S},ACSetTransformation{S}} where {S}
+function pushout_complement(pair::ComposablePair{ACS}) where
+    {S, ACS <: StructACSet{S}}
+  l, m = pair
   valid_dpo(l, m) || error("morphisms L and m do not satisfy gluing conditions")
   I, L, G = dom(l), codom(l), codom(m)
 
@@ -45,7 +46,7 @@ function pushout_complement(
   end)
   k = ACSetTransformation(k_components, I, K)
 
-  return k => g
+  return ComposablePair(k, g)
 end
 
 """

--- a/src/categorical_algebra/DPO.jl
+++ b/src/categorical_algebra/DPO.jl
@@ -5,28 +5,6 @@ export rewrite, rewrite_match, valid_dpo, dangling_condition, id_condition,
 using ..FinSets, ..CSets, ..FreeDiagrams, ..Limits, ..Subobjects
 using ...Theories
 using ...Theories: attr
-import ..Limits: pushout_complement
-using ..CSets: unpack_diagram
-
-""" Compute pushout complement of attributed C-sets, if possible.
-
-The pushout complement is constructed pointwise from pushout complements of
-finite sets. It will fail if any of the pointwise identification conditions or
-the dangling condition do not hold.
-"""
-function pushout_complement(pair::ComposablePair{<:ACSet})
-  l, m = pair
-  I, G = dom(l), codom(m)
-  valid_dpo(l, m) || error("Morphisms l and m do not satisfy gluing conditions")
-
-  # Compute pushout complements pointwise in FinSet.
-  components = map(pushout_complement, unpack_diagram(pair))
-  k_components, g_components = map(first, components), map(last, components)
-
-  g = hom(Subobject(G, g_components))
-  k = ACSetTransformation(k_components, I, dom(g))
-  return ComposablePair(k, g)
-end
 
 """
 Apply a rewrite rule (given as a span, L<-I->R) to a ACSet
@@ -87,7 +65,7 @@ function id_condition(L::ACSetTransformation{S},
                       m::ACSetTransformation{S}) where {S}
   res1, res2 = Tuple{Symbol, Int, Int, Int}[], Tuple{Symbol, Int, Int}[]
   for comp in keys(components(L))
-    m_comp = x->m[comp](x)
+    m_comp = m[comp]
     image = Set(collect(L[comp]))
     image_complement = filter(x->!(x in image), parts(codom(L),comp))
     image_vals = map(m_comp, collect(image))

--- a/src/categorical_algebra/DPO.jl
+++ b/src/categorical_algebra/DPO.jl
@@ -1,25 +1,24 @@
 module DPO
-export rewrite, rewrite_match, valid_dpo, dangling_condition, id_condition,
-  pushout_complement
+export rewrite, rewrite_match, pushout_complement, can_pushout_complement,
+  id_condition, dangling_condition
 
-using ..FinSets, ..CSets, ..FreeDiagrams, ..Limits, ..Subobjects
 using ...Theories
-using ...Theories: attr
+using ..FinSets, ..CSets, ..FreeDiagrams, ..Limits
+using ..FinSets: id_condition
+using ..CSets: dangling_condition
 
 """
 Apply a rewrite rule (given as a span, L<-I->R) to a ACSet
 using a match morphism `m` which indicates where to apply
 the rewrite.
 """
-function rewrite_match(L::ACSetTransformation{S},
-                       R::ACSetTransformation{S},
-                       m::ACSetTransformation{S}
-                      )::StructACSet{S} where {S}
-    dom(L) == dom(R) || error("Rewriting where L, R do not share domain")
-    codom(L) == dom(m) || error("Rewriting where L does not compose with m")
-    (k, _) = pushout_complement(L, m)
-    l1, _ = pushout(R, k)
-    return codom(l1)
+function rewrite_match(L::ACSetTransformation, R::ACSetTransformation,
+                       m::ACSetTransformation)::ACSet
+  dom(L) == dom(R) || error("Rewriting where L, R do not share domain")
+  codom(L) == dom(m) || error("Rewriting where L does not compose with m")
+  (k, _) = pushout_complement(L, m)
+  l1, _ = pushout(R, k)
+  return codom(l1)
 end
 
 """
@@ -28,100 +27,16 @@ where a match morphism is found automatically. If multiple
 matches are found, a particular one can be selected using
 `m_index`.
 """
-function rewrite(L::ACSetTransformation{S},
-                 R::ACSetTransformation{S},
-                 G::StructACSet{S},
-                 monic::Bool=false, m_index::Int=1
-                )::Union{Nothing, StructACSet} where {S}
-  ms = filter(m->valid_dpo(L, m), homomorphisms(codom(L), G, monic=monic))
+function rewrite(L::ACSetTransformation, R::ACSetTransformation,
+                 G::ACSet; monic::Bool=false, m_index::Int=1
+                 )::Union{Nothing,ACSet}
+  ms = filter(m->can_pushout_complement(L, m),
+              homomorphisms(codom(L), G, monic=monic))
   if 0 < m_index <= length(ms)
-    return rewrite_match(L, R, ms[m_index])
+    rewrite_match(L, R, ms[m_index])
   else
-    return nothing
+    nothing
   end
-end
-
-
-"""
-Condition for existence of a pushout complement
-"""
-function valid_dpo(L::ACSetTransformation, m::ACSetTransformation)::Bool
-  return all(isempty, [collect(id_condition(L, m))...,
-                       dangling_condition(L, m)])
-end
-
-"""
-Check the identification condition: Does not map both a deleted item and a
-preserved item in L to the same item in G, or two distinct deleted items to the
-same. (Trivially satisfied if mono)
-
-Returns a tuple of lists of violations
-  1.) For a given component, a pair of IDs in L that are deleted yet mapped to
-      the same index (the last integer of the tuple) in G
-  2.) For a given component, a nondeleted index that maps to a deleted index
-      in G
-"""
-function id_condition(L::ACSetTransformation{S},
-                      m::ACSetTransformation{S}) where {S}
-  res1, res2 = Tuple{Symbol, Int, Int, Int}[], Tuple{Symbol, Int, Int}[]
-  for comp in keys(components(L))
-    m_comp = m[comp]
-    image = Set(collect(L[comp]))
-    image_complement = filter(x->!(x in image), parts(codom(L),comp))
-    image_vals = map(m_comp, collect(image))
-    orphan_vals = map(m_comp, image_complement)
-    orphan_set = Set(orphan_vals)
-
-    for (i, iv) in enumerate(image_complement)
-      for j in i+1:length(image_complement)
-        if m_comp(iv) == m_comp(image_complement[j])
-          push!(res1, (comp, i, j, m_comp(i)))
-        end
-      end
-    end
-    for i in image
-      if m_comp(i) in orphan_set
-        push!(res2, (comp, i, m_comp(i)))
-      end
-    end
-  end
-
-  return (res1, res2)
-end
-
-"""
-Check the dangling condition: m doesn't map a deleted element d to a element
-m(d) ∈ G if m(d) is connected to something outside the image of m.
-
-For example, in the CSet of graphs:
-  e1
-1 --> 2
-
-if e1 is not matched but either 1 and 2 are deleted, then e1 is dangling
-"""
-function dangling_condition(L::ACSetTransformation{S},
-                            m::ACSetTransformation{S}) where {S}
-  orphans, res = Dict(), []
-  for comp in keys(components(L))
-    image = Set(collect(L[comp]))
-    orphans[comp] = Set(
-      map(x->m[comp](x),
-        filter(x->!(x in image),
-          parts(codom(L), comp))))
-  end
-  # check that for all morphisms in C, we do not map to an orphan
-  for (morph, src_obj, tgt_obj) in zip(hom(S), dom(S), codom(S))
-    n_src = parts(codom(m), src_obj)
-    unmatched_vals = setdiff(n_src, collect(m[src_obj]))
-    unmatched_tgt = map(x -> m.codom[morph][x], collect(unmatched_vals))
-    for unmatched_val in setdiff(n_src, collect(m[src_obj]))  # G/m(L) src
-      unmatched_tgt = m.codom[morph][unmatched_val]
-      if unmatched_tgt in orphans[tgt_obj]
-        push!(res, (morph, unmatched_val, unmatched_tgt))
-      end
-    end
-  end
-  return res
 end
 
 end

--- a/src/categorical_algebra/FreeDiagrams.jl
+++ b/src/categorical_algebra/FreeDiagrams.jl
@@ -2,14 +2,14 @@
 
 A [free diagram](https://ncatlab.org/nlab/show/free+diagram) in a category is a
 diagram whose shape is a free category. Examples include the empty diagram,
-pairs of objects, discrete diagrams, parallel morphisms, spans, and cospans.
-Limits and colimits are most commonly taken over free diagrams.
+pairs of objects, discrete diagrams, parallel pairs, composable pairs, and spans
+and cospans. Limits and colimits are most commonly taken over free diagrams.
 """
 module FreeDiagrams
 export AbstractFreeDiagram, FreeDiagram, BipartiteFreeDiagram,
   FixedShapeFreeDiagram, DiscreteDiagram, EmptyDiagram, ObjectPair,
   Span, Cospan, Multispan, Multicospan, SMultispan, SMulticospan,
-  ParallelPair, ParallelMorphisms,
+  ParallelPair, ParallelMorphisms, ComposablePair, ComposableMorphisms,
   ob, hom, dom, codom, apex, legs, feet, left, right, bundle_legs,
   nv, ne, src, tgt, vertices, edges, has_vertex, has_edge,
   add_vertex!, add_vertices!, add_edge!, add_edges!,
@@ -225,6 +225,48 @@ Base.lastindex(para::ParallelMorphisms) = lastindex(para.homs)
 
 allequal(xs::AbstractVector) = isempty(xs) || all(==(xs[1]), xs)
 
+# Composable morphisms
+#---------------------
+
+""" Composable morphisms in a category.
+
+Composable morphisms are a sequence of morphisms in a category that form a path
+in the underlying graph of the category.
+
+For the common special case of two morphisms, see [`ComposablePair`](@ref).
+"""
+@auto_hash_equals struct ComposableMorphisms{Ob,Hom,Homs<:AbstractVector{Hom}} <:
+    FixedShapeFreeDiagram{Ob}
+  homs::Homs
+end
+
+function ComposableMorphisms(homs::Homs) where {Hom, Homs<:AbstractVector{Hom}}
+  doms, codoms = dom.(homs), codom.(homs)
+  all(c == d for (c,d) in zip(codoms[1:end-1], doms[2:end])) ||
+    error("Domain mismatch in composable sequence: $homs")
+  ComposableMorphisms{Union{eltype(doms),eltype(codoms)},Hom,Homs}(homs)
+end
+
+""" Pair of composable morphisms in a category.
+
+[Composable pairs](https://ncatlab.org/nlab/show/composable+pair) are a common
+special case of [`ComposableMorphisms`](@ref).
+"""
+const ComposablePair{Ob,Hom} = ComposableMorphisms{Ob,Hom,<:StaticVector{2,Hom}}
+
+ComposablePair(first, last) = ComposableMorphisms(SVector(first, last))
+
+dom(comp::ComposableMorphisms) = dom(first(comp))
+codom(comp::ComposableMorphisms) = codom(last(comp))
+hom(comp::ComposableMorphisms) = comp.homs
+
+Base.iterate(comp::ComposableMorphisms, args...) = iterate(comp.homs, args...)
+Base.eltype(comp::ComposableMorphisms) = eltype(comp.homs)
+Base.length(comp::ComposableMorphisms) = length(comp.homs)
+Base.getindex(comp::ComposableMorphisms, i) = comp.homs[i]
+Base.firstindex(comp::ComposableMorphisms) = firstindex(comp.homs)
+Base.lastindex(comp::ComposableMorphisms) = lastindex(comp.homs)
+
 # Diagrams of flexible shape
 ############################
 
@@ -348,6 +390,14 @@ function FreeDiagram(para::ParallelMorphisms{Dom,Codom,Hom}) where {Dom,Codom,Ho
   d = FreeDiagram{Union{Dom,Codom},Hom}()
   add_vertices!(d, 2, ob=[dom(para), codom(para)])
   add_edges!(d, fill(1,length(para)), fill(2,length(para)), hom=hom(para))
+  return d
+end
+
+function FreeDiagram(comp::ComposableMorphisms{Ob,Hom}) where {Ob,Hom}
+  d = FreeDiagram{Ob,Hom}()
+  n = length(comp)
+  add_vertices!(d, n+1, ob=[dom.(comp); codom(comp)])
+  add_edges!(d, 1:n, 2:(n+1), hom=hom(comp))
   return d
 end
 

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -9,7 +9,7 @@ export AbstractLimit, AbstractColimit, Limit, Colimit,
   BinaryPullback, Pullback, pullback,
   BinaryEqualizer, Equalizer, equalizer, incl,
   BinaryCoproduct, Coproduct, coproduct, coproj1, coproj2, copair,
-  BinaryPushout, Pushout, pushout,
+  BinaryPushout, Pushout, pushout, pushout_complement,
   BinaryCoequalizer, Coequalizer, coequalizer, proj,
   @cartesian_monoidal_instance, @cocartesian_monoidal_instance,
   ComposeProductEqualizer, ComposeCoproductCoequalizer
@@ -259,6 +259,13 @@ define the method `universal(::Coequalizer{T}, ::SMulticospan{1,T})`.
 """
 factorize(lim::Equalizer, h) = universal(lim, SMultispan{1}(h))
 factorize(colim::Coequalizer, h) = universal(colim, SMulticospan{1}(h))
+
+""" Pushout complement: extend composable pair to a pushout square.
+
+[Pushout complements](https://ncatlab.org/nlab/show/pushout+complement) are the
+essential ingredient for double pushout (DPO) rewriting.
+"""
+pushout_complement(f, g) = pushout_complement(ComposablePair(f, g))
 
 # (Co)cartesian monoidal categories
 ###################################

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -9,7 +9,7 @@ export AbstractLimit, AbstractColimit, Limit, Colimit,
   BinaryPullback, Pullback, pullback,
   BinaryEqualizer, Equalizer, equalizer, incl,
   BinaryCoproduct, Coproduct, coproduct, coproj1, coproj2, copair,
-  BinaryPushout, Pushout, pushout, pushout_complement,
+  BinaryPushout, Pushout, pushout, pushout_complement, can_pushout_complement,
   BinaryCoequalizer, Coequalizer, coequalizer, proj,
   @cartesian_monoidal_instance, @cocartesian_monoidal_instance,
   ComposeProductEqualizer, ComposeCoproductCoequalizer
@@ -266,6 +266,12 @@ factorize(colim::Coequalizer, h) = universal(colim, SMulticospan{1}(h))
 essential ingredient for double pushout (DPO) rewriting.
 """
 pushout_complement(f, g) = pushout_complement(ComposablePair(f, g))
+
+""" Can a pushout complement be constructed for a composable pair?
+
+Even in nice categories, this is not generally possible.
+"""
+can_pushout_complement(f, g) = can_pushout_complement(ComposablePair(f, g))
 
 # (Co)cartesian monoidal categories
 ###################################

--- a/test/categorical_algebra/DPO.jl
+++ b/test/categorical_algebra/DPO.jl
@@ -192,12 +192,11 @@ add_parts!(L,:X,1)
 add_parts!(G,:X,1)
 l = CSetTransformation(I,L,X=[1,1])
 m = CSetTransformation(L,G,X=[1])
-@test isempty(dangling_condition(l,m))
-@test isempty(vcat(collect(id_condition(l,m))...))
+@test can_pushout_complement(l,m)
 ik, kg = pushout_complement(l,m)
 # There are 3 functions `ik` that make this a valid P.C.
 # codom=1 with [1,1], codom=2 with [1,2] or [2,1]
-K = ik.codom
+K = codom(ik)
 @test nparts(K, :X) == 1 # algorithm currently picks the first option
 
 # Non-discrete interface graph. Non-monic matching
@@ -216,21 +215,19 @@ m = CSetTransformation(arr, arr_loop, V=[2,2], E=[2]) # NOT MONIC
 @test is_isomorphic(arr_looploop, rewrite_match(L,R,m))
 
 # only one monic match
-@test is_isomorphic(arrarr_loop, rewrite(L, R, arr_loop, true))
+@test is_isomorphic(arrarr_loop, rewrite(L, R, arr_loop, monic=true))
 
 # two possible morphisms L -> squarediag, but both violate dangling condition
 L = CSetTransformation(arr, span, V=[1,2], E=[1]);
 m = CSetTransformation(span, squarediag, V=[2,1,4], E=[1,2]);
-
-@test (:src, 5, 4) in dangling_condition(L,m)
+@test (:src, 5, 4) in dangling_condition(ComposablePair(L,m))
 
 # violate id condition because two orphans map to same point
 L = CSetTransformation(I2, biarr, V=[1,2]); # delete both arrows
 m = CSetTransformation(biarr, arr_loop, V=[2,2], E=[2,2]);
-@test (:E, 1, 2, 2) in id_condition(L,m)[1]
+@test (1, 2) in id_condition(ComposablePair(L[:E],m[:E]))[2]
 L = CSetTransformation(arr, biarr, V=[1,2], E=[1]); # delete one arrow
-@test (:E, 1, 2) in id_condition(L,m)[2]
-
+@test 1 in id_condition(ComposablePair(L[:E],m[:E]))[1]
 
 span_triangle = Graph(3); # 2 <- 1 -> 3 (with edge 2->3)
 add_edges!(span_triangle,[1,1,2], [2,3,3]);

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -382,6 +382,22 @@ colim = colimit(diagram)
 @test ι1 == FinFunction([1,2], 3)
 @test ι2 == FinFunction([1,1,3], 3)
 
+# Pushout complements
+#--------------------
+
+f = FinFunction([1,3], 4)
+g = FinFunction([1,2,5,6], 6)
+h, k = pushout_complement(f, g)
+@test f⋅g == h⋅k
+colim = pushout(f,h)
+@test ob(colim) == FinSet(6)
+@test allunique(collect(copair(colim, g, k)))
+
+# Identification condition failure.
+f = FinFunction([1,3], 4)
+g = FinFunction([1,2,2,3], 3)
+@test_throws ErrorException pushout_complement(f, g)
+
 # Subsets
 #########
 

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -387,6 +387,7 @@ colim = colimit(diagram)
 
 f = FinFunction([1,3], 4)
 g = FinFunction([1,2,5,6], 6)
+@test can_pushout_complement(f, g)
 h, k = pushout_complement(f, g)
 @test f⋅g == h⋅k
 colim = pushout(f,h)
@@ -396,6 +397,7 @@ colim = pushout(f,h)
 # Identification condition failure.
 f = FinFunction([1,3], 4)
 g = FinFunction([1,2,2,3], 3)
+@test !can_pushout_complement(f, g)
 @test_throws ErrorException pushout_complement(f, g)
 
 # Subsets

--- a/test/categorical_algebra/FreeDiagrams.jl
+++ b/test/categorical_algebra/FreeDiagrams.jl
@@ -142,4 +142,22 @@ diagram = FreeDiagram(para)
 @test hom(diagram) == [f,g,h]
 @test (src(diagram), tgt(diagram)) == ([1,1,1], [2,2,2])
 
+# Composable pairs.
+f, g = Hom(:f, A, B), Hom(:g, B, C)
+pair = ComposablePair(f,g)
+@test (dom(pair), codom(pair)) == (A, C)
+@test (first(pair), last(pair)) == (f, g)
+@test_throws ErrorException ComposablePair(f,f)
+
+# Composable morphisms.
+f, g, h = Hom(:f, A, B), Hom(:g, B, C), Hom(:h, C, D)
+comp = ComposableMorphisms([f,g,h])
+@test (dom(comp), codom(comp)) == (A, D)
+@test hom(comp) == [f,g,h]
+
+diagram = FreeDiagram(comp)
+@test ob(diagram) == [A,B,C,D]
+@test hom(diagram) == [f,g,h]
+@test (src(diagram), tgt(diagram)) == (1:3, 2:4)
+
 end


### PR DESCRIPTION
This PR

- defines a generic interface for pushout complements (`pushout_complement` and `can_pushout_complement`)
- extracts an implementation of pushout complements in FinSet from pushout complements in C-Set
- refactors the latter to use the former