### PR TITLE
More flexible Graphviz support for acset schemas

### DIFF
--- a/src/graphics/GraphvizGraphs.jl
+++ b/src/graphics/GraphvizGraphs.jl
@@ -311,44 +311,47 @@ end
 # Schemas
 #########
 
-to_graphviz(pres::Presentation{Schema}) =
-  to_graphviz(to_graphviz_property_graph(pres))
+to_graphviz(pres::Presentation{Schema}; kw...) =
+  to_graphviz(to_graphviz_property_graph(pres; kw...))
 
-function to_graphviz_property_graph(pres::Presentation{Schema})
-  obs,homs,attr_types,attrs = generators.(Ref(pres), [:Ob,:Hom,:AttrType,:Attr])
-  g = PropertyGraph{Any}()
+function to_graphviz_property_graph(pres::Presentation{Schema};
+    prog::AbstractString="neato", graph_attrs::AbstractDict=Dict(),
+    node_attrs::AbstractDict=Dict(), edge_attrs::AbstractDict=Dict())
+  pg = PropertyGraph{Any}(; prog = prog,
+    graph = graph_attrs,
+    node = merge!(Dict(:margin => "0"), node_attrs),
+    edge = merge!(Dict(:len => "1.5"), edge_attrs),
+  )
 
-  ob_vertices = add_vertices!(g,length(obs))
+  obs = generators(pres, :Ob)
+  ob_vertices = add_vertices!(pg, length(obs))
   for (v, ob) in zip(ob_vertices, obs)
-    set_vprop!(g,v,:label,string(nameof(ob)))
-    set_vprop!(g,v,:shape,"plain")
-    set_vprop!(g,v,:margin,"2")
+    set_vprops!(pg, v, label=string(first(ob)), shape="circle")
   end
 
-  attr_vertices = add_vertices!(g,length(attr_types))
+  attr_types = generators(pres, :AttrType)
+  attr_vertices = add_vertices!(pg, length(attr_types))
   for (v, attr_type) in zip(attr_vertices, attr_types)
-    set_vprop!(g,v,:label,string(nameof(attr_type)))
+    set_vprops!(pg, v, xlabel=string(first(attr_type)), shape="point")
   end
 
-  hom_edges = add_edges!(g,
-    ob_vertices[generator_index.(Ref(pres), nameof.(dom.(homs)))],
-    ob_vertices[generator_index.(Ref(pres), nameof.(codom.(homs)))])
+  homs = generators(pres, :Hom)
+  hom_edges = add_edges!(pg,
+    ob_vertices[generator_index.(Ref(pres), first.(dom.(homs)))],
+    ob_vertices[generator_index.(Ref(pres), first.(codom.(homs)))])
   for (e, hom) in zip(hom_edges, homs)
-    set_eprop!(g,e,:label,string(nameof(hom)))
-    set_eprop!(g,e,:len,"2")
-  end
-  
-  attr_edges = add_edges!(g,
-    ob_vertices[generator_index.(Ref(pres), nameof.(dom.(attrs)))],
-    attr_vertices[generator_index.(Ref(pres), nameof.(codom.(attrs)))])
-  for (e, attr) in zip(attr_edges, attrs)
-    set_eprop!(g,e,:label,string(nameof(attr)))
-    set_eprop!(g,e,:len,"2")
+    set_eprop!(pg, e, :label, string(first(hom)))
   end
 
-  set_gprop!(g,:graph,Dict(:rankdir => "LR"))
-  set_gprop!(g,:prog,"neato")
-  g
+  attrs = generators(pres, :Attr)
+  attr_edges = add_edges!(pg,
+    ob_vertices[generator_index.(Ref(pres), first.(dom.(attrs)))],
+    attr_vertices[generator_index.(Ref(pres), first.(codom.(attrs)))])
+  for (e, attr) in zip(attr_edges, attrs)
+    set_eprop!(pg, e, :label, string(first(attr)))
+  end
+
+  pg
 end
 
 end


### PR DESCRIPTION
The conventions are now inline with `to_graphviz` functions for other graph types.