### PR TITLE
Find C-set homomorphisms using conjunctive queries

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 
 [compat]
 AutoHashEquals = "0.2"
@@ -40,11 +39,11 @@ Reexport = "^1"
 Requires = "^1"
 StaticArrays = "0.12, 1.0"
 Tables = "^1"
-TypedTables = "^1"
 julia = "1.6"
 
 [extras]
 Convex = "f65535da-76fb-5f13-bab9-19810c17039a"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Graphviz_jll = "3c863552-8265-54e4-a6dc-903eb78fde85"
 LightGraphs = "093fc24a-ae57-5d10-9952-331d41423f4d"
 LinearMaps = "7a12625a-238d-50fd-b39a-03d52299707e"

--- a/benchmark/Graphs.jl
+++ b/benchmark/Graphs.jl
@@ -68,19 +68,15 @@ function Graphs.connected_component_projection(g::LG.AbstractGraph)
 end
 
 abstract type FindTrianglesAlgorithm end
-struct TriangleHomomorphism <: FindTrianglesAlgorithm end
+struct TriangleBacktrackingSearch <: FindTrianglesAlgorithm end
 struct TriangleQuery <: FindTrianglesAlgorithm end
 
 """ Number of triangles in a graph.
 """
-function ntriangles(g::T, ::TriangleHomomorphism) where T
+function ntriangles(g::T, ::TriangleBacktrackingSearch) where T
   triangle = T(3)
   add_edges!(triangle, [1,2,1], [2,3,3])
-  count = 0
-  homomorphisms(triangle, g) do α;
-    count += 1; return false
-  end
-  count
+  length(homomorphisms(triangle, g, alg=BacktrackingSearch()))
 end
 function ntriangles(g, ::TriangleQuery)
   length(query(g, ntriangles_query))
@@ -141,7 +137,7 @@ n = 100
 g = wheel_graph(Graph, n)
 lg = LG.DiGraph(g)
 clbench["wheel-graph-triangles-hom"] =
-  @benchmarkable ntriangles($g, TriangleHomomorphism())
+  @benchmarkable ntriangles($g, TriangleBacktrackingSearch())
 clbench["wheel-graph-triangles-query"] =
   @benchmarkable ntriangles($g, TriangleQuery())
 
@@ -195,7 +191,7 @@ n = 100
 g = wheel_graph(SymmetricGraph, n)
 lg = LG.Graph(g)
 clbench["wheel-graph-triangles-hom"] =
-  @benchmarkable ntriangles($g, TriangleHomomorphism())
+  @benchmarkable ntriangles($g, TriangleBacktrackingSearch())
 clbench["wheel-graph-triangles-query"] =
   @benchmarkable ntriangles($g, TriangleQuery())
 lgbench["wheel-graph-triangles"] = @benchmarkable sum(LG.triangles($lg))

--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -190,9 +190,6 @@ function ACSetTableType(X::Type, ob::Symbol; union_all::Bool=false)
   (union_all ? ACSetTableUnionAll : ACSetTableDataType)(X, ob)
 end
 
-make_table(::Type{T}, cols) where T = T(cols)
-make_table(::Type{NamedTuple}, cols) = cols # No copy constructor defined.
-
 # StructACSet Operations
 ########################
 

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -2,6 +2,7 @@
 """
 module CSets
 export ACSetTransformation, CSetTransformation, SubACSet, SubCSet,
+  ACSetHomomorphismAlgorithm, BacktrackingSearch,
   components, force, is_natural, homomorphism, homomorphisms, is_homomorphic,
   isomorphism, isomorphisms, is_isomorphic,
   generate_json_acset, parse_json_acset, read_json_acset, write_json_acset
@@ -163,11 +164,11 @@ force(α::ACSetTransformation) = map_components(force, α)
 # Finding C-set transformations
 ###############################
 
-""" Find a homomorphism between two attributed ``C``-sets.
+""" Algorithm for finding homomorphisms between attributed ``C``-sets.
+"""
+abstract type ACSetHomomorphismAlgorithm end
 
