### PR TITLE
Better architecture for conjunctive data migration

### DIFF
--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -273,7 +273,8 @@ function incident_body(s::SchemaDesc, idxed::AbstractDict{Symbol,Bool},
       end
     elseif unique_idxed[f]
       quote
-        get.(Ref(acs.hom_unique_indices.$f), part, Ref(0))
+        indices = $(GlobalRef(ACSetInterface,:view_or_slice))(acs.hom_unique_indices.$f, part)
+        copy ? Base.copy.(indices) : indices
       end
     else
       :(broadcast_findall(part, acs.homs.$f))

--- a/src/categorical_algebra/DataMigrations.jl
+++ b/src/categorical_algebra/DataMigrations.jl
@@ -146,21 +146,14 @@ function migrate(X::ACSet, F::ConjSchemaMigration)
   X = FinDomFunctor(X)
   tgt_schema = dom(F)
   limits = make_map(ob_generators(tgt_schema)) do c
-    Fc = diagram(ob_map(F, c))
-    J = dom(Fc)
+    Fc = ob_map(F, c)
+    J = shape(Fc)
     names = (ob_name(J, j) for j in ob_generators(J))
-    limit(compose(Fc, X, strict=false),
-          ToTabularLimit(alg=ToBipartiteLimit(), names=names))
+    TabularLimit(limit(compose(Fc, X), alg=ToBipartiteLimit()), names=names)
   end
   funcs = make_map(hom_generators(tgt_schema)) do f
     Ff, c, d = hom_map(F, f), dom(tgt_schema, f), codom(tgt_schema, f)
-    J′ = shape(codom(Ff))
-    cone = Multispan(ob(limits[c]), map(ob_generators(J′)) do j′
-      j, g = ob_map(Ff, j′)
-      πⱼ = legs(limits[c])[j]
-      compose(πⱼ, hom_map(X, g))
-    end)
-    universal(limits[d], cone)
+    universal(compose(Ff, X), limits[c], limits[d])
   end
   FinDomFunctor(mapvals(ob, limits), funcs, tgt_schema)
 end

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -685,11 +685,12 @@ function limit(d::BipartiteFreeDiagram{Ob,Hom}) where
   # (product of sizes of relations to join). This is a simple greedy heuristic.
   # For more control over the order of the joins, create a UWD schedule.
   if nv₂(d) == 0
+    # FIXME: Shouldn't need FinSetIndexedLimit in these special cases.
     if nv₁(d) == 1
-      Limit(d_original, SMultispan{1}(ιs[1]))
+      FinSetIndexedLimit(d_original, SMultispan{1}(ιs[1]))
     else
       πs = legs(product(SVector(ob₁(d)...)))
-      Limit(d_original, Multispan(map(compose, πs, ιs)))
+      FinSetIndexedLimit(d_original, Multispan(map(compose, πs, ιs)))
     end
   else
     # Select the join to perform.

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -20,7 +20,7 @@ using ...GAT, ...Theories
 import ...Theories: ob, terminal, product, proj1, proj2, equalizer, incl,
   initial, coproduct, coproj1, coproj2, coequalizer, proj,
   delete, create, pair, copair, factorize
-using ...CSetDataStructures, ..FreeDiagrams
+using ...CSetDataStructures, ..Categories, ..FreeDiagrams
 import ..FreeDiagrams: apex, legs
 
 # Data types for limits
@@ -428,19 +428,20 @@ end
 """
 struct ToBipartiteLimit <: LimitAlgorithm end
 
-function limit(diagram, ::ToBipartiteLimit)
-  bdiagram, vmap = to_bipartite_diagram(diagram)
-  lim = limit(bdiagram)
-  cone = Multispan(apex(lim), map(vmap) do (v₁, v₂)
-    if isnothing(v₁)
-      e = first(incident(bdiagram, v₂, :tgt))
-      compose(legs(lim)[src(bdiagram, e)], hom(bdiagram, e))
+function limit(F::Union{Functor,FreeDiagram}, ::ToBipartiteLimit)
+  d = BipartiteFreeDiagram(F)
+  lim = limit(d)
+  cone = Multispan(apex(lim), map(incident(d, :, :orig_vert₁),
+                                  incident(d, :, :orig_vert₂)) do v₁, v₂
+    if v₁ == 0
+      e = first(incident(d, v₂, :tgt))
+      compose(legs(lim)[src(d, e)], hom(d, e))
     else
       legs(lim)[v₁]
     end
   end)
   # FIXME: Should have a specialized type that handles universal property.
-  (Theories.roottypeof(lim))(diagram, cone)
+  (Theories.roottypeof(lim))(F, cone)
 end
 
 end

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -439,7 +439,8 @@ function limit(diagram, ::ToBipartiteLimit)
       legs(lim)[v₁]
     end
   end)
-  Limit(diagram, cone)
+  # FIXME: Should have a specialized type that handles universal property.
+  (Theories.roottypeof(lim))(diagram, cone)
 end
 
 end

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -424,9 +424,18 @@ function universal(lim::CompositePushout, cone::Multicospan)
   factorize(lim.coeq, universal(lim.coprod, cone))
 end
 
-""" Compute a limit by reducing the diagram shape to a bipartite graph.
+""" Compute a limit by reducing the diagram to a free bipartite diagram.
 """
 struct ToBipartiteLimit <: LimitAlgorithm end
+
+""" Limit computed by reduction to the limit of a free bipartite diagram.
+"""
+struct BipartiteLimit{Ob, Diagram, Cone<:Multispan{Ob},
+                      Lim<:AbstractLimit} <: AbstractLimit{Ob,Diagram}
+  diagram::Diagram
+  cone::Cone
+  limit::Lim
+end
 
 function limit(F::Union{Functor,FreeDiagram}, ::ToBipartiteLimit)
   d = BipartiteFreeDiagram(F)
@@ -440,8 +449,12 @@ function limit(F::Union{Functor,FreeDiagram}, ::ToBipartiteLimit)
       legs(lim)[v₁]
     end
   end)
