### PR TITLE
Different internal representations of subobjects

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -686,10 +686,14 @@ Subobject(X::ACSet, components::NamedTuple) =
   SubACSetComponentwise(X, components)
 Subobject(X::ACSet; components...) = Subobject(X, (; components...))
 
-coerce_subob_component(X::FinSet, subset::SubFinSet) =
-  X == ob(subset) ? subset : error("Domain mismatch: $X != $(ob(subset))")
-coerce_subob_component(X::FinSet, f::FinFunction) =
-  X == codom(f) ? Subobject(f) : error("Domain mismatch: $X != $(codom(f))")
+function coerce_subob_component(X::FinSet, subset::SubFinSet)
+  X == ob(subset) ? subset :
+    error("Set $X in C-set does not match set of subset $subset")
+end
+function coerce_subob_component(X::FinSet, f::FinFunction)
+  X == codom(f) ? Subobject(f) :
+    error("Set $X in C-set does not match codomain of inclusion $f")
+end
 coerce_subob_component(X::FinSet, f) = Subobject(X, f)
 
 ob(A::SubACSetComponentwise) = A.ob

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -19,11 +19,11 @@ import ..Limits: limit, colimit, universal, pushout_complement,
   can_pushout_complement
 import ..Subobjects: Subobject, SubobjectBiHeytingAlgebra,
   implies, ⟹, subtract, \, negate, ¬, non, ~
-import ..FinSets: FinSet, FinFunction, FinDomFunction, force, as_predicate
-using ...Theories: SchemaDesc, SchemaDescType, CSetSchemaDescType,
-  Category, ob, hom, attr, adom, acodom, acodom_nums
+import ..FinSets: FinSet, FinFunction, FinDomFunction, force, predicate
+using ...Theories: SchemaDescType, CSetSchemaDescType, Category,
+  attr, adom, acodom, acodom_nums
 import ...Theories: dom, codom, compose, ⋅, id,
-  meet, ∧, join, ∨, top, ⊤, bottom, ⊥
+  ob, hom, meet, ∧, join, ∨, top, ⊤, bottom, ⊥
 
 # FinSets interop
 #################
@@ -40,15 +40,14 @@ FinFunction(X::StructACSet, name::Symbol) = fin_function(X, Val{name})
 
 @generated function fin_function(X::StructACSet{S,Ts,Idxed},
     ::Type{Val{name}}) where {Ts,S,Idxed,name}
-  s = SchemaDesc(S)
-  if name ∈ s.obs
+  if name ∈ ob(S)
     quote
       FinFunction(identity, FinSet(X, $(QuoteNode(name))))
     end
-  elseif name ∈ s.homs
+  elseif name ∈ hom(S)
     quote
       FinFunction(subpart(X, $(QuoteNode(name))),
-                  FinSet(X, $(QuoteNode(s.codoms[name]))),
+                  FinSet(X, $(QuoteNode(codom(S, name)))),
                   index=$(Idxed[name] ? :(X.hom_indices.$name) : false))
     end
   else
@@ -65,21 +64,20 @@ FinDomFunction(X::StructACSet, name::Symbol) = fin_dom_function(X, Val{name})
 
 @generated function fin_dom_function(X::StructACSet{S,Ts,Idxed},
     ::Type{Val{name}}) where {S,Ts,Idxed,name}
-  s = SchemaDesc(S)
-  if name ∈ s.obs
+  if name ∈ ob(S)
     quote
       n = nparts(X, $(QuoteNode(name)))
       FinDomFunction(1:n, FinSet(n), TypeSet{Int}())
     end
-  elseif name ∈ s.homs || name ∈ s.attrs
-    index_name = name ∈ s.homs ? :hom_indices : :attr_indices
+  elseif name ∈ hom(S) || name ∈ attr(S)
+    index_name = name ∈ hom(S) ? :hom_indices : :attr_indices
     quote
       FinDomFunction(subpart(X, $(QuoteNode(name))),
-                     index=$(Idxed[name] ? :(X.$(index_name).$name) : false))
+                     index=$(Idxed[name] ? :(X.$index_name.$name) : false))
     end
   else
     throw(ArgumentError(
-      "$(repr(name)) not in $(s.obs), $(s.homs), or $(s.attrs)"))
+      "$(repr(name)) not in $(ob(S)), $(hom(S)), or $(attr(S))"))
   end
 end
 
@@ -104,11 +102,10 @@ for data attributes is a commutative triangle, rather than a commutative square.
   codom::Codom
   function ACSetTransformation{S}(components::NamedTuple, X::Dom, Y::Codom) where
       {S, Dom <: StructACSet{S}, Codom <: StructACSet{S}}