-Returns `nothing` if no homomorphism exists. For many categories ``C``, the
-``C``-set homomorphism problem is NP-complete and thus this procedure generally
-runs in exponential time. It works best when the domain object is small.
+""" Find attributed ``C``-set homomorphisms using backtracking search.
 
 This procedure uses the classic backtracking search algorithm for a
 combinatorial constraint satisfaction problem (CSP). As is well known, the
@@ -178,7 +179,15 @@ also reducible to CSP. Backtracking search for CSP is described in many computer
 science textbooks, such as (Russell & Norvig 2010, *Artificial Intelligence*,
 Third Ed., Chapter 6: Constraint satisfaction problems, esp. Algorithm 6.5). In
 our implementation, the search tree is ordered using the popular heuristic of
-"minimum remaining values" (MRV), also known as "most constrained variable."
+"minimum remaining values" (MRV), also known as "most constrained variable.
+"""
+struct BacktrackingSearch <: ACSetHomomorphismAlgorithm end
+
+""" Find a homomorphism between two attributed ``C``-sets.
+
+Returns `nothing` if no homomorphism exists. For many categories ``C``, the
+``C``-set homomorphism problem is NP-complete and thus this procedure generally
+runs in exponential time. It works best when the domain object is small.
 
 To restrict to *monomorphisms*, or homomorphisms whose components are all
 injective functions, set the keyword argument `monic=true`. To restrict only
@@ -190,11 +199,17 @@ To restrict the homomorphism to a given partial assignment, set the keyword
 argument `initial`. For example, to fix the first source vertex to the third
 target vertex in a graph homomorphism, set `initial=(V=Dict(1 => 3),)`.
 
+Use the keyword argument `alg` to set the homomorphism-finding algorithm. By
+default, a backtracking search algorithm is used ([`BacktrackingSearch`](@ref)).
+
 See also: [`homomorphisms`](@ref), [`isomorphism`](@ref).
 """
-function homomorphism(X::StructACSet, Y::StructACSet; kw...)
+homomorphism(X::ACSet, Y::ACSet; alg=BacktrackingSearch(), kw...) =
+  homomorphism(X, Y, alg; kw...)
+
+function homomorphism(X::ACSet, Y::ACSet, alg::BacktrackingSearch; kw...)
   result = nothing
-  homomorphisms(X, Y; kw...) do α
+  backtracking_search(X, Y; kw...) do α
     result = α; return true
   end
   result
@@ -205,48 +220,63 @@ end
 This function is at least as expensive as [`homomorphism`](@ref) and when no
 homomorphisms exist, it is exactly as expensive.
 """
-function homomorphisms(X::StructACSet{S}, Y::StructACSet{S};
-                       kw...) where {S}
+homomorphisms(X::ACSet, Y::ACSet; alg=BacktrackingSearch(), kw...) =
+  homomorphisms(X, Y, alg; kw...)
+
+function homomorphisms(X::StructACSet{S}, Y::StructACSet{S},
+                       alg::BacktrackingSearch; kw...) where {S}
   results = ACSetTransformation{S}[]
-  homomorphisms(X, Y; kw...) do α
+  backtracking_search(X, Y; kw...) do α
     push!(results, map_components(deepcopy, α)); return false
   end
   results
 end
-homomorphisms(f, X::StructACSet, Y::StructACSet;
-              monic=false, iso=false, initial=(;)) =
-  backtracking_search(f, X, Y, monic=monic, iso=iso, initial=initial)
 
 """ Is the first attributed ``C``-set homomorphic to the second?
 
-A convenience function based on [`homomorphism`](@ref).
+This function generally reduces to [`homomorphism`](@ref) but certain algorithms
+may have minor optimizations.
 """
-is_homomorphic(X::StructACSet, Y::StructACSet; kw...) =
-  !isnothing(homomorphism(X, Y; kw...))
+is_homomorphic(X::ACSet, Y::ACSet; alg=BacktrackingSearch(), kw...) =
+  is_homomorphic(X, Y, alg; kw...)
+
+is_homomorphic(X::ACSet, Y::ACSet, alg::BacktrackingSearch; kw...) =
+  !isnothing(homomorphism(X, Y, alg; kw...))
 
 """ Find an isomorphism between two attributed ``C``-sets, if one exists.
 
 See [`homomorphism`](@ref) for more information about the algorithms involved.
 """
-isomorphism(X::StructACSet, Y::StructACSet; initial=(;)) =
-  homomorphism(X, Y, iso=true, initial=initial)
+isomorphism(X::ACSet, Y::ACSet; alg=BacktrackingSearch(), kw...) =
+  isomorphism(X, Y, alg; kw...)
+
+isomorphism(X::ACSet, Y::ACSet, alg::BacktrackingSearch; initial=(;)) =
+  homomorphism(X, Y, alg; iso=true, initial=initial)
 
 """ Find all isomorphisms between two attributed ``C``-sets.
 
 This function is at least as expensive as [`isomorphism`](@ref) and when no
 homomorphisms exist, it is exactly as expensive.
 """
-isomorphisms(X::StructACSet, Y::StructACSet; initial=(;)) =
-  homomorphisms(X, Y, iso=true, initial=initial)
-isomorphisms(f, X::StructACSet, Y::StructACSet; initial=(;)) =
-  homomorphisms(f, X, Y, iso=true, initial=initial)
+isomorphisms(X::ACSet, Y::ACSet; alg=BacktrackingSearch(), kw...) =
+  isomorphisms(X, Y, alg; kw...)
+
+isomorphisms(X::ACSet, Y::ACSet, alg::BacktrackingSearch; initial=(;)) =
+  homomorphisms(X, Y, alg; iso=true, initial=initial)
 
 """ Are the two attributed ``C``-sets isomorphic?
 
