### PR TITLE
Initiality test for FinFunctors

### DIFF
--- a/src/categorical_algebra/FinCats.jl
+++ b/src/categorical_algebra/FinCats.jl
@@ -366,10 +366,13 @@ function is_initial(F::FinFunctor)::Bool
   pathₛ, pathₜ = enumerate_paths.([Gₛ, Gₜ])
 
   function connected_nonempty_slice(t::Int)::Bool
+    edges_into_t = incident(pathₜ, t, :tgt)
     # Generate slice objects
     ob_slice = Pair{Int,Vector{Int}}[] # s ∈Ob(S) and a path ∈ T(F(s), t)
     for s in vertices(Gₛ)
-        append!(ob_slice, [s => p for p in pathₜ[ob_map(F,s) => t]])
+      e = incident(pathₜ, ob_map(F,s), :src) ∩ edges_into_t
+      paths_s_to_t = isempty(e) ? [] : pathₜ[only(e), :eprops]
+      append!(ob_slice, [s => p for p in paths_s_to_t])
     end
 
     # Empty case
@@ -383,7 +386,9 @@ function is_initial(F::FinFunctor)::Bool
     """
     function check_pair(i::Int, j::Int)::Bool
       (m,pₘ), (n,pₙ) = ob_slice[i], ob_slice[j]
-      return any(f -> pₘ == vcat(edges.(hom_map(F,f))..., pₙ), pathₛ[m => n])
+      e = incident(pathₛ, m, :src) ∩ incident(pathₛ, n, :tgt)
+      paths = isempty(e) ? [] : pathₛ[only(e), :eprops]
+      return any(f -> pₘ == vcat(edges.(hom_map(F,f))..., pₙ), paths)
     end
 
     # Use check_pair to determine pairwise connectivity

--- a/src/categorical_algebra/FinCats.jl
+++ b/src/categorical_algebra/FinCats.jl
@@ -366,13 +366,12 @@ function is_initial(F::FinFunctor)::Bool
   pathₛ, pathₜ = enumerate_paths.([Gₛ, Gₜ])
 
   function connected_nonempty_slice(t::Int)::Bool
-    edges_into_t = incident(pathₜ, t, :tgt)
+    paths_into_t = incident(pathₜ, t, :tgt)
     # Generate slice objects
     ob_slice = Pair{Int,Vector{Int}}[] # s ∈Ob(S) and a path ∈ T(F(s), t)
     for s in vertices(Gₛ)
-      e = incident(pathₜ, ob_map(F,s), :src) ∩ edges_into_t
-      paths_s_to_t = isempty(e) ? [] : pathₜ[only(e), :eprops]
-      append!(ob_slice, [s => p for p in paths_s_to_t])
+      paths_s_to_t = incident(pathₜ, ob_map(F,s), :src) ∩ paths_into_t
+      append!(ob_slice, [s => pathₜ[p, :eprops] for p in paths_s_to_t])
     end
 
     # Empty case
@@ -386,8 +385,8 @@ function is_initial(F::FinFunctor)::Bool
     """
     function check_pair(i::Int, j::Int)::Bool
       (m,pₘ), (n,pₙ) = ob_slice[i], ob_slice[j]
-      e = incident(pathₛ, m, :src) ∩ incident(pathₛ, n, :tgt)
-      paths = isempty(e) ? [] : pathₛ[only(e), :eprops]
+      es = incident(pathₛ, m, :src) ∩ incident(pathₛ, n, :tgt)
+      paths = pathₛ[es, :eprops]
       return any(f -> pₘ == vcat(edges.(hom_map(F,f))..., pₙ), paths)
     end
 

