### PR TITLE
Arbitrarily color boxes / junctions of a wiring diagram

### DIFF
--- a/src/graphics/GraphvizWiringDiagrams.jl
+++ b/src/graphics/GraphvizWiringDiagrams.jl
@@ -427,7 +427,6 @@ function to_graphviz_property_graph(d::UndirectedWiringDiagram;
   # Create nodes for boxes.
   box_vs = add_vertices!(graph, nboxes(d))
   set_vprop!(graph, box_vs, :id, [ "box$b" for b in boxes(d) ])
-  set_vprop!(graph, box_vs, :fillcolor, [ "green" for b in boxes(d) ])
   labels = if box_labels isa Symbol
     node_label.(subpart(d, box_vs, box_labels))
   else

--- a/src/graphics/GraphvizWiringDiagrams.jl
+++ b/src/graphics/GraphvizWiringDiagrams.jl
@@ -85,6 +85,7 @@ function to_graphviz(f::WiringDiagram;
     outer_ports::Bool=true, anchor_outer_ports::Bool=true,
     graph_attrs::AbstractDict=Dict(), node_attrs::AbstractDict=Dict(),
     title::Union{Nothing, Graphviz.Label}=nothing,
+    node_colors::AbstractDict=Dict(),
     edge_attrs::AbstractDict=Dict(), cell_attrs::AbstractDict=Dict())::Graphviz.Graph
   @assert label_attr in (:label, :xlabel, :headlabel, :taillabel)
 
@@ -115,7 +116,8 @@ function to_graphviz(f::WiringDiagram;
   for v in box_ids(f)
     gv_box = graphviz_box(box(f,v), box_id([v]),
       orientation=orientation, labels=node_labels, port_size=port_size,
-      junction_size=junction_size, cell_attrs=cell_attrs)
+      junction_size=junction_size, node_color=get(node_colors,v, nothing),
+      cell_attrs=cell_attrs)
     append!(stmts, gv_box.stmts)
     update_port_map!(v, InputPort, gv_box.input_ports)
     update_port_map!(v, OutputPort, gv_box.output_ports)
@@ -163,6 +165,7 @@ end
 function graphviz_box(box::AbstractBox, node_id;
     orientation::LayoutOrientation=TopToBottom,
     labels::Bool=true, port_size::String="0",
+    node_color::Union{Nothing,String}=nothing,
     cell_attrs::AbstractDict=Dict(), kw...)
   # Main node.
   nin, nout = length(input_ports(box)), length(output_ports(box))
@@ -176,6 +179,9 @@ function graphviz_box(box::AbstractBox, node_id;
     id = node_id,
     comment = node_label(box.value),
     label = html_label,
+    color = "black",
+    fillcolor=isnothing(node_color) ? "white" : node_color,
+    style=isnothing(node_color) ? "solid" : "filled"
   )
 
   # Input and output ports.
@@ -192,13 +198,14 @@ end
 """ Graphviz box for a junction.
 """
 function graphviz_box(junction::Junction, node_id;
-    junction_size::String="0", kw...)
+    junction_size::String="0",
+    node_color::Union{Nothing,String}=nothing, kw...)
   graphviz_junction(junction, node_id;
     comment = "junction",
     label = "",
     shape = "circle",
     style = "filled",
-    fillcolor = "black",
+    fillcolor = isnothing(node_color) ? "black" : node_color,
     width = junction_size,
     height = junction_size,
   )
@@ -223,7 +230,7 @@ function box_html_label(nin::Int, nout::Int, text_label::String;
     Graphviz.Html("""
       <TABLE BORDER="0" CELLPADDING="0" CELLSPACING="0">
       <TR><TD>$(orientation == TopToBottom ? input_label : output_label)</TD></TR>
-      <TR><TD $(html_attributes(attrs))>$(escape_html(text_label))</TD></TR>
+      <TR><TD $(html_attributes(attrs))>$((text_label))</TD></TR>
       <TR><TD>$(orientation == BottomToTop ? input_label : output_label)</TD></TR>
       </TABLE>""")
   else
@@ -420,6 +427,7 @@ function to_graphviz_property_graph(d::UndirectedWiringDiagram;
   # Create nodes for boxes.
   box_vs = add_vertices!(graph, nboxes(d))
   set_vprop!(graph, box_vs, :id, [ "box$b" for b in boxes(d) ])
+  set_vprop!(graph, box_vs, :fillcolor, [ "green" for b in boxes(d) ])
   labels = if box_labels isa Symbol
     node_label.(subpart(d, box_vs, box_labels))
   else
@@ -485,7 +493,7 @@ end
 
 """ Create a label for the main content of a box.
 """
-node_label(box_value) = box_label(MIME("text/plain"), box_value)
+node_label(box_value) = box_label(MIME("text/html"), box_value)
 
 """ Create a label for an edge.
 """

--- a/src/graphics/GraphvizWiringDiagrams.jl
+++ b/src/graphics/GraphvizWiringDiagrams.jl
@@ -230,7 +230,7 @@ function box_html_label(nin::Int, nout::Int, text_label::String;
     Graphviz.Html("""
       <TABLE BORDER="0" CELLPADDING="0" CELLSPACING="0">
       <TR><TD>$(orientation == TopToBottom ? input_label : output_label)</TD></TR>
-      <TR><TD $(html_attributes(attrs))>$((text_label))</TD></TR>
+      <TR><TD $(html_attributes(attrs))>$(escape_html(text_label))</TD></TR>
       <TR><TD>$(orientation == BottomToTop ? input_label : output_label)</TD></TR>
       </TABLE>""")
   else
@@ -492,7 +492,7 @@ end
 
 """ Create a label for the main content of a box.
 """
-node_label(box_value) = box_label(MIME("text/html"), box_value)
+node_label(box_value) = box_label(MIME("text/plain"), box_value)
 
 """ Create a label for an edge.
 """


### PR DESCRIPTION
This is one way we could allow users to color wiring diagrams. A dictionary mapping box IDs to strings (e.g. `"lightblue"`) can be passed to `to_graphviz`, with the default behavior being unchanged (unfilled boxes, black junctions).