-A convenience function based on [`isomorphism`](@ref).
+This function generally reduces to [`isomorphism`](@ref) but certain algorithms
+may have minor optimizations.
 """
-is_isomorphic(X::StructACSet, Y::StructACSet; kw...) =
-  !isnothing(isomorphism(X, Y; kw...))
+is_isomorphic(X::ACSet, Y::ACSet; alg=BacktrackingSearch(), kw...) =
+  is_isomorphic(X, Y, alg; kw...)
+
+is_isomorphic(X::ACSet, Y::ACSet, alg::BacktrackingSearch; kw...) =
+  !isnothing(isomorphism(X, Y, alg; kw...))
+
+# Backtracking search
+#--------------------
 
 """ Internal state for backtracking search for ACSet homomorphisms.
 """

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -2,7 +2,7 @@
 """
 module CSets
 export ACSetTransformation, CSetTransformation, SubACSet, SubCSet,
-  ACSetHomomorphismAlgorithm, BacktrackingSearch,
+  ACSetHomomorphismAlgorithm, BacktrackingSearch, HomomorphismQuery,
   components, force, is_natural, homomorphism, homomorphisms, is_homomorphic,
   isomorphism, isomorphisms, is_isomorphic,
   generate_json_acset, parse_json_acset, read_json_acset, write_json_acset
@@ -182,6 +182,16 @@ our implementation, the search tree is ordered using the popular heuristic of
 "minimum remaining values" (MRV), also known as "most constrained variable.
 """
 struct BacktrackingSearch <: ACSetHomomorphismAlgorithm end
+
+""" Find attributed ``C``-set homomorphisms using a conjunctive query.
+
+This algorithm evaluates a conjunctive query (limit in `FinSet`) to find all
+homomorphisms between two ``C``-sets. In fact, conjunctive queries are exactly
+the *representable* functors from ``C``-sets to sets, so every conjunctive query
+arises in this way, with the caveat that conjunctive queries may correspond to
+to infinite ``C``-sets when ``C`` is infinite (but possibly finitely presented).
+"""
+struct HomomorphismQuery <: ACSetHomomorphismAlgorithm end
 
 """ Find a homomorphism between two attributed ``C``-sets.
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
 Catlab = "134e5e36-593f-5add-ad60-77f754baafbe"
 Compose = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 IterativeSolvers = "42fd0dbc-a981-5370-80f2-aaf504508153"
 JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