-    s = SchemaDesc(S)
-    @assert keys(components) ⊆ s.obs
-    coerced_components = NamedTuple{Tuple(s.obs)}(
-      coerce_component(ob, get(components, ob) do; Int[] end, X, Y)
-      for ob in s.obs)
+    @assert keys(components) ⊆ ob(S)
+    coerced_components = NamedTuple{Tuple(ob(S))}(
+      coerce_component(ob, get(components, ob) do; 1:0 end, X, Y)
+      for ob in ob(S))
     new{S,typeof(coerced_components),Dom,Codom}(coerced_components, X, Y)
   end
 end
@@ -148,13 +145,12 @@ check the naturality equation on a generating set of morphisms.
 """
 function is_natural(α::ACSetTransformation{S}) where {S}
   X, Y = dom(α), codom(α)
-  s = SchemaDesc(S)
-  for f in s.homs
-    Xf, Yf, α_c, α_d = subpart(X,f), subpart(Y,f), α[s.doms[f]], α[s.codoms[f]]
+  for (f, c, d) in zip(hom(S), dom(S), codom(S))
+    Xf, Yf, α_c, α_d = subpart(X,f), subpart(Y,f), α[c], α[d]
     all(Yf[α_c(i)] == α_d(Xf[i]) for i in eachindex(Xf)) || return false
   end
-  for f in s.attrs
-    Xf, Yf, α_c = subpart(X,f), subpart(Y,f), α[s.doms[f]]
+  for (f, c) in zip(attr(S), adom(S))
+    Xf, Yf, α_c = subpart(X,f), subpart(Y,f), α[c]
     all(Yf[α_c(i)] == Xf[i] for i in eachindex(Xf)) || return false
   end
   return true
@@ -661,31 +657,50 @@ end
 # Sub-C-sets
 ############
 
+""" Sub-C-set of a C-set.
+"""
 const SubCSet{S} = Subobject{<:StructCSet{S}}
 const SubACSet{S} = Subobject{<:StructACSet{S}}
 
 components(A::SubACSet) = map(Subobject, components(hom(A)))
 force(A::SubACSet) = Subobject(force(hom(A)))
 
-""" Construct subobject of C-set from components of inclusion or predicate.
-
-This function constructs a subobject from the components of the inclusion
-morphism, given as a named tuple or as keyword arguments. The components can
-also be specified as predicates (boolean vectors).
+""" Sub-C-set represented componentwise as a collection of subsets.
 """
-function Subobject(X::T, components) where T <: ACSet
-  U = T()
-  components = map(coerce_subob_component, components)
-  copy_parts!(U, X, components)
-  Subobject(ACSetTransformation(components, U, X))
+@auto_hash_equals struct SubACSetComponentwise{
+    Ob<:ACSet, Comp<:NamedTuple} <: Subobject{Ob}
+  ob::Ob
+  components::Comp
+
+  function SubACSetComponentwise(X::Ob, components::NamedTuple) where Ob<:ACSet
+    sets = fin_sets(X)
+    @assert keys(components) ⊆ keys(sets)
+    coerced_components = NamedTuple{keys(sets)}(
+      coerce_subob_component(set, get(components, ob) do; 1:0 end)
+      for (ob, set) in pairs(sets))
+    new{Ob,typeof(coerced_components)}(X, coerced_components)
+  end
 end
+
+Subobject(X::ACSet, components::NamedTuple) =
+  SubACSetComponentwise(X, components)
 Subobject(X::ACSet; components...) = Subobject(X, (; components...))
 
-coerce_subob_component(f::FinFunction{Int}) = collect(f)
-coerce_subob_component(A::SubFinSet{Int}) = collect(hom(A))
-coerce_subob_component(f::AbstractVector{Int}) = f
-coerce_subob_component(pred::Union{AbstractVector{Bool},BitVector}) =
-  findall(pred)
+coerce_subob_component(X::FinSet, subset::SubFinSet) =
+  X == ob(subset) ? subset : error("Domain mismatch: $X != $(ob(subset))")
+coerce_subob_component(X::FinSet, f::FinFunction) =
+  X == codom(f) ? Subobject(f) : error("Domain mismatch: $X != $(codom(f))")
+coerce_subob_component(X::FinSet, f) = Subobject(X, f)
+
+ob(A::SubACSetComponentwise) = A.ob
+components(A::SubACSetComponentwise) = A.components
+
+function hom(A::SubACSetComponentwise{T}) where T <: ACSet
+  U, X = T(), ob(A)
+  hom_components = map(collect∘hom, components(A))
+  copy_parts!(U, X, hom_components)
+  ACSetTransformation(hom_components, U, X)
+end
 
 @instance SubobjectBiHeytingAlgebra{ACSet,SubACSet} begin
   @import ob
