### PR TITLE
minor rem_part bug for certain ACSet schemas

### DIFF
--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -192,7 +192,7 @@ end
 
 make_table(::Type{T}, cols) where T = T(cols)
 make_table(::Type{NamedTuple}, cols) = cols # No copy constructor defined.
-       
+
 # StructACSet Operations
 ########################
 
@@ -308,7 +308,7 @@ function incident_body(s::SchemaDesc,
     throw(ArgumentError("$(repr(f)) not in $(s.homs)"))
   end
 end
-    
+
 @generated function _incident(acs::StructACSet{S,Ts,Idxed,UniqueIdxed},
                               part, ::Type{Val{f}}; copy::Bool=false) where
   {S,Ts,Idxed,UniqueIdxed,f}
@@ -497,7 +497,7 @@ end
 
 @generated function _rem_part!(acs::StructACSet{S,Ts,idxed}, ::Type{Val{ob}},
                                part::Int) where {S,Ts,ob,idxed}
-  rem_part_body(SchemaDesc(S),Dict(idxed),ob)
+  rem_part_body(SchemaDesc(S),Dict{Symbol, Bool}(idxed),ob)
 end
 
 function Base.copy(acs::StructACSet)


### PR DESCRIPTION
There is a bug that prevents one from using `rem_part` on an initial CSet schema instance due to type ambiguity of a Dict. This is a really minor fix that is needed for the following example to work.
```
using Catlab.CategoricalAlgebra
using Catlab.Present
using Catlab.Graphs

initG = Graph(1)
rem_part!(initG, :V, 1) # WORKS!

@present ThInitial(FreeSchema) begin
  I::Ob
end

@acset_type Initial(ThInitial)
init = Initial()
add_part!(init, :I)
rem_part!(init, :I, 1) #ERROR in calling rem_part_body 
```