### PR TITLE
Type inference can fail in `FinSetIndexedLimit`

### DIFF
--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -518,7 +518,7 @@ function universal(lim::FinSetIndexedLimit, cone::Multispan)
     lim.index = make_limit_index(lim.cone)
   end
   fs = Tuple(legs(cone))
-  FinFunction([lim.index[map(f -> f(x), fs)] for x in apex(cone)],
+  FinFunction(Int[lim.index[map(f -> f(x), fs)] for x in apex(cone)],
               apex(cone), ob(lim))
 end
 


### PR DESCRIPTION
Happens in the degenerate case where the vector is empty.