### PR TITLE
GitHub action to test downstream packages

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -1,0 +1,47 @@
+name: Integration Tests
+on: workflow_dispatch
+jobs:
+  test:
+    name: ${{ matrix.package.repo }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version: ['1.6']
+        os: [ubuntu-latest]
+        package:
+          - {user: AlgebraicJulia, repo: AlgebraicDynamics.jl}
+          - {user: AlgebraicJulia, repo: AlgebraicPetri.jl}
+          - {user: AlgebraicJulia, repo: AlgebraicRelations.jl}
+          - {user: AlgebraicJulia, repo: CombinatorialSpaces.jl}
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: x64
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Clone downstream
+        uses: actions/checkout@v2
+        with:
+          repository: ${{ matrix.package.user }}/${{ matrix.package.repo }}
+          path: downstream
+      - name: Run downstream tests
+        shell: julia --color=yes --project=downstream {0}
+        run: |
+          using Pkg
+          try
+            # force it to use this PR's version of the package
+            Pkg.develop(PackageSpec(path="."))
+            Pkg.update()
+            Pkg.test()  # resolver may fail with test time deps
+          catch err
+            err isa Pkg.Resolve.ResolverError || rethrow()
+            # If we can't resolve that means this is incompatible by SemVer and
+            # this is fine It means we marked this as a breaking change, so we
+            # don't need to worry about Mistakenly introducing a breaking
+            # change, as we have intentionally made one
+            @info "Not compatible with this release. No problem." exception=err
+            exit(0)  # Exit immediately, as a success
+          end


### PR DESCRIPTION
This will help me determine whether borderline changes should be considered breaking. To avoid long check times, the action is only run when triggered manually.