### PR TITLE
Refactor type hierarchy in graphs module

### DIFF
--- a/benchmark/Graphs.jl
+++ b/benchmark/Graphs.jl
@@ -254,8 +254,9 @@ lgbench = bench["LightGraphs"] = BenchmarkGroup()
   Label::AttrType
   label::Attr(V,Label)
 end
-@acset_type LabeledGraph(TheoryLabeledGraph, index=[:src,:tgt])
-@acset_type IndexedLabeledGraph(TheoryLabeledGraph, index=[:src,:tgt], unique_index=[:label])
+@acset_type LabeledGraph(TheoryLabeledGraph, index=[:src,:tgt]) <: AbstractGraph
+@acset_type IndexedLabeledGraph(TheoryLabeledGraph, index=[:src,:tgt],
+                                unique_index=[:label]) <: AbstractGraph
 
 function discrete_labeled_graph(n::Int; indexed::Bool=false)
   g = (indexed ? IndexedLabeledGraph{String} : LabeledGraph{String})()

--- a/src/graphs/PropertyGraphs.jl
+++ b/src/graphs/PropertyGraphs.jl
@@ -23,7 +23,7 @@ abstract type AbstractPropertyGraph{T} end
   eprops::Attr(E,Props)
 end
 
-@abstract_acset_type __AbstractPropertyGraph
+@abstract_acset_type __AbstractPropertyGraph <: HasGraph
 
 const _AbstractPropertyGraph{T} = __AbstractPropertyGraph{S, Tuple{Dict{Symbol,T}}} where {S}
 
@@ -57,7 +57,7 @@ PropertyGraph{T}(; kw...) where T = PropertyGraph{T,_PropertyGraph{T}}(; kw...)
   compose(inv,eprops) == eprops # Edge involution preserves edge properties.
 end
 
-@abstract_acset_type __AbstractSymmetricPropertyGraph
+@abstract_acset_type __AbstractSymmetricPropertyGraph <: HasGraph
 
 const _AbstractSymmetricPropertyGraph{T} = __AbstractSymmetricPropertyGraph{S, Tuple{Dict{Symbol,T}}} where {S}
 

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -4,7 +4,7 @@ using Test
 using Catlab, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra,
   Catlab.CategoricalAlgebra.FinSets
 using Catlab.CategoricalAlgebra.CSets, Catlab.CSetDataStructures
-using Catlab.Graphs.BasicGraphs: TheoryGraph
+using Catlab.Graphs.BasicGraphs: AbstractGraph, TheoryGraph
 
 @present TheoryDDS(FreeSchema) begin
   X::Ob
@@ -233,7 +233,7 @@ h = path_graph(WeightedGraph{Float64}, 4, E=(weight=[1.,2.,3.],))
   elabel::Attr(E,Label)
 end
 
-@acset_type VELabeledGraph(TheoryVELabeledGraph, index=[:src,:tgt])
+@acset_type VELabeledGraph(TheoryVELabeledGraph, index=[:src,:tgt]) <: AbstractGraph
 
 # Initial labeled graph.
 @test ob(initial(VELabeledGraph{Symbol})) == VELabeledGraph{Symbol}()
@@ -330,7 +330,7 @@ C₅, C₆ = cycle_graph(SymmetricGraph, 5), cycle_graph(SymmetricGraph, 6)
   Label::AttrType
   label::Attr(V,Label)
 end
-@acset_type LabeledGraph(TheoryLabeledGraph, index=[:src,:tgt])
+@acset_type LabeledGraph(TheoryLabeledGraph, index=[:src,:tgt]) <: AbstractGraph
 
 g = cycle_graph(LabeledGraph{Symbol}, 4, V=(label=[:a,:b,:c,:d],))
 h = cycle_graph(LabeledGraph{Symbol}, 4, V=(label=[:c,:d,:a,:b],))

--- a/test/categorical_algebra/StructuredCospans.jl
+++ b/test/categorical_algebra/StructuredCospans.jl
@@ -3,7 +3,7 @@ using Test
 
 using Catlab, Catlab.Theories, Catlab.Graphs,
   Catlab.CategoricalAlgebra, Catlab.CategoricalAlgebra.FinSets
-using Catlab.Graphs.BasicGraphs: TheoryGraph
+using Catlab.Graphs.BasicGraphs: AbstractGraph, TheoryGraph
 
 # Structured cospans of C-sets
 ##############################
@@ -107,7 +107,7 @@ k0 = apex(k)
   elabel::Attr(E,Label)
 end
 
-@acset_type LabeledGraph(TheoryLabeledGraph, index=[:src,:tgt])
+@acset_type LabeledGraph(TheoryLabeledGraph, index=[:src,:tgt]) <: AbstractGraph
 const OpenLabeledGraphOb, OpenLabeledGraph = OpenACSetTypes(LabeledGraph, :V)
 
 g0 = LabeledGraph{Symbol}()


### PR DESCRIPTION
This PR fixes the overly loose typing of accessors like `vertices`, `edges`, and `src`. This is important for exporting a graphs interface that is generic over ACSet types. We will take advantage of this to fix longstanding hacks in CombinatorialSpaces.

This was made possible by the struct acsets refactor (#376).