--- a/src/graphs/GraphAlgorithms.jl
+++ b/src/graphs/GraphAlgorithms.jl
@@ -120,7 +120,7 @@ end
 """Enumerate all paths of an acyclic graph, indexed by src+tgt"""
 function enumerate_paths(G::Graph;
                          sorted::Union{AbstractVector{Int},Nothing}=nothing
-                        )::ReflexiveEdgePropertyGraph{Set{Vector{Int}}}
+                        )::ReflexiveEdgePropertyGraph{Vector{Int}}
   sorted = isnothing(sorted) ? topological_sort(G) : sorted
   Path = Vector{Int}
 
@@ -135,19 +135,13 @@ function enumerate_paths(G::Graph;
     end
   end
   # Initialize output data structure with empty paths
-  res = @acset ReflexiveEdgePropertyGraph{Set{Path}} begin
+  res = @acset ReflexiveEdgePropertyGraph{Path} begin
     V=nv(G); E=nv(G); src=1:nv(G); tgt=1:nv(G); refl=1:nv(G)
-    eprops=[Set([Path()]) for _ in 1:nv(G)]
+    eprops=[Int[] for _ in 1:nv(G)]
   end
   for (src, ps) in enumerate(paths)
     for p in filter(x->!isempty(x), ps)
-      tgt = G[p[end],:tgt]
-      e = incident(res, src, :src) ∩ incident(res, tgt, :tgt)
-      if isempty(e)
-        add_part!(res, :E; src=src, tgt=tgt, eprops=Set([p]))
-      else
-        push!(res[only(e), :eprops], p)
-      end
+      add_part!(res, :E; src=src, tgt=G[p[end],:tgt], eprops=p)
     end
   end
   return res

--- a/src/graphs/GraphAlgorithms.jl
+++ b/src/graphs/GraphAlgorithms.jl
@@ -8,6 +8,7 @@ using DataStructures: Stack, DefaultDict
 
 using ...Theories: dom, codom
 using ...CSetDataStructures, ..BasicGraphs
+using ..PropertyGraphs: ReflexiveEdgePropertyGraph
 
 # Connectivity
 ##############
@@ -119,9 +120,10 @@ end
 """Enumerate all paths of an acyclic graph, indexed by src+tgt"""
 function enumerate_paths(G::Graph;
                          sorted::Union{AbstractVector{Int},Nothing}=nothing
-                        )::DefaultDict{Pair{Int,Int},Set{Vector{Int}}}
+                        )::ReflexiveEdgePropertyGraph{Set{Vector{Int}}}
   sorted = isnothing(sorted) ? topological_sort(G) : sorted
   Path = Vector{Int}
+
   paths = [Set{Path}() for _ in 1:nv(G)] # paths that start on a particular V
   for v in reverse(sorted)
     push!(paths[v], Int[]) # add length 0 paths