@@ -732,7 +747,7 @@ subtraction of sub-C-sets ([`subtract`](@ref)).
 """
 function implies(A::SubACSet{S}, B::SubACSet{S}, ::SubOpBoolean) where S
   X = common_ob(A, B)
-  A, B = map(as_predicate, components(A)), map(as_predicate, components(B))
+  A, B = map(predicate, components(A)), map(predicate, components(B))
   D = map(X₀ -> trues(length(X₀)), fin_sets(X))
 
   function unset!(c, x)
@@ -759,7 +774,7 @@ for all ``c ∈ C`` and ``x ∈ X(c)``. Compare with [`implies`](@ref).
 """
 function subtract(A::SubACSet{S}, B::SubACSet{S}, ::SubOpBoolean) where S
   X = common_ob(A, B)
-  A, B = map(as_predicate, components(A)), map(as_predicate, components(B))
+  A, B = map(predicate, components(A)), map(predicate, components(B))
   D = map(X₀ -> falses(length(X₀)), fin_sets(X))
 
   function set!(c, x)

--- a/src/categorical_algebra/Subobjects.jl
+++ b/src/categorical_algebra/Subobjects.jl
@@ -76,15 +76,24 @@ end
 
 """ Subobject in a category.
 
-A subobject of an object ``X`` is a monomorphism into ``X``.
+By definition, a subobject of an object ``X`` in a category is a monomorphism
+into ``X``. This is the default representation of a subobject. Certain
+categories may support additional representations. For example, if the category
+has a subobject classifier ``Ω``, then subobjects of ``X`` are also morphisms
+``X → Ω``.
 """
-@auto_hash_equals struct Subobject{Ob,Hom}
+abstract type Subobject{Ob} end
+
+# Default constructor for subobjects assumes a morphism representation.
+Subobject(hom) = SubobjectHom(hom)
+
+@auto_hash_equals struct SubobjectHom{Ob,Hom} <: Subobject{Ob}
   hom::Hom
-  Subobject(hom::Hom) where Hom = new{typeof(codom(hom)),Hom}(hom)
+  SubobjectHom(hom::Hom) where Hom = new{typeof(codom(hom)),Hom}(hom)
 end
 
-hom(sub::Subobject) = sub.hom
-ob(sub::Subobject) = codom(hom(sub))
+hom(sub::SubobjectHom) = sub.hom
+ob(sub::SubobjectHom) = codom(hom(sub))
 
 # Algorithms
 ############

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -344,20 +344,22 @@ h = cycle_graph(LabeledGraph{Symbol}, 4, V=(label=[:a,:b,:d,:c],))
 # Construct sub-C-sets.
 X = path_graph(Graph, 4)
 A = Subobject(X, V=[2,3,4], E=[2,3])
-@test Subobject(X, V=[false,true,true,true], E=[false,true,true]) == A
+@test ob(A) == X
 α = hom(A)
 @test is_natural(α)
 @test dom(α) == path_graph(Graph, 3)
 @test codom(α) == X
+A_pred = Subobject(X, V=[false,true,true,true], E=[false,true,true])
+@test hom(A_pred) == α
 
 # Lattice of sub-C-sets.
 X = Graph(6)
 add_edges!(X, [1,2,3,4,4], [3,3,4,5,6])
 A, B = Subobject(X, V=1:4, E=1:3), Subobject(X, V=3:6, E=3:5)
-@test A ∧ B == Subobject(X, V=3:4, E=3:3)
-@test A ∨ B == Subobject(X, V=1:6, E=1:5)
-@test ⊤(X) |> force == Subobject(X, V=1:6, E=1:5)
-@test ⊥(X) |> force == Subobject(X, V=1:0, E=1:0)
+@test A ∧ B |> force == Subobject(X, V=3:4, E=3:3) |> force
+@test A ∨ B |> force == Subobject(X, V=1:6, E=1:5) |> force
+@test ⊤(X) |> force == Subobject(X, V=1:6, E=1:5) |> force
+@test ⊥(X) |> force == Subobject(X, V=1:0, E=1:0) |> force
 
 # Bi-Heyting algebra of sub-C-sets.
 #
@@ -371,12 +373,12 @@ Z = cycle_graph(Graph, 1) ⊕ cycle_graph(Graph, 1)
                          CSetTransformation(I, Z, V=[1]))
 B_implies_C, B = Subobject(ιY), Subobject(ιZ)
 C = Subobject(ob(colim), V=2:5, E=2:3)
