### PR TITLE
DOC: add ACSetInterface to docs

### DIFF
--- a/docs/src/apis/categorical_algebra.md
+++ b/docs/src/apis/categorical_algebra.md
@@ -107,6 +107,7 @@ We first give an overview of the data types used in the acset machinery.
 Modules = [
   CategoricalAlgebra.CSets,
   CategoricalAlgebra.StructuredCospans,
+  CategoricalAlgebra.ACSetInterface,
 ]
 Private = false
 ```


### PR DESCRIPTION
This PR adds the ACSetInterface file to the docs markdown so that the doscstrings in ACSetInterface.jl will build in the documentation.