@@ -132,14 +134,23 @@ function enumerate_paths(G::Graph;
       end
     end
   end
-  # Restructure `paths` into a data structure indexed by start AND end V
-  allpaths = DefaultDict{Pair{Int,Int},Set{Path}}(()->Set{Path}())
-  for (s, ps) in enumerate(paths)
-    for p in ps
-      push!(allpaths[s => isempty(p) ? s : G[p[end],:tgt]], p)
+  # Initialize output data structure with empty paths
+  res = @acset ReflexiveEdgePropertyGraph{Set{Path}} begin
+    V=nv(G); E=nv(G); src=1:nv(G); tgt=1:nv(G); refl=1:nv(G)
+    eprops=[Set([Path()]) for _ in 1:nv(G)]
+  end
+  for (src, ps) in enumerate(paths)
+    for p in filter(x->!isempty(x), ps)
+      tgt = G[p[end],:tgt]
+      e = incident(res, src, :src) ∩ incident(res, tgt, :tgt)
+      if isempty(e)
+        add_part!(res, :E; src=src, tgt=tgt, eprops=Set([p]))
+      else
+        push!(res[only(e), :eprops], p)
+      end
     end
   end
-  return allpaths
+  return res
 end
 
 end

--- a/src/graphs/GraphAlgorithms.jl
+++ b/src/graphs/GraphAlgorithms.jl
@@ -123,7 +123,7 @@ function enumerate_paths(G::Graph;
   sorted = isnothing(sorted) ? topological_sort(G) : sorted
   Path = Vector{Int}
   paths = [Set{Path}() for _ in 1:nv(G)] # paths that start on a particular V
-  for v in reverse(topological_sort(G))
+  for v in reverse(sorted)
     push!(paths[v], Int[]) # add length 0 paths
     for e in incident(G, v, :src)
       push!(paths[v], [e]) # add length 1 paths

--- a/src/graphs/PropertyGraphs.jl
+++ b/src/graphs/PropertyGraphs.jl
@@ -1,10 +1,11 @@
 module PropertyGraphs
 export AbstractPropertyGraph, PropertyGraph, SymmetricPropertyGraph,
+  ReflexiveEdgePropertyGraph,
   gprops, vprops, eprops, get_gprop, get_vprop, get_eprop,
   set_gprop!, set_vprop!, set_eprop!, set_gprops!, set_vprops!, set_eprops!
 
 using ...Present, ...CSetDataStructures, ..BasicGraphs
-using ..BasicGraphs: TheoryGraph, TheorySymmetricGraph
+using ..BasicGraphs: TheoryGraph, TheorySymmetricGraph, TheoryReflexiveGraph
 import ..BasicGraphs: nv, ne, src, tgt, inv, edges, vertices,
   has_edge, has_vertex, add_edge!, add_edges!, add_vertex!, add_vertices!
 
@@ -83,6 +84,17 @@ SymmetricPropertyGraph{T,G}(; kw...) where {T,G<:_AbstractSymmetricPropertyGraph
   SymmetricPropertyGraph(G(), Dict{Symbol,T}(kw...))
 SymmetricPropertyGraph{T}(; kw...) where T =
   SymmetricPropertyGraph{T,_SymmetricPropertyGraph{T}}(; kw...)
+
+
+
+@present TheoryReflexiveEdgePropertyGraph <: TheoryReflexiveGraph begin
+  Props::AttrType
+  eprops::Attr(E,Props)
+end
+
+@abstract_acset_type AbstractReflexiveEdgePropertyGraph <: HasGraph
+@acset_type ReflexiveEdgePropertyGraph(TheoryReflexiveEdgePropertyGraph, index=[:src,:tgt]) <:
+AbstractReflexiveEdgePropertyGraph
 
 # Accessors and mutators
 ########################

--- a/test/categorical_algebra/FinCats.jl
+++ b/test/categorical_algebra/FinCats.jl
@@ -175,4 +175,63 @@ G = FinDomFunctor(g)
 @test ob_map(G, :Weight) == TypeSet(Float64)
 @test hom_map(G, :weight) == FinDomFunction([0.5, 1.5])
 
+# Initiality of functors
+########################
+
+"Commutative square diagram: with 1→2→4 and 1→3→4"
+S = FinCat(@acset Graph begin
+  V = 4
+  E = 4
+  src = [1,1,2,3]
+  tgt = [2,3,4,4]
+end)
+
+"Equalizer diagram: 1→2⇉3"
+T = FinCat(@acset Graph begin
+  V = 3
+  E = 3
+  src = [1,2,2]
+  tgt = [2,3,3]
+end)
+
+"Extra bit added to beginning equalizer diagram: 4→1→2⇉3"
+T2 = FinCat(@acset Graph begin
+  V = 4
+  E = 4
+  src = [1,2,2,4]
+  tgt = [2,3,3,1]
+end)
+
+"Extra bit added to end of equalizer diagram: 1→2⇉3→4"
+T3 = FinCat(@acset Graph begin
+  V = 4
+  E = 4
+  src = [1,2,2,3]
+  tgt = [2,3,3,4]
+end)
+
+
+# Opposite square corners folded on top of each other
+F1 = FinFunctor([1,2,2,3], [1,1,2,3], S, T)
+
+# Both paths in square get mapped onto single length-2 path in equalizer
+F2 = FinFunctor([1,2,2,3], [1,1,2,2], S, T)
+
+# Fit equalizer into square, ignoring opposite corner
+F3 = FinFunctor([1,2,4], [1,3,3], T, S)
+
+# Same as F1, but there is an additional piece of data in codomain, ignored
+F4 = FinFunctor([1,2,3], [1,2,3], T, T2)
+
+# Same as F1, but there is an additional piece of data in codomain, ignored
+F5 = FinFunctor([1,2,3], [1,2,3], T, T2)
+
+
+@test all(is_functorial.([F1,F2,F3,F4]))
+@test is_initial(F1)
+@test !is_initial(F2)
+@test !is_initial(F3)
+@test !is_initial(F4)
+@test !is_initial(F5)
+
 end

--- a/test/graphs/GraphAlgorithms.jl
+++ b/test/graphs/GraphAlgorithms.jl
@@ -55,4 +55,14 @@ add_edges!(g, [1,1,1,1,2,3,3,4], [2,3,4,5,4,4,5,5])
 transitive_reduction!(g)
 @test sort!(collect(zip(src(g), tgt(g)))) == [(1,2),(1,3),(2,4),(3,4),(4,5)]
 
+# Enumerating paths
+g = Graph(3)
+add_edges!(g, [1,2,2], [2,3,3])
+
+ep = enumerate_paths(g)
+@test all([length(ep[i=>i]) == 1 for i in vertices(g)])
+@test length(ep[1=>2]) == 1
+@test length(ep[1=>3]) == 2
+@test length(ep[2=>1]) == 0
+
 end

--- a/test/graphs/GraphAlgorithms.jl
+++ b/test/graphs/GraphAlgorithms.jl
@@ -60,13 +60,13 @@ g = Graph(3)
 add_edges!(g, [1,2,2], [2,3,3])
 
 ep = enumerate_paths(g)
-@test ep[:eprops] == [
-    Set([Int[]]), # 1=>1
-    Set([Int[]]), # 2=>2
-    Set([Int[]]), # 3=>3
-    Set([[1, 2], [1, 3]]), # 1=>3
-    Set([[1]]), # 1=>2
-    Set([[2], [3]]), # 2=>3
-]
-
+@test sort(collect(zip(ep[:src],ep[:tgt], ep[:eprops]))) == [
+    (1, 1, [])
+    (1, 2, [1])
+    (1, 3, [1, 2])
+    (1, 3, [1, 3])
+    (2, 2, [])
+    (2, 3, [2])
+    (2, 3, [3])
+    (3, 3, [])]
 end

--- a/test/graphs/GraphAlgorithms.jl
+++ b/test/graphs/GraphAlgorithms.jl
@@ -60,9 +60,13 @@ g = Graph(3)
 add_edges!(g, [1,2,2], [2,3,3])
 
 ep = enumerate_paths(g)
-@test all([length(ep[i=>i]) == 1 for i in vertices(g)])
-@test length(ep[1=>2]) == 1
-@test length(ep[1=>3]) == 2
-@test length(ep[2=>1]) == 0
+@test ep[:eprops] == [
+    Set([Int[]]), # 1=>1
+    Set([Int[]]), # 2=>2
+    Set([Int[]]), # 3=>3
+    Set([[1, 2], [1, 3]]), # 1=>3
+    Set([[1]]), # 1=>2
+    Set([[2], [3]]), # 2=>3
+]
 
 end


### PR DESCRIPTION
A property a FinFunctor may or may not have is being an initial functor (dual of [final functor](https://ncatlab.org/nlab/show/final+functor)). This can be straightforwardly computed for functors between free categories finitely presented by DAGs. For a functor of this sort F: S->T, we check whether, for each object t in Ob(T), that the comma category F/t is nonempty and connected.

This requires the path enumeration of DAGs.