### PR TITLE
Reexport the `Sets` and `FinSets` submodules

### DIFF
--- a/benchmark/FinSets.jl
+++ b/benchmark/FinSets.jl
@@ -2,7 +2,7 @@ using BenchmarkTools
 const SUITE = BenchmarkGroup()
 
 using Random
-using Catlab.CategoricalAlgebra, Catlab.CategoricalAlgebra.FinSets
+using Catlab.CategoricalAlgebra
 
 bench = SUITE["Limits"] = BenchmarkGroup()
 

--- a/docs/literate/sketches/meets.jl
+++ b/docs/literate/sketches/meets.jl
@@ -9,10 +9,8 @@
 using Core: GeneratedFunctionStub
 using Test
 
-using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.CategoricalAlgebra.FinSets
-using Catlab.Present
-using Catlab.Graphics
-using Catlab.Graphics.Graphviz
+using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra
+using Catlab.Graphics, Catlab.Graphics.Graphviz
 
 import Catlab.Theories: compose
 using DataStructures

--- a/docs/literate/sketches/partitions.jl
+++ b/docs/literate/sketches/partitions.jl
@@ -10,7 +10,7 @@
 using Core: GeneratedFunctionStub
 using Test
 
-using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.CategoricalAlgebra.FinSets
+using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra
 import Catlab.Theories: compose
 using DataStructures
 using PrettyTables

--- a/docs/src/apis/categorical_algebra.md
+++ b/docs/src/apis/categorical_algebra.md
@@ -1,6 +1,7 @@
 # [Categorical algebra](@id categorical_algebra)
 
 ## FinSet and FinRel
+
 The following APIs implement FinSet, the category of Finite Sets (actually the skeleton of FinSet). The objects of this category are natural numbers where `n` represents a set with `n` elements. The morphisms are functions between such sets. We use the skeleton of FinSet in order to ensure that all sets are finite and morphisms can be stored using lists of integers. Finite relations are built out of FinSet and can be used to do some relational algebra.
 
 ```@autodocs

--- a/src/categorical_algebra/CategoricalAlgebra.jl
+++ b/src/categorical_algebra/CategoricalAlgebra.jl
@@ -21,7 +21,11 @@ include("DPO.jl")
 @reexport using .CommutativeDiagrams
 @reexport using .Limits
 @reexport using .Subobjects
+
+@reexport using .Sets
+@reexport using .FinSets
 @reexport using .CSets
+
 @reexport using .StructuredCospans
 @reexport using .CatElements
 @reexport using .DataMigration

--- a/src/wiring_diagrams/Algebras.jl
+++ b/src/wiring_diagrams/Algebras.jl
@@ -7,7 +7,7 @@ using Requires
 
 using ...Present, ...Theories
 using ...Theories: dom_nums, codom_nums, attr, adom, adom_nums
-using ...CategoricalAlgebra, ...CategoricalAlgebra.FinSets
+using ...CategoricalAlgebra
 import ...CategoricalAlgebra.CSets: homomorphisms, homomorphism, is_homomorphic
 using ..UndirectedWiringDiagrams
 using ..UndirectedWiringDiagrams: TheoryUWD

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -1,10 +1,8 @@
 module TestCSets
 using Test
 
-using Catlab, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra,
-  Catlab.CategoricalAlgebra.FinSets
-using Catlab.CategoricalAlgebra.CSets, Catlab.CSetDataStructures
-using Catlab.Graphs.BasicGraphs: AbstractGraph, TheoryGraph
+using Catlab, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
+using Catlab.Graphs.BasicGraphs: TheoryGraph
 
 @present TheoryDDS(FreeSchema) begin
   X::Ob

--- a/test/categorical_algebra/CatElements.jl
+++ b/test/categorical_algebra/CatElements.jl
@@ -1,10 +1,7 @@
 module TestCatElements
 using Test
-using Catlab, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra,
-  Catlab.CategoricalAlgebra.FinSets, Catlab.CategoricalAlgebra.CatElements
+using Catlab, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
 
-
-@testset "Elements" begin
 arr = @acset Graph begin
   V = 2
   E = 1
@@ -70,7 +67,6 @@ end
   @test nparts(sir_eltsch, :E_1) == 3
   @test nparts(sir_eltsch, :E_2) == 3
   @test sir_eltsch[:, :src_E_2] == [1,1,2]
-end
 end
 
 end

--- a/test/categorical_algebra/DPO.jl
+++ b/test/categorical_algebra/DPO.jl
@@ -1,10 +1,8 @@
 module TestDPO
 using Test
-using Catlab.Graphs
-using Catlab.Present
-using Catlab.WiringDiagrams
-using Catlab.CategoricalAlgebra.FinSets
+
 using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra
+using Catlab.Graphs, Catlab.WiringDiagrams
 
 # Wiring diagrams
 #################

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -2,7 +2,6 @@ module TestFinSets
 using Test
 
 using Catlab.Theories, Catlab.CategoricalAlgebra
-using Catlab.CategoricalAlgebra.FinSets
 
 # Functions between finite sets
 ###############################

--- a/test/categorical_algebra/FreeDiagrams.jl
+++ b/test/categorical_algebra/FreeDiagrams.jl
@@ -2,7 +2,6 @@ module TestFreeDiagrams
 using Test
 
 using Catlab.Theories, Catlab.CategoricalAlgebra
-using Catlab.CategoricalAlgebra.FinSets: FinSet, FinFunction
 
 A, B, C, D = Ob(FreeCategory, :A, :B, :C, :D)
 

--- a/test/categorical_algebra/StructuredCospans.jl
+++ b/test/categorical_algebra/StructuredCospans.jl
@@ -1,8 +1,7 @@
 module TestStructuredCospans
 using Test
 
-using Catlab, Catlab.Theories, Catlab.Graphs,
-  Catlab.CategoricalAlgebra, Catlab.CategoricalAlgebra.FinSets
+using Catlab, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
 using Catlab.Graphs.BasicGraphs: AbstractGraph, TheoryGraph
 
 # Structured cospans of C-sets

--- a/test/wiring_diagrams/Algebras.jl
+++ b/test/wiring_diagrams/Algebras.jl
@@ -4,7 +4,7 @@ using Test
 using Tables: columns
 using DataFrames
 
-using Catlab.CategoricalAlgebra, Catlab.CategoricalAlgebra.FinSets
+using Catlab.CategoricalAlgebra
 using Catlab.Graphs, Catlab.WiringDiagrams, Catlab.Programs.RelationalPrograms
 
 tuples(args...) = sort!(collect(zip(args...)))


### PR DESCRIPTION
Given their fundamental importance, reexporting these submodules from `CategoricalAlgebra` is something I should have done from the get-go but for some reason didn't.