### PR TITLE
Refactor type hierarchy for UWDs

### DIFF
--- a/src/linear_algebra/TensorNetworks.jl
+++ b/src/linear_algebra/TensorNetworks.jl
@@ -9,7 +9,7 @@ using MLStyle: @match
 using ...CategoricalAlgebra.CSets
 using ...WiringDiagrams.UndirectedWiringDiagrams
 import ...WiringDiagrams: oapply
-using ...Programs.RelationalPrograms: RelationDiagram
+using ...Programs.RelationalPrograms: RelationDiagram, UntypedRelationDiagram
 
 # Evaluation
 ############
@@ -172,7 +172,7 @@ function parse_tensor_network(expr::Expr; all_vars=nothing)
   end
 
   # Construct the undirected wiring diagram.
-  d = RelationDiagram{Symbol}(length(outer_vars))
+  d = UntypedRelationDiagram{Symbol,Symbol}(length(outer_vars))
   add_junctions!(d, length(all_vars), variable=all_vars)
   set_junction!(d, ports(d, outer=true),
                 incident(d, outer_vars, :variable), outer=true)

--- a/src/wiring_diagrams/MonoidalUndirected.jl
+++ b/src/wiring_diagrams/MonoidalUndirected.jl
@@ -1,4 +1,4 @@
-""" Undirected wiring diagrams as symmetric monoidal categories.
+""" Undirected wiring diagrams as SMCs and hypergraph categories.
 """
 module MonoidalUndirectedWiringDiagrams
 export HypergraphDiagram, HypergraphDiagramOb, HypergraphDiagramHom,
@@ -12,7 +12,7 @@ import ...Theories: dom, codom, compose, id, ⋅, ∘, otimes, ⊗, munit, braid
   mcopy, Δ, mmerge, ∇, delete, ◊, create, □, dunit, dcounit, dagger
 using ...CategoricalAlgebra.CSets: disjoint_union
 using ..UndirectedWiringDiagrams
-using ..UndirectedWiringDiagrams: AbstractUWD, AbstractTypedUWD, TheoryUWD, TheoryTypedUWD
+using ..UndirectedWiringDiagrams: AbstractUWD, TheoryUWD, TheoryTypedUWD
 import ..UndirectedWiringDiagrams: singleton_diagram, junction_diagram
 
 # Data types
@@ -20,26 +20,29 @@ import ..UndirectedWiringDiagrams: singleton_diagram, junction_diagram
 
 @present TheoryUntypedHypergraphDiagram <: TheoryUWD begin
   Name::AttrType
-  name::Attr(Box,Name)
+  name::Attr(Box, Name)
 end
 
-@abstract_acset_type AbstractUntypedHypergraphDiagram <: AbstractUWD
-@acset_type UntypedHypergraphDiagram(TheoryUntypedHypergraphDiagram, 
-  index=[:box, :junction, :outer_junction]) <: AbstractUntypedHypergraphDiagram
+""" Diagram to represent morphisms in single-sorted hypergraph categories.
 
-""" Diagram suitable for representing morphisms in hypergraph categories.
+By "single-sorted", we mean that the monoid of objects is free on one generator.
+See [`HypergraphDiagram`](@ref) for the more standard case.
+"""
+@acset_type UntypedHypergraphDiagram(TheoryUntypedHypergraphDiagram, 
+  index=[:box, :junction, :outer_junction]) <: AbstractUWD
+
+@present TheoryHypergraphDiagram <: TheoryTypedUWD begin
+  Name::AttrType
+  name::Attr(Box, Name)
+end
+
+""" Diagram to represent morphisms in hypergraph categories.
 
 An undirected wiring diagram where the ports and junctions are typed and the
 boxes have names identifying the morphisms.
 """
-@present TheoryHypergraphDiagram <: TheoryTypedUWD begin
-  Name::AttrType
-  name::Attr(Box,Name)
-end
-
-@abstract_acset_type AbstractHypergraphDiagram <: AbstractTypedUWD
 @acset_type HypergraphDiagram(TheoryHypergraphDiagram,
-  index=[:box, :junction, :outer_junction]) <: AbstractHypergraphDiagram
+  index=[:box, :junction, :outer_junction]) <: AbstractUWD
 
 # Cospan algebra
 ################