-@test (B ⟹ C) == B_implies_C
+@test (B ⟹ C) |> force == B_implies_C |> force
 
 # Subtraction in Graph (Reyes et al 2004, Sec 9.1, p. 144).
 X = ob(colim)
 C = Subobject(X, V=2:5, E=[2,3,ne(X)-1])
-@test (B \ C) == Subobject(X, V=[nv(X)], E=[ne(X)])
+@test (B \ C) |> force == Subobject(X, V=[nv(X)], E=[ne(X)]) |> force
 
 # Negation in Graph (Reyes et al 2004, Sec 9.1, p. 139-140).
 X = cycle_graph(Graph, 1) ⊕ path_graph(Graph, 2) ⊕ cycle_graph(Graph, 4)
@@ -385,15 +387,15 @@ add_edge!(X, 4, 8)
 A = Subobject(X, V=[2,3,4,5,8], E=[3,7])
 neg_A = Subobject(X, V=[1,6,7], E=[1,5])
 @test is_natural(hom(A)) && is_natural(hom(neg_A))
-@test ¬A == neg_A
-@test ¬neg_A == Subobject(X, V=[2,3,4,5,8], E=[2,3,7])
+@test ¬A |> force == neg_A |> force
+@test ¬neg_A |> force == Subobject(X, V=[2,3,4,5,8], E=[2,3,7]) |> force
 
 # Non in Graph (Reyes et al 2004, Sec 9.1, p. 144).
 X = path_graph(Graph, 5) ⊕ path_graph(Graph, 2) ⊕ cycle_graph(Graph, 1)
 A = Subobject(X, V=[1,4,5], E=[4])
 non_A = Subobject(X, V=setdiff(vertices(X), 5), E=setdiff(edges(X), 4))
-@test ~A == non_A
-@test ~non_A == Subobject(X, V=[4,5], E=[4])
+@test ~A |> force == non_A |> force
+@test ~non_A |> force == Subobject(X, V=[4,5], E=[4]) |> force
 
 # Negation and non in DDS.
 S₁ = DDS(); add_parts!(S₁, :X, 5, Φ=[3,3,4,5,5])
@@ -401,9 +403,9 @@ S₂ = DDS(); add_parts!(S₂, :X, 3, Φ=[2,3,3])
 ι₁, ι₂ = colim = coproduct(S₁, S₂)
 S = ob(colim)
 A = Subobject(S, X=[3,4,5])
-@test ¬A == Subobject(ι₂)
-@test ¬Subobject(ι₂) == Subobject(ι₁)
-@test ~A == ⊤(S) |> force
+@test ¬A |> force == Subobject(ι₂)
+@test ¬Subobject(ι₂) |> force == Subobject(ι₁)
+@test ~A |> force == ⊤(S) |> force
 
 # Serialization
 ###############

--- a/test/categorical_algebra/DPO.jl
+++ b/test/categorical_algebra/DPO.jl
@@ -242,7 +242,7 @@ k, g = pushout_complement(L, m); # get PO complement to do further tests
 @test is_isomorphic(span_triangle, codom(k))
 
 # Check pushout properties 1: apex is the original graph
-@test is_isomorphic(squarediag, pushout(L, k).cocone.apex) # recover original graph
+@test is_isomorphic(squarediag, ob(pushout(L, k))) # recover original graph
 
 # Check pushout properties 2: the diagram commutes
 Lm = compose(L,m);

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -406,10 +406,13 @@ g = FinFunction([1,2,2,3], 3)
 X = FinSet(10)
 A, B = SubFinSet(X, [1,2,5,6,8,9]), SubFinSet(X, [2,3,5,7,8])
 @test ob(A) == X
+A_pred = SubFinSet(Bool[1,1,0,0,1,1,0,1,1,0])
+@test hom(A) == hom(A_pred)
+@test FinSets.predicate(A) == FinSets.predicate(A_pred)
 
 # Lattice of subsets.
-@test A ∧ B == SubFinSet(X, [2,5,8])
-@test A ∨ B == SubFinSet(X, [1,2,3,5,6,7,8,9])
+@test A ∧ B |> force == SubFinSet(X, [2,5,8])
+@test A ∨ B |> force == SubFinSet(X, [1,2,3,5,6,7,8,9])
 @test ⊤(X) |> force == SubFinSet(X, 1:10)
 @test ⊥(X) |> force == SubFinSet(X, 1:0)
 


### PR DESCRIPTION
Closes #472. This is a cleaner design and will result in fewer allocations when stringing together sub-C-set operations.