### PR TITLE
GAT expressions and anonymous morphisms in `@diagram` macro

### DIFF
--- a/src/core/Present.jl
+++ b/src/core/Present.jl
@@ -125,20 +125,20 @@ generator_index(pres::Presentation, x::Symbol) = pres.generator_name_index[x].se
 function make_term(pres::Presentation, e::Symbol)
   pres[e]
 end
-
 function make_term(pres::Presentation, e::Expr)
   @match e begin
     Expr(:call, term_constructor, args...) =>
-      invoke_term(pres.syntax, term_constructor, map(e -> make_term(pres, e), args)...)
+      invoke_term(pres.syntax, term_constructor,
+                  map(e -> make_term(pres, e), args)...)
   end
 end
-
 
 """ Create a new generator in a presentation of a given type
 """
 function make_generator(pres::Presentation, name::Symbol,
                         type::Symbol, type_args::Vector)
-  invoke_term(pres.syntax, type, name, map(e -> make_term(pres, e), type_args)...)
+  invoke_term(pres.syntax, type, name,
+              map(e -> make_term(pres, e), type_args)...)
 end
 
 """ Create and add a new generator

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -106,8 +106,8 @@ F = @migration TheoryGraph TheoryGraph begin
   E => @join begin
     v::V
     (e₁, e₂)::E
-    (e₁ → v)::tgt
-    (e₂ → v)::src
+    tgt(e₁) == v
+    src(e₂) == v
   end
   src => e₁ ⋅ src
   tgt => e₂ ⋅ tgt
@@ -132,10 +132,10 @@ F = @migration TheoryWeightedGraph TheoryWeightedGraph begin
   V => V
   E => @join begin
     v::V; (e₁, e₂)::E; w::Weight
-    (e₁ → v)::tgt
-    (e₂ → v)::src
-    (e₁ → w)::weight
-    (e₂ → w)::weight
+    tgt(e₁) == v
+    src(e₂) == v
+    weight(e₁) == w
+    weight(e₂) == w
   end
   Weight => Weight
   src => e₁ ⋅ src
@@ -244,8 +244,8 @@ h = @migrate Graph g begin
     path => @join begin
       v::V
       (e₁, e₂)::E
-      (e₁ → v)::tgt
-      (e₂ → v)::src
+      tgt(e₁) == v
+      src(e₂) == v
     end
   end
   src => (e => src; path => e₁⋅src)

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -106,8 +106,8 @@ F = @migration TheoryGraph TheoryGraph begin
   E => @join begin
     v::V
     (e₁, e₂)::E
-    (t: e₁ → v)::tgt
-    (s: e₂ → v)::src
+    (e₁ → v)::tgt
+    (e₂ → v)::src
   end
   src => e₁ ⋅ src
   tgt => e₂ ⋅ tgt
@@ -132,10 +132,10 @@ F = @migration TheoryWeightedGraph TheoryWeightedGraph begin
   V => V
   E => @join begin
     v::V; (e₁, e₂)::E; w::Weight
-    (t: e₁ → v)::tgt
-    (s: e₂ → v)::src
-    (w₁: e₁ → w)::weight
-    (w₂: e₂ → w)::weight
+    (e₁ → v)::tgt
+    (e₂ → v)::src
+    (e₁ → w)::weight
+    (e₂ → w)::weight
   end
   Weight => Weight
   src => e₁ ⋅ src
@@ -244,8 +244,8 @@ h = @migrate Graph g begin
     path => @join begin
       v::V
       (e₁, e₂)::E
-      (t: e₁ → v)::tgt
-      (s: e₂ → v)::src
+      (e₁ → v)::tgt
+      (e₂ → v)::src
     end
   end
   src => (e => src; path => e₁⋅src)

--- a/test/programs/DiagrammaticPrograms.jl
+++ b/test/programs/DiagrammaticPrograms.jl
@@ -139,6 +139,16 @@ F_parsed = @diagram TheoryGraph begin
 end
 @test F_parsed == F
 
+F_parsed = @diagram TheoryGraph begin
+  v::V
+  (e1, e2)::E
+  (e1 → v)::tgt
+  (e2 → v)::src
+end
+J_parsed = dom(F_parsed)
+@test src(graph(J_parsed)) == src(graph(J))
+@test tgt(graph(J_parsed)) == tgt(graph(J))
+
 F = @diagram TheoryDDS begin
   x::X
   (f: x → x)::(Φ⋅Φ)
@@ -184,8 +194,8 @@ F = @migration TheoryGraph TheoryGraph begin
   E => @join begin
     v::V
     (e₁, e₂)::E
-    (t: e₁ → v)::tgt
-    (s: e₂ → v)::src
+    (e₁ → v)::tgt
+    (e₂ → v)::src
   end
   src => e₁ ⋅ src
   tgt => e₂ ⋅ tgt
@@ -310,8 +320,8 @@ F = @migration TheoryGraph begin
   V => V
   Component => @glue begin
     e::E; v::V
-    (s: e → v)::src
-    (t: e → v)::tgt
+    (e → v)::src
+    (e → v)::tgt
   end
   (component: V → Component) => v
 end
@@ -331,8 +341,8 @@ F = @migration TheoryGraph TheoryGraph begin
     path => @join begin
       v::V
       (e₁, e₂)::E
-      (t: e₁ → v)::tgt
-      (s: e₂ → v)::src
+      (e₁ → v)::tgt
+      (e₂ → v)::src
     end
   end
   src => begin
@@ -359,13 +369,13 @@ F = @migration TheoryGraph TheoryBipartiteGraph begin
   E => @cases begin
     e₁ => @join begin
       v₂::V₂; e₁₂::E₁₂; e₂₁::E₂₁
-      (t: e₁₂ → v₂)::tgt₂
-      (s: e₂₁ → v₂)::src₂
+      (e₁₂ → v₂)::tgt₂
+      (e₂₁ → v₂)::src₂
     end
     e₂ => @join begin
       v₁::V₁; e₂₁::E₂₁; e₁₂::E₁₂
-      (t: e₂₁ → v₁)::tgt₁
-      (s: e₁₂ → v₁)::src₁
+      (e₂₁ → v₁)::tgt₁
+      (e₁₂ → v₁)::src₁
     end
   end
   src => begin

--- a/test/programs/DiagrammaticPrograms.jl
+++ b/test/programs/DiagrammaticPrograms.jl
@@ -3,7 +3,7 @@ using Test
 
 using Catlab, Catlab.Graphs, Catlab.CategoricalAlgebra
 using Catlab.Programs.DiagrammaticPrograms
-using Catlab.Programs.DiagrammaticPrograms: NamedGraph, MaybeNamedGraph
+using Catlab.Programs.DiagrammaticPrograms: NamedGraph
 using Catlab.Graphs.BasicGraphs: TheoryGraph, TheoryReflexiveGraph
 using Catlab.Graphs.BipartiteGraphs: TheoryBipartiteGraph
 using Catlab.WiringDiagrams.CPortGraphs: ThCPortGraph
@@ -22,23 +22,23 @@ g = @graph begin
   s → t
   s → t
 end
-@test g == parallel_arrows(MaybeNamedGraph{Symbol}, 2,
+@test g == parallel_arrows(NamedGraph{Symbol,Union{Symbol,Nothing}}, 2,
                            V=(vname=[:s,:t],), E=(ename=[nothing,nothing],))
 
-g = @graph NamedGraph{Symbol} begin
+g = @graph NamedGraph{Symbol,Symbol} begin
   x, y
   (f, g): x → y
 end
-@test g == parallel_arrows(NamedGraph{Symbol}, 2,
+@test g == parallel_arrows(NamedGraph{Symbol,Symbol}, 2,
                            V=(vname=[:x,:y],), E=(ename=[:f,:g],))
 
-tri_parsed = @graph NamedGraph{Symbol} begin
+tri_parsed = @graph NamedGraph{Symbol,Symbol} begin
   v0, v1, v2
   fst: v0 → v1
   snd: v1 → v2
   comp: v0 → v2
 end
-tri = @acset NamedGraph{Symbol} begin
+tri = @acset NamedGraph{Symbol,Symbol} begin
   V = 3
   E = 3
   src = [1,2,1]
@@ -59,7 +59,7 @@ end
   σ₀ ∘ δ₀ == id(V)
   σ₀ ∘ δ₁ == id(V)
 end
-Δ¹_graph = @acset NamedGraph{Symbol} begin
+Δ¹_graph = @acset NamedGraph{Symbol,Symbol} begin
   V = 2
   E = 3
   src = [1,1,2]
@@ -119,7 +119,7 @@ F_parsed = @diagram C begin
   (t: e1 → v)::tgt
   (s: e2 → v)::src
 end
-J = FinCat(@acset NamedGraph{Symbol} begin
+J = FinCat(@acset NamedGraph{Symbol,Union{Symbol,Nothing}} begin
   V = 3
   E = 2
   src = [2,3]
@@ -189,7 +189,7 @@ F = @migration TheoryGraph begin
   (src: E → V) => tgt
   (tgt: E → V) => src
 end
-J = FinCat(parallel_arrows(NamedGraph{Symbol}, 2,
+J = FinCat(parallel_arrows(NamedGraph{Symbol,Union{Symbol,Nothing}}, 2,
                            V=(vname=[:E,:V],), E=(ename=[:src,:tgt],)))
 @test F == FinDomFunctor([:E,:V], [:tgt,:src], J, FinCat(TheoryGraph))
 

--- a/test/programs/DiagrammaticPrograms.jl
+++ b/test/programs/DiagrammaticPrograms.jl
@@ -100,6 +100,15 @@ end)
   tgt => tgt
 end)
 
+# GAT expressions.
+F = @finfunctor TheoryDDS TheoryDDS begin
+  X => X; Φ => id(X)
+end
+F′ = @finfunctor TheoryDDS TheoryDDS begin
+  X => X; Φ => id{X}
+end
+@test F == F′
+
 # Diagrams
 ##########
 

--- a/test/programs/DiagrammaticPrograms.jl
+++ b/test/programs/DiagrammaticPrograms.jl
@@ -149,6 +149,14 @@ J_parsed = dom(F_parsed)
 @test src(graph(J_parsed)) == src(graph(J))
 @test tgt(graph(J_parsed)) == tgt(graph(J))
 
+F_parsed′ = @free_diagram TheoryGraph begin
+  v::V
+  (e1, e2)::E
+  tgt(e1) == v
+  v == src(e2)
+end
+@test F_parsed′ == F_parsed
+
 F = @diagram TheoryDDS begin
   x::X
   (f: x → x)::(Φ⋅Φ)
@@ -341,8 +349,8 @@ F = @migration TheoryGraph TheoryGraph begin
     path => @join begin
       v::V
       (e₁, e₂)::E
-      (e₁ → v)::tgt
-      (e₂ → v)::src
+      tgt(e₁) == v
+      src(e₂) == v
     end
   end
   src => begin


### PR DESCRIPTION
Assorted, somewhat related features needed for our physics project:

- Support GAT expressions in `@finfunctor` and `@diagram` macros
- Allow unnamed/anonymous morphisms in indexing category
- New `@free_diagram` macro with alternative interpretation of equation syntax