### PR TITLE
Add debugging info to is_functorial

### DIFF
--- a/src/programs/DiagrammaticPrograms.jl
+++ b/src/programs/DiagrammaticPrograms.jl
@@ -210,11 +210,11 @@ macro finfunctor(dom_cat, codom_cat, body)
   :(parse_functor($(esc(dom_cat)), $(esc(codom_cat)), $(Meta.quot(body))))
 end
 
-function parse_functor(C::FinCat, D::FinCat, body::Expr)
+function parse_functor(C::FinCat, D::FinCat, body::Expr; debug::Bool=false)
   ob_rhs, hom_rhs = parse_ob_hom_maps(C, body)
   F = FinFunctor(mapvals(x -> parse_ob(D, x), ob_rhs),
                  mapvals(f -> parse_hom(D, f), hom_rhs), C, D)
-  is_functorial(F, check_equations=false) ||
+  is_functorial(F, check_equations=false, debug=debug) ||
     error("Parsed functor is not functorial: $body")
   return F
 end

--- a/test/categorical_algebra/FinCats.jl
+++ b/test/categorical_algebra/FinCats.jl
@@ -127,6 +127,7 @@ C = dom(F)
 # Reflexive graph as set-valued functor on a category with equations.
 G_refl = FinDomFunctor(path_graph(ReflexiveGraph, 3))
 @test is_functorial(G_refl)
+@test is_functorial(G_refl, debug=true)
 G = compose(FinFunctor(Dict(:V=>:V, :E=>:E), Dict(:src=>:src, :tgt=>:tgt),
                        TheoryGraph, TheoryReflexiveGraph),
             G_refl, strict=false)
@@ -172,6 +173,7 @@ C = FinCat(TheoryWeightedGraph)
 g = path_graph(WeightedGraph{Float64}, 3, E=(weight=[0.5,1.5],))
 G = FinDomFunctor(g)
 @test is_functorial(G)
+@test is_functorial(G, debug=true)
 @test ob_map(G, :Weight) == TypeSet(Float64)
 @test hom_map(G, :weight) == FinDomFunction([0.5, 1.5])
 


### PR DESCRIPTION
This pull request would close #598

It should be noted that the docstring for `is_functorial` states that the default value for `check_equations` is `true`, but the default value is actually `false`. As I am not sure which behavior is intended, I have left this discrepancy as is.