--- a/src/wiring_diagrams/ScheduleUndirected.jl
+++ b/src/wiring_diagrams/ScheduleUndirected.jl
@@ -15,10 +15,14 @@ using ...Present, ...CategoricalAlgebra.CSets, ...CategoricalAlgebra.FinSets
 using ..UndirectedWiringDiagrams, ..WiringDiagramAlgebras
 using ..UndirectedWiringDiagrams: TheoryUWD, flat
 
-const AbstractUWD = UndirectedWiringDiagram
-
 # Data types
 ############
+
+""" Abstract type for C-sets that contain a scheduled UWDS.
+
+This type includes [`ScheduledUWD`](@ref) and [`NestedUWD`](@ref).
+"""
+@abstract_acset_type HasScheduledUWD <: HasUWD
 
 @present TheoryScheduledUWD <: TheoryUWD begin
   Composite::Ob
@@ -30,7 +34,7 @@ const AbstractUWD = UndirectedWiringDiagram
   # parent <= id(Composite)
 end
 
-@abstract_acset_type AbstractScheduledUWD <: AbstractUWD
+@abstract_acset_type AbstractScheduledUWD <: HasScheduledUWD
 
 """ Scheduled undirected wiring diagram.
 
@@ -43,13 +47,17 @@ See also: [`NestedUWD`](@ref).
 @acset_type ScheduledUWD(TheoryScheduledUWD,
   index=[:box, :junction, :outer_junction, :parent, :box_parent]) <: AbstractScheduledUWD
 
-ncomposites(x::ACSet) = nparts(x, :Composite)
-composites(x::ACSet) = parts(x, :Composite)
-parent(x::ACSet, args...) = subpart(x, args..., :parent)
-children(x::ACSet, c::Int) =
+ncomposites(x::HasScheduledUWD) = nparts(x, :Composite)
+composites(x::HasScheduledUWD) = parts(x, :Composite)
+parent(x::HasScheduledUWD, args...) = subpart(x, args..., :parent)
+children(x::HasScheduledUWD, c::Int) =
   filter(c′ -> c′ != c, incident(x, c, :parent))
-box_parent(x::ACSet, args...) = subpart(x, args..., :box_parent)
-box_children(x::ACSet, args...) = incident(x, args..., :box_parent)
+box_parent(x::HasScheduledUWD, args...) = subpart(x, args..., :box_parent)
+box_children(x::HasScheduledUWD, args...) = incident(x, args..., :box_parent)
+
+""" Abstract type for C-sets that contained a nested UWD.
+"""
+@abstract_acset_type HasNestedUWD <: HasScheduledUWD
 
 @present TheoryNestedUWD <: TheoryScheduledUWD begin
   CompositePort::Ob
@@ -58,7 +66,7 @@ box_children(x::ACSet, args...) = incident(x, args..., :box_parent)
   composite_junction::Hom(CompositePort, Junction)
 end
 
-@abstract_acset_type AbstractNestedUWD <: AbstractScheduledUWD
+@abstract_acset_type AbstractNestedUWD <: HasNestedUWD
 
 """ Nested undirected wiring diagram.
 
@@ -74,10 +82,10 @@ See also: [`ScheduledUWD`](@ref).
   index=[:box, :junction, :outer_junction,
          :composite, :composite_junction, :parent, :box_parent]) <: AbstractNestedUWD
 
-composite_ports(x::ACSet, args...) = incident(x, args..., :composite)
-composite_junction(x::ACSet, args...) =
+composite_ports(x::HasNestedUWD, args...) = incident(x, args..., :composite)
+composite_junction(x::HasNestedUWD, args...) =
   subpart(x, args..., :composite_junction)
-composite_ports_with_junction(x::ACSet, args...) =
+composite_ports_with_junction(x::HasNestedUWD, args...) =
   incident(x, args..., :composite_junction)
 
 # Evaluation

--- a/test/linear_algebra/TensorNetworks.jl
+++ b/test/linear_algebra/TensorNetworks.jl
@@ -13,7 +13,7 @@ using Catlab.LinearAlgebra.TensorNetworks
 #--------
 
 parsed = @tensor_network (i,j,k,ℓ) D[i,j,k] = A[i,ℓ] * B[j,ℓ] * C[k,ℓ]
