### PR TITLE
Restore support for non-vector iterators in `@acset` macro

### DIFF
--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -872,16 +872,15 @@ function init_acset(T::Type{<:ACSet{CD,AD,Ts}}, initvals::Dict{Symbol,Any}) wher
   hom_specs = filter((kv) -> kv[1] ∈ hom(CD), pairs(initvals))
   attr_specs = filter((kv) -> kv[1] ∈ attr(AD), pairs(initvals))
   for (k,v) in ob_specs
-      add_parts!(acs, k, Int(v))
+    add_parts!(acs, k, Int(v))
   end
-  for (k,v) in hom_specs
-      set_subpart!(acs, :, k, Vector{Int}(v))
-  end
-  for (k,v) in attr_specs
-    set_subpart!(acs, :, k, Vector{Ts.parameters[data_num(AD,codom(AD,k))]}(v))
+  for (k,v) in Iterators.flatten((hom_specs, attr_specs))
+    set_subpart!(acs, :, k, collect_nonvector(v))
   end
   acs
 end
+collect_nonvector(v::AbstractVector) = v
+collect_nonvector(v) = collect(v)
 
 """ Map over a data type, in the style of Haskell functors
 """

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -342,27 +342,33 @@ g = @acset DecGraph{String} begin
   tgt = [2,3,4,1]
   dec = ["a","b","c","d"]
 end
-
-@test nparts(g,:V) == 4
-@test subpart(g,:,:src) == [1,2,3,4]
-@test incident(g,1,:src) == [1]
+@test nparts(g, :V) == 4
+@test subpart(g, :, :src) == [1,2,3,4]
+@test incident(g, 1, :src) == [1]
 
 function path_graph(n::Int)
   @acset DecGraph{Float64} begin
     V = n
-    E = (n-1)
-    src = (1:n-1)
-    tgt = (2:n)
+    E = n-1
+    src = 1:n-1
+    tgt = 2:n
     dec = zeros(n-1)
   end
 end
 
 pg = path_graph(30)
-
-@test nparts(pg, :V) == 30
-@test nparts(pg, :E) == 29
+@test (nparts(pg, :V), nparts(pg, :E)) == (30, 29)
 @test incident(pg, 1, :src) == [1]
-    
+
+n = 4
+pg = @acset DecGraph{Tuple{Int,Int}} begin
+  V = n
+  E = n-1
+  src = 1:n-1
+  tgt = 2:n
+  dec = zip(1:n-1, 2:n)
+end
+@test pg[:dec] == [(1,2), (2,3), (3,4)]
 
 # Test mapping
 #-------------


### PR DESCRIPTION
A side effect of #463 caused a test failure in AlgDynamics.