### PR TITLE
Use meaningful column name when promoting trivial queries

### DIFF
--- a/src/categorical_algebra/Diagrams.jl
+++ b/src/categorical_algebra/Diagrams.jl
@@ -205,8 +205,9 @@ end
 
 function munit(::Type{DiagramHom{T}}, C::Cat, f;
                dom_shape=nothing, codom_shape=nothing) where T
-  d = munit(DiagramHom{T}, C, dom(C,f), shape=dom_shape)
-  d′= munit(DiagramHom{T}, C, codom(C,f), shape=codom_shape)
+  f = hom(C, f)
+  d = munit(Diagram{T}, C, dom(C, f), shape=dom_shape)
+  d′= munit(Diagram{T}, C, codom(C, f), shape=codom_shape)
   j = only(ob_generators(shape(d′)))
   DiagramHom{T}(@SVector([(j, f)]), d, d′)
 end

--- a/src/categorical_algebra/FinCats.jl
+++ b/src/categorical_algebra/FinCats.jl
@@ -264,6 +264,14 @@ const FinDomFunctor{Dom<:FinCat,Codom<:Cat} = Functor{Dom,Codom}
 FinDomFunctor(maps::NamedTuple{(:V,:E)}, dom::FinCatGraph, codom::Cat) =
   FinDomFunctor(maps.V, maps.E, dom, codom)
 
+function FinDomFunctor(ob_map, dom::FinCat, codom::Cat{Ob,Hom}) where {Ob,Hom}
+  is_discrete(dom) ||
+    error("Morphism map omitted by domain category is not discrete: $dom")
+  FinDomFunctor(ob_map, empty(ob_map, Hom), dom, codom)
+end
+FinDomFunctor(ob_map, ::Nothing, dom::FinCat, codom::Cat) =
+  FinDomFunctor(ob_map, dom, codom)
+
 function hom_map(F::FinDomFunctor{<:FinCatPathGraph}, path::Path)
   D = codom(F)
   mapreduce(e -> hom_map(F, e), (gs...) -> compose(D, gs...),

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -18,8 +18,7 @@ using ...GAT, ...Theories, ...CSetDataStructures, ...Graphs
 using ..FinCats, ..FreeDiagrams, ..Limits, ..Subobjects
 import ...Theories: Ob, meet, ∧, join, ∨, top, ⊤, bottom, ⊥
 import ..Categories: ob, hom, dom, codom, compose, id, ob_map, hom_map
-import ..FinCats: FinDomFunctor, ob_generators, hom_generators, graph,
-  is_discrete
+import ..FinCats: ob_generators, hom_generators, graph, is_discrete
 import ..Limits: limit, colimit, universal, pushout_complement,
   can_pushout_complement
 import ..Subobjects: Subobject, SubobjectLattice
@@ -138,11 +137,6 @@ codom(C::DiscreteCat{T}, f) where T = f::T
 id(C::DiscreteCat{T}, x) where T = x::T
 compose(C::DiscreteCat{T}, f, g) where T = (f::T == g::T) ? f :
   error("Nontrivial composite in discrete category: $f != $g")
-
-FinDomFunctor(ob_map, dom::DiscreteCat, codom::Cat{Ob,Hom}) where {Ob,Hom} =
-  FinDomFunctor(ob_map, empty(ob_map, Hom), dom, codom)
-FinDomFunctor(ob_map, ::Nothing, dom::DiscreteCat, codom::Cat) =
-  FinDomFunctor(ob_map, dom, codom)
 
 hom_map(F::FinDomFunctor{<:DiscreteCat}, x) = id(codom(F), ob_map(F, x))
 

--- a/src/graphs/BasicGraphs.jl
+++ b/src/graphs/BasicGraphs.jl
@@ -62,8 +62,10 @@ end
 """
 @acset_type Graph(TheoryGraph, index=[:src,:tgt]) <: AbstractGraph
 
-function (::Type{T})(nv::Int) where T <: HasVertices
-  g = T(); add_vertices!(g, nv); g
+function (::Type{T})(nv::Int; kw...) where T <: HasVertices
+  g = T()
+  add_vertices!(g, nv; kw...)
+  return g
 end
 
 """ Number of vertices in a graph.

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -94,6 +94,10 @@ X = path_graph(Graph, 5)
 Y = migrate(X, F)
 @test length(Y(V)) == 5
 @test length(Y(E)) == 3
+@test Y(src)((v=3, e₁=2, e₂=3)) |> only == 2
+@test Y(tgt)((v=3, e₁=2, e₂=3)) |> only == 4
+@test Y(src)((3, 2, 3)) |> only == 2
+@test Y(tgt)((3, 2, 3)) |> only == 4
 
 # Same query, but with `@migration` macro.
 F = @migration TheoryGraph TheoryGraph begin
@@ -110,10 +114,8 @@ end
 Y = migrate(X, F)
 @test length(Y(V)) == 5
 @test length(Y(E)) == 3
-@test Y(src)((v=3, e₁=2, e₂=3)) |> only == 2
-@test Y(tgt)((v=3, e₁=2, e₂=3)) |> only == 4
-@test Y(src)((3, 2, 3)) |> only == 2
-@test Y(tgt)((3, 2, 3)) |> only == 4
+@test Y(src)((v=3, e₁=2, e₂=3)) == (V=2,)
+@test Y(tgt)((v=3, e₁=2, e₂=3)) == (V=4,)
 
 # Sigma data migration
 ######################

--- a/test/categorical_algebra/Diagrams.jl
+++ b/test/categorical_algebra/Diagrams.jl
@@ -2,7 +2,7 @@ module TestDiagrams
 using Test
 
 using Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
-using Catlab.Graphs.BasicGraphs: TheorySymmetricGraph
+using Catlab.Graphs.BasicGraphs: TheoryGraph, TheorySymmetricGraph
 
 const SchSGraph = TheorySymmetricGraph
 
@@ -58,5 +58,15 @@ d = dom(f)
 @test codom(op(g)) == Diagram{co}(D)
 @test op(g) == DiagramHom{co}([(1,:src)], ιV, D)
 @test op(g)⋅op(f) == op(f⋅g)
+
+# Monads of diagrams
+####################
+
+C = FinCat(TheoryGraph)
+d = munit(Diagram{id}, C, :V)
+@test is_discrete(shape(d))
+@test only(collect_ob(diagram(d))) == TheoryGraph[:V]
+f = munit(DiagramHom{id}, C, :src)
+@test only(components(diagram_map(f))) == TheoryGraph[:src]
 
 end

--- a/test/programs/DiagrammaticPrograms.jl
+++ b/test/programs/DiagrammaticPrograms.jl
@@ -247,6 +247,6 @@ end
 F_src = hom_map(F, 3)
 @test ob_map(F_src, 1) == (1, TheoryGraph[:src])
 @test ob_map(F_src, 2) == (1, id(TheoryGraph[:E]))
-@test hom_map(F_src, 1) == 1
+@test hom_map(F_src, 1) == id(shape(codom(F_src)), 1)
 
 end


### PR DESCRIPTION
Previously the column name ended up being `1`, which was confusing.