### PR TITLE
surjective homomorphism constraint

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -27,7 +27,8 @@ import ..Limits: limit, colimit, universal, pushout_complement,
 import ..Subobjects: Subobject, SubobjectBiHeytingAlgebra,
   implies, ⟹, subtract, \, negate, ¬, non, ~
 import ..Sets: SetOb, SetFunction, TypeSet
-import ..FinSets: FinSet, FinFunction, FinDomFunction, force, predicate
+import ..FinSets: FinSet, FinFunction, FinDomFunction, force, predicate,
+                  is_injective, is_surjective
 import ..FinCats: FinDomFunctor, components, is_natural
 
 # Sets interop
@@ -381,6 +382,21 @@ function is_natural(α::ACSetTransformation{S}) where {S}
   end
   return true
 end
+
+function is_injective(α::ACSetTransformation{S}) where {S}
+  for c in α.components
+    if !is_injective(c) return false end
+  end
+  return true
+end
+
+function is_surjective(α::ACSetTransformation{S}) where {S}
+  for c in α.components
+    if !is_surjective(c) return false end
+  end
+  return true
+end
+
 
 # Category of C-sets
 ####################

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -4,7 +4,7 @@ module FinSets
 export FinSet, FinFunction, FinDomFunction, TabularSet, TabularLimit,
   force, is_indexed, preimage,
   JoinAlgorithm, SmartJoin, NestedLoopJoin, SortMergeJoin, HashJoin,
-  SubFinSet, SubOpBoolean
+  SubFinSet, SubOpBoolean, is_surjective, is_injective
 
 using AutoHashEquals
 using DataStructures: OrderedDict, IntDisjointSets, union!, find_root!
@@ -191,6 +191,11 @@ FinFunction(f::AbstractVector{Int}; kw...) =
 
 Sets.show_type_constructor(io::IO, ::Type{<:FinFunction}) =
   print(io, "FinFunction")
+
+# These could be made to fail early if ever used in performance-critical areas
+image(f::FinFunction) = Set([f(x) for x in dom(f)]) # need when domain isn't Int
+is_surjective(f::FinFunction) = length(codom(f)) == length(image(f))
+is_injective(f::FinFunction)  = length(dom(f)) == length(image(f))
 
 """ Function out of a finite set.
 

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -347,6 +347,24 @@ add_edge!(g2, 1, 2)  # double arrow
 @test length(homomorphisms(g2, g1, monic=[:E])) == 2 # two for 2->3
 @test length(homomorphisms(g2, g1, iso=[:E])) == 0
 
+# Epic constraint
+g0, g1, g2 = Graph(2), Graph(2), Graph(2)
+add_edges!(g0, [1,1],[1,2]) # ↻•→•
+add_edges!(g1, [1,1],[2,2]) # •⇉•
+add_edges!(g2, [1,1,1],[1,1,2]) # ↻↻•→•
+@test length(homomorphisms(g1, g2, epic=[:V])) == 1
+@test length(homomorphisms(g1, g2, epic=[:E])) == 0
+@test length(homomorphisms(g2, g0, epic=[:E])) == 1
+@test length(homomorphisms(g2, g0, epic=[:V])) == 1
+
+g3, g4 = path_graph(Graph,3), path_graph(Graph,4)
+add_edges!(g3,[1,3],[1,3])  # g3: ↻•→•→• ↺
+@test length(homomorphisms(g4,g3)) == 6 # 2 for each: 1/2/3 edges sent to loop
+@test length(homomorphisms(g4,g3; epic=[:V])) == 2 # send only one edge to loop
+@test length(homomorphisms(g4,g3; epic=[:E])) == 0 # only have 3 edges to map
+
+@test length(homomorphisms(Graph(4),Graph(2); epic=true)) == 14 # 2^4 - 2
+
 # Symmetric graphs
 #-----------------
 

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -65,6 +65,13 @@ g, h = path_graph(Graph, 4), cycle_graph(Graph, 2)
 β = CSetTransformation((V=[2,1], E=[2,1]), h, h)
 @test is_natural(β)
 
+# Injectivity/surjectivity
+@test is_surjective(α)
+@test !is_injective(α)
+@test is_injective(homomorphism(Graph(), Graph(1)))
+@test is_injective(id(g))
+@test is_surjective(id(g))
+
 # Category of C-sets.
 @test dom(α) === g
 @test codom(α) === h

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -64,6 +64,16 @@ k = FinFunction(Dict(:a => :x, :b => :y, :c => :z), X)
 @test codom(FinFunction(Dict(:a => :x, :b => :y, :c => :z))) ==
   FinSet(Set([:x,:y,:z]))
 
+# FinSet
+@test is_injective(f)
+@test !is_injective(g)
+@test is_surjective(g)
+@test is_surjective(h)
+@test is_injective(k)
+@test !is_surjective(k)
+@test !is_injective(ℓ)
+
+
 # Evaluation.
 rot3(x) = (x % 3) + 1
 @test map(f, 1:3) == [1,3,4]


### PR DESCRIPTION
Just as we have a monic constraint option, the epic constraint keyword can be used to componentwise prune partial homomorphisms  in the search process that have no chance of becoming an epic homomorphism. 

By keeping track of how many elements have yet to be assigned in the domain and a vector for each element in the codomain (how many elements map to each element), we can check this.  When assigning a new element, we decrement the domain unassigned counter and we increment the counter on the element in the codomain (vice-versa when unassigning an element).