### PR TITLE
Allow adding titles to wiring diagrams

### DIFF
--- a/src/graphics/Graphviz.jl
+++ b/src/graphics/Graphviz.jl
@@ -7,7 +7,7 @@ References:
 """
 module Graphviz
 export Expression, Statement, Attributes, Graph, Digraph, Subgraph,
-  Node, NodeID, Edge, pprint, run_graphviz
+  Node, NodeID, Edge, Title, pprint, run_graphviz
 
 using DataStructures: OrderedDict
 using AutoHashEquals
@@ -107,6 +107,10 @@ Edge(path::Vararg{NodeID}; attrs...) = Edge(collect(path), attrs)
 Edge(path::Vector{String}, attrs::AbstractDict) = Edge(map(NodeID, path), attrs)
 Edge(path::Vector{String}; attrs...) = Edge(map(NodeID, path), attrs)
 Edge(path::Vararg{String}; attrs...) = Edge(map(NodeID, collect(path)), attrs)
+
+@auto_hash_equals struct Title <: Statement
+  title::String
+end
 
 # Bindings
 ##########
@@ -237,6 +241,11 @@ function pprint_attrs(io::IO, attrs::Attributes, n::Int=0;
     print(io, "]")
     print(io, post)
   end
+end
+
+function pprint(io::IO, titl::Title, n::Int; directed::Bool=false)
+  print(io, """labelloc="t";
+  label="$(titl.title)";""")
 end
 
 indent(io::IO, n::Int) = print(io, " "^n)

--- a/src/graphics/Graphviz.jl
+++ b/src/graphics/Graphviz.jl
@@ -7,7 +7,7 @@ References:
 """
 module Graphviz
 export Expression, Statement, Attributes, Graph, Digraph, Subgraph,
-  Node, NodeID, Edge, Title, pprint, run_graphviz
+  Node, NodeID, Edge, Label, pprint, run_graphviz
 
 using DataStructures: OrderedDict
 using AutoHashEquals
@@ -108,8 +108,13 @@ Edge(path::Vector{String}, attrs::AbstractDict) = Edge(map(NodeID, path), attrs)
 Edge(path::Vector{String}; attrs...) = Edge(map(NodeID, path), attrs)
 Edge(path::Vararg{String}; attrs...) = Edge(map(NodeID, collect(path)), attrs)
 
-@auto_hash_equals struct Title <: Statement
-  title::String
+"""
+labelloc defaults: "t" (clusters) , "b" (root graphs) , "c" (nodes)
+For graphs and clusters, only labelloc=t and labelloc=b are allowed
+"""
+Base.@kwdef struct Label <: Statement
+  labelloc::String = ""
+  label::String = ""
 end
 
 # Bindings
@@ -243,9 +248,11 @@ function pprint_attrs(io::IO, attrs::Attributes, n::Int=0;
   end
 end
 
-function pprint(io::IO, titl::Title, n::Int; directed::Bool=false)
-  print(io, """labelloc="t";
-  label="$(titl.title)";""")
+function pprint(io::IO, lab::Label, n::Int; directed::Bool=false)
+  if !isempty(lab.labelloc)
+    print(io, "labelloc=\"$(lab.labelloc)\";")
+  end
+  print(io, "label=\"$(lab.label)\";")
 end
 
 indent(io::IO, n::Int) = print(io, " "^n)

--- a/src/graphics/GraphvizWiringDiagrams.jl
+++ b/src/graphics/GraphvizWiringDiagrams.jl
@@ -84,15 +84,14 @@ function to_graphviz(f::WiringDiagram;
     port_size::String="24", junction_size::String="0.05",
     outer_ports::Bool=true, anchor_outer_ports::Bool=true,
     graph_attrs::AbstractDict=Dict(), node_attrs::AbstractDict=Dict(),
-    node_colors::Dict{Int,String}=Dict{Int,String}(),
-    title::Union{Nothing,String}=nothing,
+    title::Union{Nothing, Graphviz.Label}=nothing,
     edge_attrs::AbstractDict=Dict(), cell_attrs::AbstractDict=Dict())::Graphviz.Graph
   @assert label_attr in (:label, :xlabel, :headlabel, :taillabel)
 
   # State variables.
   stmts = Graphviz.Statement[]
   if !isnothing(title)
-    push!(stmts, Graphviz.Title(title))
+    push!(stmts, title)
   end
   port_map = Dict{Port,Graphviz.NodeID}()
   update_port_map! = (v::Int, kind::PortKind, node_ids) -> begin

--- a/src/graphics/GraphvizWiringDiagrams.jl
+++ b/src/graphics/GraphvizWiringDiagrams.jl
@@ -84,11 +84,16 @@ function to_graphviz(f::WiringDiagram;
     port_size::String="24", junction_size::String="0.05",
     outer_ports::Bool=true, anchor_outer_ports::Bool=true,
     graph_attrs::AbstractDict=Dict(), node_attrs::AbstractDict=Dict(),
+    node_colors::Dict{Int,String}=Dict{Int,String}(),
+    title::Union{Nothing,String}=nothing,
     edge_attrs::AbstractDict=Dict(), cell_attrs::AbstractDict=Dict())::Graphviz.Graph
   @assert label_attr in (:label, :xlabel, :headlabel, :taillabel)
 
   # State variables.
   stmts = Graphviz.Statement[]
+  if !isnothing(title)
+    push!(stmts, Graphviz.Title(title))
+  end
   port_map = Dict{Port,Graphviz.NodeID}()
   update_port_map! = (v::Int, kind::PortKind, node_ids) -> begin
     for (i, node_id) in enumerate(node_ids)

--- a/test/graphics/Graphviz.jl
+++ b/test/graphics/Graphviz.jl
@@ -81,7 +81,7 @@ digraph G {
 """
 
 # Subgraph statement
-subgraph = Subgraph("sub", 
+subgraph = Subgraph("sub",
   Node("n1"),
   Node("n2"),
   Edge("n1","n2")
@@ -104,5 +104,12 @@ subgraph = Subgraph(
   n1;
   n2;
 }"""
+
+# Label statement
+label1 = Label(label="abc")
+label2 = Label(labelloc="t", label="abc")
+@test spprint(label1) == "label=\"abc\";"
+@test spprint(label2) == "labelloc=\"t\";label=\"abc\";"
+
 
 end


### PR DESCRIPTION
For visualizing a dynamic process (each timestep represented by a wiring diagram), I've found it's helpful to have a [title](https://stackoverflow.com/questions/6450765/how-do-you-center-a-title-for-a-diagram-output-to-svg-using-dot) that provides information during that timestep.  E.g.

<img width="970" alt="Screen Shot 2021-11-12 at 12 28 33 PM" src="https://user-images.githubusercontent.com/27834499/141530785-842ad502-9daa-436d-a7ee-f47cf9bf0604.png">

To do this, I added a `Title` as a new kind of `Graphviz.Statement` and added a `title::Union{Nothing,String}` keyword argument to `to_graphviz`.
 