-d = RelationDiagram{Symbol}(3)
+d = RelationDiagram(3)
 add_box!(d, 2, name=:A); add_box!(d, 2, name=:B); add_box!(d, 2, name=:C)
 add_junctions!(d, 4, variable=[:i,:j,:k,:ℓ])
 set_junction!(d, [1,4,2,4,3,4])
@@ -27,13 +27,13 @@ parsed = @tensor_network D[i,j,k] := A[i,ℓ] * B[j,ℓ] * C[k,ℓ]
 
 # Degenerate case: single term.
 parsed = @tensor_network B[i,j,k] = A[i,j,k]
-d = singleton_diagram(RelationDiagram{Symbol}, 3, name=:A)
+d = singleton_diagram(RelationDiagram, 3, name=:A)
 set_subpart!(d, :variable, [:i,:j,:k])
 @test parsed == d
 
 # Degenerate case: no terms.
 parsed = @tensor_network A[i,j] = 1
-d = RelationDiagram{Symbol}(2)
+d = RelationDiagram(2)
 add_junctions!(d, 2, variable=[:i,:j])
 set_junction!(d, 1:2, outer=true)
 @test parsed == d

--- a/test/programs/RelationalPrograms.jl
+++ b/test/programs/RelationalPrograms.jl
@@ -16,7 +16,7 @@ parsed = @relation (x,z) where (x,y,z) begin
   S(y,z)
 end
 
-d = RelationDiagram{Symbol}(2)
+d = RelationDiagram(2)
 add_box!(d, 2, name=:R); add_box!(d, 2, name=:S)
 add_junctions!(d, 3, variable=[:x,:y,:z])
 set_junction!(d, [1,2,2,3])
@@ -39,13 +39,13 @@ d2 = @relation ((x,z) where (x,z,y)) -> (R(x,y); S(y,z))
 
 # Special case: closed diagram.
 parsed = @relation (() where (a,)) -> R(a,a)
-d = RelationDiagram{Symbol}(0)
+d = RelationDiagram(0)
 add_box!(d, 2, name=:R)
 add_junction!(d, variable=:a); set_junction!(d, [1,1])
 @test parsed == d
 
 parsed = @relation () -> A()
-d = RelationDiagram{Symbol}(0)
+d = RelationDiagram(0)
 add_box!(d, 0, name=:A)
 @test parsed == d
 
@@ -57,7 +57,7 @@ parsed = @relation (x,y,z) where (x::X, y::Y, z::Z, w::W) begin
   S(y,w)
   T(z,w)
 end
-d = RelationDiagram{Symbol}([:X,:Y,:Z])
+d = RelationDiagram([:X,:Y,:Z])
 add_box!(d, [:X,:W], name=:R)
 add_box!(d, [:Y,:W], name=:S)
 add_box!(d, [:Z,:W], name=:T)
@@ -73,7 +73,7 @@ parsed = @relation (start=u, stop=w) where (u, v, w) begin
   E(src=u, tgt=v)
   E(src=v, tgt=w)
 end
-d = RelationDiagram{Symbol}(2, port_names=[:start, :stop])
+d = RelationDiagram(2, port_names=[:start, :stop])
 add_box!(d, 2, name=:E)
 add_box!(d, 2, name=:E)
 add_junctions!(d, 3, variable=[:u,:v,:w])
@@ -114,7 +114,7 @@ parsed = @relation (e=e, e′=e′) where (e::Employee, e′::Employee,
   Employee(id=e, department=d)
   Employee(id=e′, department=d)
 end
-d = RelationDiagram{Symbol}([:Employee, :Employee], port_names=[:e,:e′])
+d = RelationDiagram([:Employee, :Employee], port_names=[:e,:e′])
 add_box!(d, [:Employee, :Department], name=:Employee)
 add_box!(d, [:Employee, :Department], name=:Employee)
 add_junctions!(d, [:Employee, :Employee, :Department], variable=[:e,:e′,:d])


### PR DESCRIPTION
Following of the approach of #486, this PR refactors the type hierarchy of undirected wiring diagrams. 