### PR TITLE
ENH: Equality and hash operators for Graphviz Edge and NodeID

### DIFF
--- a/src/graphics/Graphviz.jl
+++ b/src/graphics/Graphviz.jl
@@ -10,6 +10,7 @@ export Expression, Statement, Attributes, Graph, Digraph, Subgraph,
   Node, NodeID, Edge, pprint, run_graphviz
 
 using DataStructures: OrderedDict
+using AutoHashEquals
 using Requires: @require
 
 const USE_GV_JLL = Ref(false)
@@ -89,14 +90,14 @@ end
 Node(name::String, attrs::AbstractDict) = Node(name, as_attributes(attrs))
 Node(name::String; attrs...) = Node(name, attrs)
 
-struct NodeID <: Expression
+@auto_hash_equals struct NodeID <: Expression
   name::String
   port::String
   anchor::String
   NodeID(name::String, port::String="", anchor::String="") = new(name, port, anchor)
 end
 
-struct Edge <: Statement
+@auto_hash_equals struct Edge <: Statement
   path::Vector{NodeID}
   attrs::Attributes
 end

--- a/test/graphics/Graphviz.jl
+++ b/test/graphics/Graphviz.jl
@@ -28,6 +28,12 @@ spprint(expr::Expression) = sprint(pprint, expr)
 @test spprint(Edge(NodeID("n1"), NodeID("n2"), NodeID("n3"))) ==
   "n1 -- n2 -- n3;"
 
+# NodeID/Edge equality
+@test Edge("n1","n2") == Edge("n1","n2")
+@test Edge(NodeID("n1","p1"), NodeID("n2","p2")) ==
+  Edge(NodeID("n1","p1"), NodeID("n2","p2"))
+@test NodeID("n1", "p1") == NodeID("n1", "p1")
+
 # Graph statement
 graph = Graph("G",
   Node("n1"),


### PR DESCRIPTION
This PR adds equality and hash operators for the `Edge` and `NodeID` structs using AutoHashEquals.

This is to resolve Issue #522.