### PR TITLE
Fast Left-Kan Extensions Using The Chase implementation

### DIFF
--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -192,7 +192,7 @@ end
 
 make_table(::Type{T}, cols) where T = T(cols)
 make_table(::Type{NamedTuple}, cols) = cols # No copy constructor defined.
-       
+
 # StructACSet Operations
 ########################
 
@@ -308,7 +308,7 @@ function incident_body(s::SchemaDesc,
     throw(ArgumentError("$(repr(f)) not in $(s.homs)"))
   end
 end
-    
+
 @generated function _incident(acs::StructACSet{S,Ts,Idxed,UniqueIdxed},
                               part, ::Type{Val{f}}; copy::Bool=false) where
   {S,Ts,Idxed,UniqueIdxed,f}
@@ -454,7 +454,7 @@ function getassigned(acs::StructACSet, arrows, i)
   Dict(f => subpart(acs,i,f) for f in assigned_subparts)
 end
 
-function rem_part_body(s::SchemaDesc, idxed::Dict{Symbol,Bool}, ob::Symbol)
+function rem_part_body(s::SchemaDesc, idxed, ob::Symbol)
   in_homs = filter(hom -> s.codoms[hom] == ob, s.homs)
   out_homs = filter(f -> s.doms[f] == ob, s.homs)
   out_attrs = filter(f -> s.doms[f] == ob, s.attrs)

--- a/src/categorical_algebra/DataMigration.jl
+++ b/src/categorical_algebra/DataMigration.jl
@@ -1,11 +1,13 @@
 """ Data Migration functors
 """
 module DataMigration
-export Functor, Delta, Sigma, migrate!
+export Functor, Delta, Sigma, migrate!, chase
 
 using ...Present, ...Theories
 using ...Theories: SchemaDesc, ob, hom, dom, codom, attr
 using ..FinSets, ..CSets, ..Limits, ...Graphs, ..FreeDiagrams
+using ...CSetDataStructures: struct_acset
+using DataStructures
 
 import ...CategoricalAlgebra.FreeDiagrams: FreeDiagram
 import ...Present: Presentation
@@ -18,7 +20,7 @@ abstract type AbstractFunctor end
 
 """   Functor
 
-A functor ``F: \\mathcal{C} \\to \\mathcal{D}`` consists of a map of objects and a 
+A functor ``F: \\mathcal{C} \\to \\mathcal{D}`` consists of a map of objects and a
 map of homomorphisms from a domain category ``\\mathcal{C}``  to a codomain
 category ``\\mathcal{D}``.
 """
@@ -35,10 +37,10 @@ codom(F::Functor) = F.codom
 Ob(F::Functor) = F.FOb
 Hom(F::Functor) = F.FHom
 
-# To construct a functor where FOb and FHom are keyed by the symbols of 
-# the domain and codomain presentations. Turn them into a dictionaries 
+# To construct a functor where FOb and FHom are keyed by the symbols of
+# the domain and codomain presentations. Turn them into a dictionaries
 # whose keys and values are homs.
-function Functor(FOb::Dict{Symbol, Symbol}, FHom::Dict{Symbol, H}, 
+function Functor(FOb::Dict{Symbol, Symbol}, FHom::Dict{Symbol, H},
                  dom::Presentation, codom::Presentation) where H
   Functor(
     Dict(dom[c_name] => codom[Fc_name] for (c_name, Fc_name) in FOb),
@@ -49,7 +51,7 @@ end
 
 get_hom(presY::Presentation, Ff::FreeSchema.Hom) = Ff
 get_hom(presY::Presentation, Ff::Symbol) = presY[Ff]
-get_hom(presY::Presentation, Ff::Array) = 
+get_hom(presY::Presentation, Ff::Array) =
   reduce(compose, map(h -> get_hom(presY, h), Ff))
 
 
@@ -84,7 +86,7 @@ end
 """   Delta(F::Functor)
 
 Given a functor ``F: \\mathcal{C} \\to \\mathcal{D}`` produces a `MigrationFunctor`
-which maps a ``\\mathcal{D}``-set ``X`` to the ``\\mathcal{C}``-set 
+which maps a ``\\mathcal{D}``-set ``X`` to the ``\\mathcal{C}``-set
 ``\\Delta_F(X) := X \\circ F``.
 
 See (Spivak, 2014, *Category Theory for the Sciences*) for details.
@@ -95,9 +97,9 @@ function (ΔF::DeltaMigration)(X::StructACSet{S}, Y::ACSet) where {S}
   FOb = Ob(ΔF.F)
   FHom = Hom(ΔF.F)
 
-  partsX = Dict(map(ob(S)) do c_name 
+  partsX = Dict(map(ob(S)) do c_name
     c = dom(ΔF.F)[c_name]
-    c => add_parts!(X, c_name, nparts(Y, nameof(FOb[c]))) 
+    c => add_parts!(X, c_name, nparts(Y, nameof(FOb[c])))
   end)
 
   for (f, Ff) in collect(FHom)
@@ -112,13 +114,13 @@ end
 
 """   migrate!(X::ACSet, Y::ACSet, FOb, FHom)
 
-Migrates the data from `Y` to `X` via the pullback 
-data migration induced by the functor defined on objects by `FOb` and 
+Migrates the data from `Y` to `X` via the pullback
+data migration induced by the functor defined on objects by `FOb` and
 on morphisms by `FHom`.
 """
 migrate!(X::ACSet, Y::ACSet, F::Functor) = Delta(F, typeof(Y), typeof(X))(X,Y)
 
-migrate!(X::ACSet, Y::ACSet, FOb, FHom) = 
+migrate!(X::ACSet, Y::ACSet, FOb, FHom) =
   migrate!(X,Y, Functor(FOb, FHom, Presentation(X), Presentation(Y)))
 
 function (::Type{T})(Y::ACSet, FOb::AbstractDict, FHom::AbstractDict) where T <: ACSet
@@ -152,11 +154,11 @@ end
 
 Given a functor ``F: \\mathcal{C} \\to \\mathcal{D}`` produces a `MigrationFunctor`
 which maps a ``\\mathcal{C}``-set ``X`` to the ``\\mathcal{D}``-set ``\\Sigma_F(X)``.
-``\\Sigma_F`` is left-adjoint to ``\\Delta_F``. 
+``\\Sigma_F`` is left-adjoint to ``\\Delta_F``.
 
-For ``d \\in \\mathsf{ob}\\mathcal{D}``, 
-``\\Sigma_F(X)(d) := \\mathsf{colim}_{F \\downarrow d} X \\circ \\pi`` where 
-``\\pi: F\\downarrow d \\to \\mathcal{C}`` is the projection. 
+For ``d \\in \\mathsf{ob}\\mathcal{D}``,
+``\\Sigma_F(X)(d) := \\mathsf{colim}_{F \\downarrow d} X \\circ \\pi`` where
+``\\pi: F\\downarrow d \\to \\mathcal{C}`` is the projection.
 
 See (Spivak, 2014, *Category Theory for the Sciences*) for details.
 """
@@ -181,14 +183,14 @@ function (ΣF::SigmaMigration)(Y::ACSet, X::ACSet)
   for d in parts(diagramD, :V)
     add_parts!(Y, nameof(ob(diagramD, d)), length(apex(colimX[d])))
   end
-  
+
   # Define Y on morphisms by the universal property
   for g in parts(diagramD, :E)
     if nparts(Y, nameof(dom(hom(diagramD, g)))) == 0
       continue
     end
     set_subpart!(Y, nameof(hom(diagramD, g)),
-      universal(colimX[src(diagramD, g)], 
+      universal(colimX[src(diagramD, g)],
         Multicospan(legs(colimX[tgt(diagramD, g)])[hom(comma_cats, g)[:V].func])
       ).func
     )
@@ -199,7 +201,7 @@ end
 
 """   inv(D::AbstractDict)
 
-Given a dictionary `D` returns a function that maps a proposed value 
+Given a dictionary `D` returns a function that maps a proposed value
 `y` to the array of all keys with value `y`.
 """
 inv(D::AbstractDict) = y -> [k for (k,v) in D if v == y]
@@ -209,7 +211,7 @@ inv(D::AbstractDict) = y -> [k for (k,v) in D if v == y]
 
 Adds a hom to `d` from the vertex with object `src_ob` to the vertex with object `tgt_ob`.
 """
-function add_hom!(d::FreeDiagram, src_ob, tgt_ob, hom) 
+function add_hom!(d::FreeDiagram, src_ob, tgt_ob, hom)
   src_idx = first(incident(d, src_ob, :ob))
   tgt_idx = first(incident(d, tgt_ob, :ob))
   return add_edge!(d, src_idx, tgt_idx, hom = hom)
@@ -217,9 +219,9 @@ end
 
 """   comma_cats(diagramD::FreeDiagram{FreeSchema.Ob, FreeSchema.Hom}, FOb, FHom)
 
-Given a free category ``\\mathcal{D}`` with no cycles and 
-a functor represented by the pair `(FOb, FHom)`, returns a diagram 
-``\\mathcal{D} \\to \\mathsf{Cat}`` which on objects takes ``d \\in \\mathcal{D}`` to the 
+Given a free category ``\\mathcal{D}`` with no cycles and
+a functor represented by the pair `(FOb, FHom)`, returns a diagram
+``\\mathcal{D} \\to \\mathsf{Cat}`` which on objects takes ``d \\in \\mathcal{D}`` to the
 comma category ``F \\downarrow d``.
 """
 function get_comma_cats(F::Functor)
@@ -227,9 +229,9 @@ function get_comma_cats(F::Functor)
   FObInv = inv(Ob(F)); FHomInv = inv(Hom(F))
   comma_cats = FreeDiagram{FreeDiagram, ACSetTransformation}()
   add_vertices!(comma_cats,
-    nparts(diagramD, :V), 
+    nparts(diagramD, :V),
     ob = map(parts(diagramD, :V)) do _
-      FreeDiagram{Pair{FreeSchema.Ob, FreeSchema.Hom}, FreeSchema.Hom}() 
+      FreeDiagram{Pair{FreeSchema.Ob, FreeSchema.Hom}, FreeSchema.Hom}()
     end
   )
 
@@ -238,10 +240,10 @@ function get_comma_cats(F::Functor)
     id_d = id(ob(diagramD, d))
 
     # If FOb[c] = d, add an objects (c, id(d)) to F∇d
-    preimage_d = FObInv(ob(diagramD, d)) 
+    preimage_d = FObInv(ob(diagramD, d))
     id_obs = add_vertices!(F∇d, length(preimage_d), ob = map(c->c=>id_d, preimage_d))
-    
-    # if FHom[h] = id(d), add a hom h: (dom(h), id(d)) -> (codom(h), id(d)) to F∇d 
+
+    # if FHom[h] = id(d), add a hom h: (dom(h), id(d)) -> (codom(h), id(d)) to F∇d
     id_homs = map(FHomInv(id_d)) do h
       add_hom!(F∇d, dom(h) => id_d, codom(h) => id_d, h)
     end
@@ -251,8 +253,8 @@ function get_comma_cats(F::Functor)
     for g in incident(diagramD, d, :tgt)
       d′ = src(diagramD, g)
       F∇g = comma_cat_hom!(F∇d, ob(comma_cats, d′), id_d, hom(diagramD, g), FHomInv)
-      add_edge!(comma_cats, d′, d, hom=F∇g)      
-    end 
+      add_edge!(comma_cats, d′, d, hom=F∇g)
+    end
   end
 
   return comma_cats
@@ -261,14 +263,14 @@ end
 function comma_cat_hom!(F∇d, F∇d′, id_d, g, FHomInv)
   # for (c,f) in F∇d' add ob (c, compose(f,g)) to F∇d
   vs = add_vertices!(F∇d, nparts(F∇d′, :V), ob = map(ob(F∇d′)) do (c,f)
-    c => compose(f, g)                
+    c => compose(f, g)
   end)
 
-  # for h: (c, f) -> (c', f') in diagram_d', add hom h to F∇d    
+  # for h: (c, f) -> (c', f') in diagram_d', add hom h to F∇d
   es = add_edges!(F∇d, vs[src(F∇d′)], vs[tgt(F∇d′)], hom = hom(F∇d′))
-  
 
-  # for every (c,f) in the recently added objects. If FHom[h] == f, then add the hom 
+
+  # for every (c,f) in the recently added objects. If FHom[h] == f, then add the hom
   #       h: (c,f) -> (codom(h), idv)
   # relies on D being free
   for (c, f) in ob(F∇d, vs)
@@ -277,7 +279,7 @@ function comma_cat_hom!(F∇d, F∇d′, id_d, g, FHomInv)
     end
   end
 
-  # return the inclusion from F∇d′ to F∇d 
+  # return the inclusion from F∇d′ to F∇d
   return ACSetTransformation((V = collect(vs), E = collect(es)), F∇d′, F∇d)
 end
 
@@ -291,7 +293,7 @@ end
 
 """   FreeDiagram(pres::Presentation{FreeSchema, Symbol})
 
-Returns a `FreeDiagram` whose objects are the generating objects of `pres` and 
+Returns a `FreeDiagram` whose objects are the generating objects of `pres` and
 whose homs are the generating homs of `pres`.
 """
 function FreeDiagram(pres::Presentation{Schema, Symbol}) where Schema
@@ -301,5 +303,244 @@ function FreeDiagram(pres::Presentation{Schema, Symbol}) where Schema
   codoms = map(h -> generator_index(pres, nameof(codom(h))), homs)
   return FreeDiagram(obs, collect(zip(homs, doms, codoms)))
 end
+
+
+# Chase Algorithm
+#################
+
+add_srctgt(x::Symbol) = Symbol("src_$(x)") => Symbol("tgt_$(x)")
+
+"""Create a ACSet instance modeling a C-Rel from an instance of an ACSet"""
+function crel(x::StructACSet{S}) where {S}
+  name = Symbol("Rel_$(typeof(x).name.name)")
+  os, hs, _, _, src, tgt = S.parameters
+  pres = Presentation(FreeSchema)
+  nv = length(os)
+  alledge = Symbol[]
+  xobs = [Ob(FreeSchema, sym) for sym in vcat(os...,hs...)]
+  for x in xobs
+    add_generator!(pres, x)
+  end
+  for (i,h) in enumerate(hs)
+    s, t = add_srctgt(h)
+    add_generator!(pres, Hom(s, xobs[nv+i], xobs[src[h]]))
+    add_generator!(pres, Hom(t, xobs[nv+i], xobs[tgt[h]]))
+    append!(alledge, [s,t])
+  end
+  expr = struct_acset(name, StructACSet, pres, index=alledge)
+  eval(expr)
+  rel = eval(name)
+  J = Base.invokelatest(rel)
+
+  # initialize the C-Rel with x which satisfies the laws
+  for o in ob(S)
+    add_parts!(J, o, nparts(x, o))
+  end
+  src, tgt = dom(S), codom(S)
+  for (i, d) in enumerate(hom(S))
+    hs, ht = add_srctgt(d)
+    add_parts!(J, d, nparts(x, src[i]))
+    set_subpart!(J, hs, parts(x, src[i]))
+    set_subpart!(J, ht, x[d])
+  end
+  return J
+end
+
+"""Convert a C-Rel back to a C-Set, fail if relations are not functional"""
+function uncrel(J::StructACSet, I::StructACSet{S}) where {S}
+  res = typeof(I)()
+  for o in ob(S)
+    add_parts!(res, o, nparts(J, o))
+  end
+  for m in hom(S)
+    msrc, mtgt = add_srctgt(m)
+    md, mcd = zip(sort(collect(zip(J[msrc], J[mtgt])))...)
+    collect(md) == collect(1:length(md)) || error("nonfunctional $J")
+    set_subpart!(res, m, mcd)
+  end
+  return res
+end
+
+"""Evaluate a possibly composite composition on a subset of the domain"""
+function eval_path(pth, J::StructACSet, xs::Set{Int})::Set{Int}
+  pthkind = typeof(pth).parameters[1]  # Warning: uses implementation details
+  if pthkind == :id
+    return xs
+  elseif pthkind == :generator
+    args = [pth]
+  elseif pthkind == :compose
+    args = pth.args
+  else
+    error(pthkind)
+  end
+  # Iteratively update X to Y by searching through all (x,y) in R ⊆ X×Y
+  for m in map(Symbol, args)
+    msrc, mtgt = add_srctgt(m)
+    if isempty(xs)
+      return xs
+    else
+      newxs = Set{Int}()
+      for (jx, jy) in zip(J[msrc], J[mtgt])
+        if jx ∈ xs
+          push!(newxs, jy)
+        end
+      end
+      xs = newxs
+    end
+  end
+  return xs
+end
+
+"""
+Chase algorithm as described by Spivak and Wisnesky in "Fast Left-Kan Extensions
+Using The Chase"
+
+Todo: handle attributes
+"""
+function chase(F::Functor, I::StructACSet{IS}, codomI::StructACSet{S};
+               n::Int=8, verbose::Bool=false)::StructACSet{S} where {IS, S}
+  J = crel(codomI) # pre-model data structure, initialized with codomI
+  η = Dict() # mapping into J from I
+
+  # Further initialize J using the domain instance, I
+  for c in generators(dom(F), :Ob)
+    η[c] = add_parts!(J, Symbol(Ob(F)[c]), nparts(I, Symbol(c)))
+  end
+  changed = false # iterate until no change or n is reached
+  for counter in 1:n
+    if verbose
+      println("----- ITERATION $counter ------")
+    end
+
+    # Initialize equivalence relations for each component
+    eqclasses = Dict([o=>IntDisjointSets(nparts(J, o)) for o in ob(S)])
+    changed = false
+
+    # Action α: add new elements when a function is dangling
+    fresh = Dict{Symbol, Set{Int}}([o=>Set{Int}() for o in ob(S)])
+    for (d, ddom, dcodom) in zip(hom(S), dom(S), codom(S))
+      dsrc, dtgt = add_srctgt(d)
+      xs = setdiff(parts(J, ddom), J[dsrc] ∪ fresh[ddom])
+      for x in xs  # no y such that (x,y) ∈ J(d) and no fresh x
+        gx = add_part!(J, dcodom) # add a fresh symbol
+        if verbose
+          println("α: $d($ddom#$x) ADDED $dcodom $gx")
+        end
+        add_part!(J, d; Dict([dsrc=>x, dtgt=>gx])...)
+        gx_ = push!(eqclasses[dcodom])
+        push!(fresh[dcodom], gx)
+        gx == gx_ || error("Unexpected mismatch: $eqclasses \n$J")
+        changed = true
+      end
+    end
+
+    # Action βd: add all coincidences induced by D (i.e. fire EGDs)
+    for (p, q) in equations(codom(F))
+      for x in parts(J, Symbol(dom(p)))
+        for px in eval_path(p, J, Set([x]))
+          for qx in eval_path(q, J, Set([x]))
+            union!(eqclasses[Symbol(codom(p))], px, qx)
+            if verbose && px != qx
+              println("βF: $p=$q MERGED $(codom(p)) $px = $qx")
+            end
+            changed |= px != qx # flip iff changed = ⊥ AND px != qx
+          end
+        end
+      end
+    end
+
+    # Action βF: add all coincidences induced by F. Naturality square constraint
+    for mg in generators(dom(F), :Hom)
+      m, Fm, Fmcodom = map(Symbol, [mg, Hom(F)[mg], Ob(F)[codom(mg)]])
+      is_id = typeof(Hom(F)[mg]).parameters[1] == :id
+      for (x, mx) in enumerate(I[m])
+        mα = η[codom(mg)][mx]
+        Fms, Fmt = add_srctgt(Fm)
+        αx = η[dom(mg)][x]
+        αm = is_id ? αx : J[Fmt][incident(J, αx, Fms)[1]]
+        union!(eqclasses[Fmcodom], mα, αm)
+        if verbose && mα != αm
+          println("βF: $mg ($(dom(mg))#$x) MERGED $Fmcodom $mα = $αm")
+        end
+        changed |= mα != αm # flip iff changed = ⊥ AND mα != αm
+      end
+    end
+
+    # Action δ: add all coincidences induced by functionality
+    for (d, ddom, dcodom) in zip(hom(S), dom(S), codom(S))
+      dsrc, dtgt = add_srctgt(d)
+      for x in parts(J, ddom)
+        eq_ys = collect(Set(J[dtgt][incident(J, x, dsrc)]))
+        for (y1, y2) in zip(eq_ys, eq_ys[2:end])
+          union!(eqclasses[dcodom], y1, y2)
+          if verbose
+            println("δ: $d($ddom#$x) MERGED $dcodom $y1 = $y2")
+          end
+          changed = true
+        end
+      end
+    end
+
+    # Action γ: merge coincidentally equal elements
+    μ = Dict{Symbol, Vector{Pair{Int,Int}}}([o=>Pair{Int,Int}[] for o in ob(S)])
+    delob = Dict{Symbol, Vector{Int}}([o=>Int[] for o in ob(S)])
+    for (o, eq) in pairs(eqclasses)
+      eqsets = Dict{Int,Set{Int}}()
+      # Recover the equivalence classes from the union-find structure
+      for x in parts(J, o)
+        eqrep = find_root(eq, x)
+        if haskey(eqsets, eqrep)
+          push!(eqsets[eqrep], x)
+        else
+          eqsets[eqrep] = Set([x])
+        end
+      end
+      if verbose
+        println("eqset $o $(values(eqsets))")
+      end
+      # Minimum element is the representative
+      for vs in values(eqsets)
+        m = minimum(vs)
+        delete!(vs, m)
+        append!(μ[o], [v=>m for v in vs])
+        append!(delob[o], collect(vs))
+      end
+    end
+    # Replace all instances of a class with its representative in J and η
+    for (d, ddom, dcodom) in zip(hom(S), dom(S), codom(S))
+      dsrc, dtgt = add_srctgt(d)
+      isempty(μ[ddom]) || set_subpart!(J, dsrc, replace(J[dsrc], μ[ddom]...))
+      isempty(μ[dcodom]) || set_subpart!(J, dtgt, replace(J[dtgt], μ[dcodom]...))
+      # remove redundant duplicate relation rows
+      seen = Set()
+      for (i, st) in enumerate(zip(J[dsrc], J[dtgt]))
+        if st ∈ seen
+          rem_part!(J, d, i)
+        else
+          push!(seen, st)
+        end
+      end
+    end
+    for (Iob, mapping) in collect(η)
+      reps = μ[Symbol(Ob(F)[Iob])]
+      if !isempty(reps)
+        η[Iob] = replace(mapping, reps...)
+      end
+    end
+    for (o, vs) in collect(delob)
+      isempty(vs) || rem_parts!(J, o, sort(vs))
+    end
+    if !changed
+      break # termination condition
+    end
+  end
+
+  if changed
+    error("Chase did not terminate with $n steps: $J")
+  else
+    return uncrel(J, codomI)
+  end
+end
+
 
 end #module

--- a/test/categorical_algebra/DataMigration.jl
+++ b/test/categorical_algebra/DataMigration.jl
@@ -9,6 +9,7 @@ using Catlab.Theories
 using Catlab.Theories: id, compose
 using Catlab.Present
 
+
 # Pullback data migration
 ###########################
 
@@ -24,10 +25,12 @@ h = Graph(3)
 add_parts!(h, :E, 3, src = [1,2,3], tgt = [2,3,1])
 
 # Identity data migration.
+#-------------------------
 @test h == Graph(h, Dict(:V => :V, :E => :E),
                     Dict(:src => :src, :tgt => :tgt))
 
 # Migrate DDS → Graph.
+#---------------------
 dds = DDS()
 add_parts!(dds, :X, 3, Φ=[2,3,1])
 X = TheoryDDS[:X]
@@ -40,6 +43,7 @@ migrate!(h2, dds, Dict(:V => :X, :E => :X),
 @test h2 == ob(coproduct(h, h))
 
 # Migrate DDS → DDS by advancing four steps.
+#-------------------------------------------
 @test dds == DDS(dds, Dict(:X => :X),
                       Dict(:Φ => [:Φ, :Φ, :Φ, :Φ]))
 
@@ -47,6 +51,7 @@ migrate!(h2, dds, Dict(:V => :X, :E => :X),
   Label::AttrType
   label::Attr(X, Label)
 end
+
 @acset_type LabeledDDS(TheoryLabeledDDS, index=[:Φ, :label])
 
 S, ϕ, Label, label = generators(TheoryLabeledDDS)
@@ -67,7 +72,7 @@ add_parts!(wg, :E, 4, src=[1,2,3,4], tgt=[2,3,4,1], weight=[101, 102, 103, 100])
 
 
 F = Functor(
-  Dict(V => S, E => S), 
+  Dict(V => S, E => S),
   Dict(s => id(S), t => ϕ, weight => compose(ϕ, label)),
   TheoryWeightedGraph, TheoryLabeledDDS
 )
@@ -76,20 +81,23 @@ F = Functor(
 @test dom(ΔF) == LabeledDDS
 @test codom(ΔF) == WeightedGraph
 
-@test wg == WeightedGraph{Int}(ldds, F) 
+@test wg == WeightedGraph{Int}(ldds, F)
 
 idF = Functor(
-  Dict(X => X, Label => Label), 
-  Dict(ϕ => ϕ, label => label), 
+  Dict(X => X, Label => Label),
+  Dict(ϕ => ϕ, label => label),
   TheoryLabeledDDS, TheoryLabeledDDS
 )
 
 @test ldds == LabeledDDS{Int}(ldds, idF)
 
+
 # Left Pushforward data migration
 #################################
-
 Σ = Sigma
+
+# Bipartite graph to graph
+#-------------------------
 
 V1B, V2B, EB = generators(TheoryUndirectedBipartiteGraph, :Ob)
 srcB, tgtB = generators(TheoryUndirectedBipartiteGraph, :Hom)
@@ -97,28 +105,28 @@ srcB, tgtB = generators(TheoryUndirectedBipartiteGraph, :Hom)
 VG, EG = generators(TheoryGraph, :Ob)
 srcG, tgtG = generators(TheoryGraph, :Hom)
 
+# Merge the two kinds of vertices into one (disjointly)
 F = Functor(
-    Dict(V1B => VG, V2B => VG, EB => EG), 
+    Dict(V1B => VG, V2B => VG, EB => EG),
     Dict(srcB => srcG, tgtB => tgtG),
     TheoryUndirectedBipartiteGraph, TheoryGraph
 )
 
+# Identity
 idF = Functor(
   Dict(VG => VG, EG => EG),
   Dict(srcG => srcG, tgtG => tgtG),
   TheoryGraph, TheoryGraph
 )
 
+# Test Implementation 1
 ΣF =  Σ(F, UndirectedBipartiteGraph, Graph)
 @test dom(ΣF) == UndirectedBipartiteGraph
 @test codom(ΣF) == Graph
-
 X = UndirectedBipartiteGraph()
 Y = ΣF(X)
-
 @test nparts(Y, :V) == 0
 @test nparts(Y, :E) == 0
-
 X = @acset UndirectedBipartiteGraph begin
   V₁ = 4
   V₂ = 3
@@ -126,7 +134,6 @@ X = @acset UndirectedBipartiteGraph begin
   src = [1,2,2,3]
   tgt = [1,1,2,3]
 end
-
 Y = ΣF(X)
 @test nparts(Y, :V) == 7
 @test nparts(Y, :E) == 4
@@ -134,12 +141,33 @@ Y = ΣF(X)
 
 @test Σ(idF, Graph, Graph)(Y) == Y
 
-@present ThSpan(FreeSchema) begin 
+
+# Test implementation 2
+
+# Chasing an empty instance yields an empty instance in this case
+@test chase(F, UndirectedBipartiteGraph(), Graph()) == Graph()
+
+Y = chase(F, X, Graph())
+chase_res = Graph(7)
+add_edges!(chase_res, [1,2,2,3],[5,5,6,7])
+@test is_isomorphic(chase_res, Y)
+
+
+@test is_isomorphic(Y, chase(idF, Y, Graph())) # chasing valid instance on id
+
+# Connected components of span
+#-----------------------------
+
+@present ThSpan(FreeSchema) begin
   (L1, L2, A)::Ob
   l1::Hom(A, L1)
   l2::Hom(A, L2)
 end
+
 @acset_type Span(ThSpan, index=[:l1, :l2])
+
+L1, L2, A = generators(ThSpan, :Ob)
+l1, l2 = generators(ThSpan, :Hom)
 
 X = @acset Span begin
   L1 = 3
@@ -149,44 +177,171 @@ X = @acset Span begin
   l2 = [1,2,3]
 end
 
-@present ThInitial(FreeSchema) begin
+@present ThInit(FreeSchema) begin
   I::Ob
 end
-@acset_type Initial(ThInitial)
+@acset_type Init(ThInit)
 
-L1, L2, A = generators(ThSpan, :Ob)
-l1, l2 = generators(ThSpan, :Hom)
-I = generators(ThInitial)[1]
+I = generators(ThInit)[1]
 
+# Collect the connected components across all three sets
 bang = Functor(
   Dict{FreeSchema.Ob, FreeSchema.Ob}(L1 => I, L2 => I, A => I),
   Dict{FreeSchema.Hom, FreeSchema.Hom}(l1 => id(I), l2 => id(I)),
-  ThSpan, ThInitial
+  ThSpan, ThInit
 )
 
-Σbang = Σ(bang, Span, Initial)
+# Test Implementation 1
+Σbang = Σ(bang, Span, Init)
 Y = Σbang(X)
-
 @test nparts(Y, :I) == 4
 
+# Test implementation 2
+Σbang = chase(bang, X, Init()) # Σ(bang, Span, Init)
+@test nparts(Σbang, :I) == 4
+
+
+# Init -> Graph
+#-----------------
+
+# Interpret points as vertices
 vertex = Functor(
   Dict{FreeSchema.Ob, FreeSchema.Ob}(I => VG),
   Dict{FreeSchema.Hom, FreeSchema.Hom}(),
-  ThInitial, TheoryGraph
+  ThInit, TheoryGraph
 )
+# Interpret points as edges, with arbitrary src/tgt
 edge = Functor(
-  Dict{FreeSchema.Ob, FreeSchema.Ob}(I => EG), 
+  Dict{FreeSchema.Ob, FreeSchema.Ob}(I => EG),
   Dict{FreeSchema.Hom, FreeSchema.Hom}(),
-  ThInitial, TheoryGraph
+  ThInit, TheoryGraph
 )
+I4 = Init()
+add_parts!(I4, :I, 4)
 
-Z = Σ(vertex, Initial, Graph)(Y)
+# Test implementation 1
+Z = Σ(vertex, I4, Graph)(Y)
 @test nparts(Z, :V) == 4
 @test nparts(Z, :E) == 0
 
-Z = Σ(edge, Initial, Graph)(Y)
+Z = Σ(edge, I4, Graph)(Y)
 @test nparts(Z, :V) == 8
 @test nparts(Z, :E) == 4
 @test Z[:src] ∪ Z[:tgt] == 1:8
+
+# Test implementation 2
+@test chase(vertex, I4, Graph()) == Graph(4)
+chase_res = Graph(8)
+add_edges!(chase_res, [1,2,3,4], [5,6,7,8])
+@test is_isomorphic(chase_res, chase(edge, I4, Graph()))
+
+# Non-acyclic example
+#--------------------
+@present ThCompany(FreeSchema) begin
+  Employee::Ob
+  Department::Ob
+  Str::Ob
+  name::Hom(Employee, Str)
+  manager::Hom(Employee, Employee)
+  works_in::Hom(Employee, Department)
+  secretary::Hom(Department, Employee)
+
+  # Managers work in same department
+  compose(manager, works_in) == works_in
+
+  # The secretary of a department works in that department.
+  compose(secretary, works_in) == id(Department)
+
+  # Everyone's their own boss
+  manager == id(Employee)
+
+end
+
+@acset_type Company(ThCompany)
+
+ex = @acset Company begin
+  Employee=3
+  Department = 1
+  Str = 3
+  name = [1,2,3]
+  manager = [1,2,3]
+  works_in = [1,1,1]
+  secretary = [1]
+end
+
+# add one arbitrary employee to the company => induces a new dept + secretary
+chase_res = @acset Company begin
+  Employee= 3 + 2
+  Department = 1 + 1
+  Str = 3 + 2
+  name = [1,2,3, 4,5]
+  manager = [1,2,3, 4,5]
+  works_in = [1,1,1, 2,2]
+  secretary = [1, 4]
+end
+
+
+(EG, _, _) = generators(ThCompany, :Ob)
+
+I1 = @acset Init begin I=1 end
+tf = Functor(
+  Dict{FreeSchema.Ob, FreeSchema.Ob}(I => EG),
+  Dict{FreeSchema.Hom, FreeSchema.Hom}(),
+  ThInit, ThCompany
+)
+
+# Example of chasing with a non-empty codomain instance
+@test is_isomorphic(chase_res, chase(tf, I1, ex))
+
+# "Fast Left Kan Extensions Using The Chase" running example
+#-----------------------------------------------------------
+@present ThC(FreeSchema) begin
+  (TA′, Faculty′, Student′)::Ob
+  isTF′::Hom(TA′,Faculty′)
+  isTS′::Hom(TA′, Student′)
+end
+
+@present ThD(FreeSchema) begin
+  (TA, Faculty, Student, Person)::Ob
+  isTF::Hom(TA,Faculty)
+  isTS::Hom(TA, Student)
+  isFP::Hom(Faculty, Person)
+  isSP::Hom(Student, Person)
+  compose(isTF, isFP) == compose(isTS, isSP)
+end
+
+@acset_type C(ThC)
+@acset_type D(ThD)
+
+GT_, GF_, GS_ = generators(ThC, :Ob)
+GT, GF, GS, _ = generators(ThD, :Ob)
+GTF_, GTS_ = generators(ThC, :Hom)
+GTF, GTS,_, _ = generators(ThD, :Hom)
+
+F = Functor(
+  Dict{FreeSchema.Ob, FreeSchema.Ob}(GT_ => GT, GF_=>GF, GS_=>GS),
+  Dict{FreeSchema.Hom, FreeSchema.Hom}(GTF_=>GTF, GTS_=>GTS),
+  ThC, ThD
+)
+I = @acset C begin
+  Faculty′ = 5
+  Student′ = 4
+  TA′ = 2
+  isTF′ = [1,2]
+  isTS′ = [1,3]
+end
+
+chase_res = @acset D begin
+  Faculty = 5
+  Student = 4
+  TA = 2
+  Person = 7
+  isTF = [1,2]
+  isTS = [1,2]
+  isFP = [1,2,3,4,5]
+  isSP = [1,2,6,7]
+end
+
+@test is_isomorphic(chase(F,I, D()), chase_res)
 
 end #module


### PR DESCRIPTION
A direct implementation of the chase algorithm for left kan extensions from this paper https://www.categoricaldata.net/cql/fmc.pdf

This extends our current approach to left kan extensions by allowing us to use acyclic schemas; however, the procedure may fail to converge in some bounded number of iterations.