### PR TITLE
Deprecate data migration constructors for acsets

### DIFF
--- a/src/categorical_algebra/DataMigrations.jl
+++ b/src/categorical_algebra/DataMigrations.jl
@@ -129,13 +129,15 @@ function migrate!(X::ACSet, Y::ACSet, FOb, FHom)
   migrate!(X, Y, F)
 end
 
-# FIXME: These two constructors are too broad to apply to all acset types and
-# should be removed.
+function (::Type{T})(X::ACSet, F::FinFunctor) where T <: ACSet
+  Base.depwarn("Data migration constructor is deprecated, use `migrate` instead", :ACSet)
+  migrate(T, X, F)
+end
 
-(::Type{T})(X::ACSet, F::FinFunctor) where T <: ACSet = migrate(T, X, F)
-
-(::Type{T})(X::ACSet, FOb::AbstractDict, FHom::AbstractDict) where T <: ACSet =
+function (::Type{T})(X::ACSet, FOb::AbstractDict, FHom::AbstractDict) where T <: ACSet
+  Base.depwarn("Data migration constructor is deprecated, use `migrate` instead", :ACSet)
   migrate(T, X, FOb, FHom)
+end
 
 # Conjunctive migration
 #######################

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -21,15 +21,15 @@ h = Graph(3)
 add_parts!(h, :E, 3, src = [1,2,3], tgt = [2,3,1])
 
 # Identity data migration.
-@test h == Graph(h, Dict(:V => :V, :E => :E),
-                    Dict(:src => :src, :tgt => :tgt))
+@test h == migrate(Graph, h, Dict(:V => :V, :E => :E),
+                   Dict(:src => :src, :tgt => :tgt))
 
 # Migrate DDS → Graph.
 dds = DDS()
 add_parts!(dds, :X, 3, Φ=[2,3,1])
 X = TheoryDDS[:X]
-@test h == Graph(dds, Dict(:V => :X, :E => :X),
-                 Dict(:src => id(X), :tgt => :Φ))
+@test h == migrate(Graph, dds, Dict(:V => :X, :E => :X),
+                   Dict(:src => id(X), :tgt => :Φ))
 
 h2 = copy(h)
 migrate!(h2, dds, Dict(:V => :X, :E => :X),
@@ -37,8 +37,8 @@ migrate!(h2, dds, Dict(:V => :X, :E => :X),
 @test h2 == ob(coproduct(h, h))
 
 # Migrate DDS → DDS by advancing four steps.
-@test dds == DDS(dds, Dict(:X => :X),
-                      Dict(:Φ => [:Φ, :Φ, :Φ, :Φ]))
+@test dds == migrate(DDS, dds, Dict(:X => :X),
+                     Dict(:Φ => [:Φ, :Φ, :Φ, :Φ]))
 
 @present TheoryLabeledDDS <: TheoryDDS begin
   Label::AttrType
@@ -55,7 +55,7 @@ add_parts!(ldds, :X, 4, Φ=[2,3,4,1], label=[100, 101, 102, 103])
 wg = WeightedGraph{Int}(4)
 add_parts!(wg, :E, 4, src=[1,2,3,4], tgt=[2,3,4,1], weight=[101, 102, 103, 100])
 
-@test wg == WeightedGraph{Int}(ldds,
+@test wg == migrate(WeightedGraph{Int}, ldds,
   Dict(:V => :X, :E => :X, :Weight => :Label),
   Dict(:src => id(S), :tgt => :Φ, :weight => [:Φ, :label]))
 
@@ -75,7 +75,7 @@ idF = FinFunctor(
   Dict(ϕ => ϕ, label => label), 
   TheoryLabeledDDS, TheoryLabeledDDS
 )
-@test ldds == LabeledDDS{Int}(ldds, idF)
+@test ldds == migrate(LabeledDDS{Int}, ldds, idF)
 
 # Conjunctive data migration
 ############################


### PR DESCRIPTION
I think these constructors are too general to apply to all acset types, especially the latter one that takes two dicts. Of course, anyone is free to add particular migration constructors to particular struct acset types, provided they own those types.