@@ -15,7 +16,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 
 [compat]
 LinearOperators = "1"

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -279,9 +279,9 @@ homs = [CSetTransformation((V=[1,2,3], E=[1,2]), g, h),
 @test !is_isomorphic(g, h)
 
 I = ob(terminal(Graph))
-deleted = CSetTransformation((V=[1,1,1], E=[1,1]), g, I)
-@test homomorphism(g, I) == deleted
-@test homomorphism(g, I, alg=HomomorphismQuery()) == deleted
+α = CSetTransformation((V=[1,1,1], E=[1,1]), g, I)
+@test homomorphism(g, I) == α
+@test homomorphism(g, I, alg=HomomorphismQuery()) == α
 @test !is_homomorphic(g, I, monic=true)
 @test !is_homomorphic(I, h)
 @test !is_homomorphic(I, h, alg=HomomorphismQuery())
@@ -339,9 +339,12 @@ end
 
 g = cycle_graph(LabeledGraph{Symbol}, 4, V=(label=[:a,:b,:c,:d],))
 h = cycle_graph(LabeledGraph{Symbol}, 4, V=(label=[:c,:d,:a,:b],))
-@test homomorphism(g, h) == ACSetTransformation((V=[3,4,1,2], E=[3,4,1,2]), g, h)
+α = ACSetTransformation((V=[3,4,1,2], E=[3,4,1,2]), g, h)
+@test homomorphism(g, h) == α
+@test homomorphism(g, h, alg=HomomorphismQuery()) == α
 h = cycle_graph(LabeledGraph{Symbol}, 4, V=(label=[:a,:b,:d,:c],))
 @test !is_homomorphic(g, h)
+@test !is_homomorphic(g, h, alg=HomomorphismQuery())
 
 # Sub-C-sets
 ############

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -300,7 +300,7 @@ add_edge!(g2, 1, 2)  # double arrow
 @test length(homomorphisms(g2, g1, monic=[:E])) == 2 # two for 2->3
 @test length(homomorphisms(g2, g1, iso=[:E])) == 0
 
-# Symmetic graphs
+# Symmetric graphs
 #-----------------
 
 g, h = path_graph(SymmetricGraph, 4), path_graph(SymmetricGraph, 4)

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -272,14 +272,19 @@ colim = pushout(α, β)
 #-------
 
 g, h = path_graph(Graph, 3), path_graph(Graph, 4)
-@test homomorphisms(g, h) == [CSetTransformation((V=[1,2,3], E=[1,2]), g, h),
-                              CSetTransformation((V=[2,3,4], E=[2,3]), g, h)]
+homs = [CSetTransformation((V=[1,2,3], E=[1,2]), g, h),
+        CSetTransformation((V=[2,3,4], E=[2,3]), g, h)]
+@test homomorphisms(g, h) == homs
+@test homomorphisms(g, h, alg=HomomorphismQuery()) == homs
 @test !is_isomorphic(g, h)
 
 I = ob(terminal(Graph))
-@test homomorphism(g, I) == CSetTransformation((V=[1,1,1], E=[1,1]), g, I)
+deleted = CSetTransformation((V=[1,1,1], E=[1,1]), g, I)
+@test homomorphism(g, I) == deleted
+@test homomorphism(g, I, alg=HomomorphismQuery()) == deleted
 @test !is_homomorphic(g, I, monic=true)
 @test !is_homomorphic(I, h)
+@test !is_homomorphic(I, h, alg=HomomorphismQuery())
 
 # Graph homomorphism starting from partial assignment, e.g. vertex assignment.
 α = CSetTransformation((V=[2,3,4], E=[2,3]), g, h)

--- a/test/wiring_diagrams/Algebras.jl
+++ b/test/wiring_diagrams/Algebras.jl
@@ -1,7 +1,8 @@
 module TestWiringDiagramAlgebras
 using Test
 
-using Tables, TypedTables
+using Tables: columns
+using DataFrames
 
 using Catlab.CategoricalAlgebra, Catlab.CategoricalAlgebra.FinSets
 using Catlab.Graphs, Catlab.WiringDiagrams, Catlab.Programs.RelationalPrograms
@@ -71,8 +72,8 @@ end
 # Graph underlying a commutative squares.
 square = Graph(4)
 add_edges!(square, [1,1,2,3], [2,3,4,4])
-result = query(square, paths2)
-@test result == Table((start=[1,1], stop=[4,4]))
+@test query(square, paths2) == DataFrame(start=[1,1], stop=[4,4])
+@test query(square, paths2, table_type=NamedTuple) == (start=[1,1], stop=[4,4])
 
 # Graph underlying a pasting of two commutative squares.
 squares2 = copy(square)
@@ -85,7 +86,7 @@ result = query(squares2, paths2)
 result = query(squares2, paths2, (start=1,))
 @test tuples(columns(result)...) == [(1,4), (1,4), (1,5)]
 result = query(squares2, paths2, (start=1, stop=4))
-@test result == Table((start=[1,1], stop=[4,4]))
+@test result == DataFrame(start=[1,1], stop=[4,4])
 @test length(query(squares2, count_paths2, (start=1, stop=4))) == 2
 
 # Query: pairs of vertices.
@@ -93,7 +94,7 @@ vertices2 = @relation (v1=v1, v2=v2) begin
   V(_id=v1)
   V(_id=v2)
 end
-@test length(query(squares2, vertices2)) == nv(squares2)^2
+@test nrow(query(squares2, vertices2)) == nv(squares2)^2
 
 # Query: directed cycles of length 3.
 cycles3 = @relation (edge1=e, edge2=f, edge3=g) where (e,f,g,u,v,w) begin
@@ -107,7 +108,7 @@ g = cycle_graph(Graph, 3)
 result = query(g, cycles3)
 @test tuples(columns(result)...) == [(1,2,3), (2,3,1), (3,1,2)]
 result = query(g, cycles3, (v=1,))
-@test result == Table((edge1=[3], edge2=[1], edge3=[2]))
+@test result == DataFrame(edge1=[3], edge2=[1], edge3=[2])
 @test isempty(query(cycle_graph(Graph, 4), cycles3))
 
 end


### PR DESCRIPTION
This PR allows the C-set homomorphism finding functions to have different algorithmic backends. In addition to backtracking search, which was already supported, the conjunctive query machinery can now be used to find homomorphisms. Thanks to @olynch for doing the [original implementation](https://github.com/AlgebraicJulia/CombinatorialChains.jl/blob/d1a54dea195d87879ac18b047964eb2df5ca12de/src/ConjuctionQueryHomomorphism.jl) of this feature. The implementation here also supports data attributes.

I also take the opportunity to remove the dependency on TypedTables, no longer needed after the struct acsets refactor. An *optional* dependency on DataFrames is added so that the `query` function can return a table when possible.