-  # FIXME: Should have a specialized type that handles universal property.
-  (Theories.roottypeof(lim))(F, cone)
+  BipartiteLimit(F, cone, lim)
+end
+
+function universal(lim::BipartiteLimit, cone::Multispan)
+  d = lim.limit.diagram
+  universal(lim.limit, Multispan(apex(cone), legs(cone)[d[:orig_vert₁]]))
 end
 
 end

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -12,7 +12,7 @@ export AbstractLimit, AbstractColimit, Limit, Colimit,
   BinaryPushout, Pushout, pushout, pushout_complement, can_pushout_complement,
   BinaryCoequalizer, Coequalizer, coequalizer, proj,
   @cartesian_monoidal_instance, @cocartesian_monoidal_instance,
-  ComposeProductEqualizer, ComposeCoproductCoequalizer, BipartiteLimit
+  ComposeProductEqualizer, ComposeCoproductCoequalizer, ToBipartiteLimit
 
 using AutoHashEquals
 
@@ -426,9 +426,9 @@ end
 
 """ Compute a limit by reducing the diagram shape to a bipartite graph.
 """
-struct BipartiteLimit <: LimitAlgorithm end
+struct ToBipartiteLimit <: LimitAlgorithm end
 
-function limit(diagram, ::BipartiteLimit)
+function limit(diagram, ::ToBipartiteLimit)
   bdiagram, vmap = to_bipartite_diagram(diagram)
   lim = limit(bdiagram)
   cone = Multispan(apex(lim), map(vmap) do (v₁, v₂)

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -90,12 +90,12 @@ F = FinDomFunctor(Dict(V => Diagram{op}(F_V),
                   Dict(src => DiagramHom{op}([(1, src)], F_E, F_V),
                        tgt => DiagramHom{op}([(2, tgt)], F_E, F_V)), C)
 @test F isa DataMigrations.ConjSchemaMigration
-X = path_graph(Graph, 5)
-Y = migrate(X, F)
-@test length(Y(V)) == 5
-@test length(Y(E)) == 3
-@test Y(src)((x1=2, x2=3, x3=3)) == (x1=2,)
-@test Y(tgt)((x1=2, x2=3, x3=3)) == (x1=4,)
+g = path_graph(Graph, 5)
+H = migrate(g, F, tabular=true)
+@test length(H(V)) == 5
+@test length(H(E)) == 3
+@test H(src)((x1=2, x2=3, x3=3)) == (x1=2,)
+@test H(tgt)((x1=2, x2=3, x3=3)) == (x1=4,)
 
 # Same query, but with `@migration` macro.
 F = @migration TheoryGraph TheoryGraph begin
@@ -109,11 +109,20 @@ F = @migration TheoryGraph TheoryGraph begin
   src => e₁ ⋅ src
   tgt => e₂ ⋅ tgt
 end
-Y = migrate(X, F)
-@test length(Y(V)) == 5
-@test length(Y(E)) == 3
-@test Y(src)((v=3, e₁=2, e₂=3)) == (V=2,)
-@test Y(tgt)((v=3, e₁=2, e₂=3)) == (V=4,)
+H = migrate(g, F, tabular=true)
+@test length(H(V)) == 5
+@test length(H(E)) == 3
+@test H(src)((v=3, e₁=2, e₂=3)) == (V=2,)
+@test H(tgt)((v=3, e₁=2, e₂=3)) == (V=4,)
+
+h = migrate(Graph, g, F)
+@test (nv(h), ne(h)) == (5, 3)
+@test sort!(collect(zip(h[:src], h[:tgt]))) == [(1,3), (2,4), (3,5)]
+
+h = Graph(5)
+migrate!(h, g, F)
+@test (nv(h), ne(h)) == (10, 3)
+@test sort!(collect(zip(h[:src], h[:tgt]))) == [(6,8), (7,9), (8,10)]
 
 # Sigma data migration
 ######################

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -124,6 +124,29 @@ migrate!(h, g, F)
 @test (nv(h), ne(h)) == (10, 3)
 @test sort!(collect(zip(h[:src], h[:tgt]))) == [(6,8), (7,9), (8,10)]
 
+# Graph whose vertices are paths of length 2 and edges are paths of length 3.
+F = @migration TheoryGraph TheoryGraph begin
+  V => @join begin
+    v::V
+    (e₁, e₂)::E
+    (t: e₁ → v)::tgt
+    (s: e₂ → v)::src
+  end
+  E => @join begin
+    (v₁, v₂)::V
+    (e₁, e₂, e₃)::E
+    (t₁: e₁ → v₁)::tgt
+    (s₁: e₂ → v₁)::src
+    (t₂: e₂ → v₂)::tgt
+    (s₂: e₃ → v₂)::src
+  end
+  src => (v => v₁; e₁ => e₁; e₂ => e₂; t => t₁; s => s₁)
+  tgt => (v => v₂; e₁ => e₂; e₂ => e₃; t => t₂; s => s₂)
+end
+g = path_graph(Graph, 6)
+h = migrate(Graph, g, F)
+@test h == path_graph(Graph, 4)
+
 # Sigma data migration
 ######################
 

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -87,15 +87,15 @@ F_V = FinDomFunctor([V], FinCat(1), C)
 F_E = FinDomFunctor(FreeDiagram(Cospan(tgt, src)), C)
 F = FinDomFunctor(Dict(V => Diagram{op}(F_V),
                        E => Diagram{op}(F_E)),
-                  Dict(src => DiagramHom{op}([(2, src)], F_E, F_V),
-                       tgt => DiagramHom{op}([(3, tgt)], F_E, F_V)), C)
+                  Dict(src => DiagramHom{op}([(1, src)], F_E, F_V),
+                       tgt => DiagramHom{op}([(2, tgt)], F_E, F_V)), C)
 @test F isa DataMigrations.ConjSchemaMigration
 X = path_graph(Graph, 5)
 Y = migrate(X, F)
 @test length(Y(V)) == 5
 @test length(Y(E)) == 3
-@test Y(src)((x1=3, x2=2, x3=3)) == (x1=2,)
-@test Y(tgt)((x1=3, x2=2, x3=3)) == (x1=4,)
+@test Y(src)((x1=2, x2=3, x3=3)) == (x1=2,)
+@test Y(tgt)((x1=2, x2=3, x3=3)) == (x1=4,)
 
 # Same query, but with `@migration` macro.
 F = @migration TheoryGraph TheoryGraph begin

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -271,7 +271,10 @@ lim = limit(BipartiteFreeDiagram(Cospan(f, g)))
 π1, π2 = legs(lim)
 @test π1 == FinFunction([1,1,2,2,4], 4)
 @test π2 == FinFunction([1,2,1,2,4], 4)
-@test π1 ⋅ f == π2 ⋅ g
+
+h = universal(lim, Span(f′, g′))
+@test force(h ⋅ π1) == f′
+@test force(h ⋅ π2) == g′
 
 # Equalizer as limit of bipartite free diagram.
 f, g = [FinDomFunction(x -> x % i, FinSet(100), TypeSet(Int)) for i in 2:3]

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -337,7 +337,7 @@ coeq = coequalizer(f,g)
 @test proj(coeq) == FinFunction([1,2,1], 2)
 @test proj(coequalizer([f,g])) == proj(coeq)
 @test factorize(coeq, FinFunction([4,1,4])) == FinFunction([4,1])
-@test_throws AssertionError factorize(coeq, FinFunction([3,1,4]))
+@test_throws ErrorException factorize(coeq, FinFunction([3,1,4]))
 
 # Coequalizer in case of identical functions.
 f = FinFunction([4,2,3,1], 5)
@@ -380,7 +380,7 @@ h, k = FinFunction([3,5]), FinFunction([1,3,5])
 @test force(coproj1(colim) ⋅ copair(colim,h,k)) == h
 @test force(coproj2(colim) ⋅ copair(colim,h,k)) == k
 k = FinFunction([1,2,5])
-@test_throws AssertionError copair(colim,h,k)
+@test_throws ErrorException copair(colim,h,k)
 
 # Same thing as a colimit of a general free diagram.
 diagram = FreeDiagram([FinSet(1),FinSet(2),FinSet(3)],[(f,1,2), (g,1,3)])

--- a/test/categorical_algebra/FreeDiagrams.jl
+++ b/test/categorical_algebra/FreeDiagrams.jl
@@ -49,6 +49,9 @@ bd = BipartiteFreeDiagram([A,B], [C], [(f,1,1),(g,2,1)])
 @test (src(bd), tgt(bd)) == ([1,2], [1,1])
 @test FreeDiagram(bd) == FreeDiagram([A,B,C], [(f,1,3),(g,2,3)])
 
+as_basic_bipartite(diagram::BipartiteFreeDiagram{Ob,Hom}) where {Ob,Hom} =
+  (d = BipartiteFreeDiagram{Ob,Hom}(); copy_parts!(d, diagram); d)
+
 # Diagrams of fixed shape
 #########################
 
@@ -72,9 +75,9 @@ diagram = FreeDiagram(discrete)
 @test ob(diagram) == [A,B,C]
 @test isempty(hom(diagram))
 @test BipartiteFreeDiagram(discrete, colimit=false) ==
-  BipartiteFreeDiagram(diagram, colimit=false)
+  as_basic_bipartite(BipartiteFreeDiagram(diagram, colimit=false))
 @test BipartiteFreeDiagram(discrete, colimit=true) ==
-  BipartiteFreeDiagram(diagram, colimit=true)
+  as_basic_bipartite(BipartiteFreeDiagram(diagram, colimit=true))
 
 # Spans.
 f, g = Hom(:f, C, A), Hom(:g, C, B)
@@ -106,7 +109,7 @@ diagram = BipartiteFreeDiagram(span)
 @test (ob₁(diagram), ob₂(diagram)) == ([C], [A,B,A])
 @test hom(diagram) == [f,g,h]
 @test (src(diagram), tgt(diagram)) == ([1,1,1], [1,2,3])
-@test diagram == BipartiteFreeDiagram(FreeDiagram(span))
+@test diagram == as_basic_bipartite(BipartiteFreeDiagram(FreeDiagram(span)))
 
 span = Multispan([ id(FinSet(2)) for i in 1:3 ])
 span = bundle_legs(span, [1, (2,3)])
@@ -143,7 +146,7 @@ diagram = BipartiteFreeDiagram(cospan)
 @test (ob₁(diagram), ob₂(diagram)) == ([A,B,A], [C])
 @test hom(diagram) == [f,g,h]
 @test (src(diagram), tgt(diagram)) == ([1,2,3], [1,1,1])
-@test diagram == BipartiteFreeDiagram(FreeDiagram(cospan))
+@test diagram == as_basic_bipartite(BipartiteFreeDiagram(FreeDiagram(cospan)))
 
 cospan = Multicospan([FinFunction([i],3) for i in 1:3])
 cospan = bundle_legs(cospan, [(1,3), 2])
@@ -171,7 +174,7 @@ diagram = BipartiteFreeDiagram(para)
 @test (ob₁(diagram), ob₂(diagram)) == ([A], [B])
 @test hom(diagram) == [f,g,h]
 @test (src(diagram), tgt(diagram)) == ([1,1,1], [1,1,1])
-@test diagram == BipartiteFreeDiagram(FreeDiagram(para))
+@test diagram == as_basic_bipartite(BipartiteFreeDiagram(FreeDiagram(para)))
 
 # Composable pairs.
 f, g = Hom(:f, A, B), Hom(:g, B, C)


### PR DESCRIPTION
By using and extending the limits system, this design clarifies the computations in conjunctive data migration and paves the way for an easy, perfectly dual implementation of agglomerative data migration (#541).

This PR also closes #547. 