### PR TITLE
Subobject image/preimage, completion of a partial subobject

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -1115,19 +1115,17 @@ function common_ob(A::Subobject, B::Subobject)
   return X
 end
 
-"""
-A map f (from A to B) as a map of subobjects of A to subjects of B
-"""
+
+# A map f (from A to B) as a map of subobjects of A to subjects of B
 (f::ACSetTransformation)(X::SubACSet)::SubACSet = begin
   codom(hom(X)) == dom(f) || error("Cannot apply $f to $X")
   Subobject(codom(f); Dict(
     [k=>f.(collect(components(X)[k])) for (k,f) in pairs(components(f))])...)
 end
 
-"""
-A map f (from A to B) as a map from A to a subobject of B
-i.e. we cast the ACSet A to its top subobject
-"""
+
+# A map f (from A to B) as a map from A to a subobject of B
+# i.e. we cast the ACSet A to its top subobject
 (f::ACSetTransformation)(X::StructACSet)::SubACSet =
   X == dom(f) ? f(top(X)) : error("Cannot apply $f to $X")
 

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -1116,7 +1116,7 @@ function common_ob(A::Subobject, B::Subobject)
 end
 
 """
-f:A->B as a map of subobjects of A to subjects of B
+A map f (from A to B) as a map of subobjects of A to subjects of B
 """
 (f::ACSetTransformation)(X::SubACSet)::SubACSet = begin
   codom(hom(X)) == dom(f) || error("Cannot apply $f to $X")
@@ -1125,14 +1125,14 @@ f:A->B as a map of subobjects of A to subjects of B
 end
 
 """
-f:A->B as a map from A to a subobject of B
+A map f (from A to B) as a map from A to a subobject of B
 i.e. we cast the ACSet A to its top subobject
 """
 (f::ACSetTransformation)(X::StructACSet)::SubACSet =
   X == dom(f) ? f(top(X)) : error("Cannot apply $f to $X")
 
 """    hom_inv(f::ACSetTransformation,Y::Subobject)::SubACSet
-Inverse of f:A->B as a map of subobjects of B to subjects of A.
+Inverse of f (from A to B) as a map of subobjects of B to subjects of A.
 It can be thought of as incident, but for homomorphisms.
 """
 hom_inv(f::ACSetTransformation,Y::Subobject)::SubACSet = begin
@@ -1144,12 +1144,12 @@ hom_inv(f::ACSetTransformation,Y::Subobject)::SubACSet = begin
 end
 
 """    hom_inv(f::CSetTransformation,Y::StructACSet)::SubACSet
-Inverse f:A->B as a map from subobjects of B to subobjects of A.
+Inverse f (from A to B) as a map from subobjects of B to subobjects of A.
 Cast an ACSet to subobject, though this has a trivial answer when computing
 the preimage (it is necessarily the top subobject of A).
 """
 hom_inv(f::CSetTransformation,Y::StructACSet)::SubACSet =
-  Y = codom(f) ? top(dom(f)) : error("Cannot apply inverse of $f to $Y")
+  Y == codom(f) ? top(dom(f)) : error("Cannot apply inverse of $f to $Y")
 
 
 """    induce_subobject(X::StructACSet{S}; vs...)

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -1129,19 +1129,19 @@ i.e. we cast the ACSet to a subobject
 (f::ACSetTransformation)(X::StructACSet)::SubACSet =
   X == dom(f) ? f(top(X)) : error("Cannot apply $f to $X")
 
-"""
+"""    hom_inv(f::ACSetTransformation,Y::Subobject)::SubACSet
 Inverse of f:A->B as a map of subobjects of B to subjects of A.
 It can be thought of as `incident`, but for homomorphisms.
 """
 hom_inv(f::ACSetTransformation,Y::Subobject)::SubACSet = begin
-  codom(hom(X)) == codom(f) || error("Cannot apply $f to $X")
+  codom(hom(Y)) == codom(f) || error("Cannot apply $f to $X")
 
   Subobject(dom(f); Dict{Symbol, Vector{Int}}(
     [k => vcat([preimage(f,y) for y in collect(components(Y)[k])]...)
      for (k,f) in pairs(components(f))])...)
 end
 
-"""
+"""    hom_inv(f::CSetTransformation,Y::StructACSet)::SubACSet
 Inverse f:A->B as a map from subobjects of B to subobjects of A.
 Cast an ACSet to subobject, though this has a trivial answer when computing
 the preimage (it is necessarily the top subobject of A).
@@ -1150,7 +1150,8 @@ hom_inv(f::CSetTransformation,Y::StructACSet)::SubACSet =
   Y = codom(f) ? top(dom(f)) : error("Cannot apply inverse of $f to $Y")
 
 
-"""
+"""    induce_subobject(X::StructACSet{S}; vs...)
+
 Takes a partially-specified ACSet subobject and completes it so that there are
 no undefined references.
 

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -1115,7 +1115,9 @@ function common_ob(A::Subobject, B::Subobject)
   return X
 end
 
-"""f:A->B as a map of subobjects of A to subjects of B"""
+"""
+f:A->B as a map of subobjects of A to subjects of B
+"""
 (f::ACSetTransformation)(X::SubACSet)::SubACSet = begin
   codom(hom(X)) == dom(f) || error("Cannot apply $f to $X")
   Subobject(codom(f); Dict(
@@ -1124,14 +1126,14 @@ end
 
 """
 f:A->B as a map from A to a subobject of B
-i.e. we cast the ACSet to a subobject
+i.e. we cast the ACSet A to its top subobject
 """
 (f::ACSetTransformation)(X::StructACSet)::SubACSet =
   X == dom(f) ? f(top(X)) : error("Cannot apply $f to $X")
 
 """    hom_inv(f::ACSetTransformation,Y::Subobject)::SubACSet
 Inverse of f:A->B as a map of subobjects of B to subjects of A.
-It can be thought of as `incident`, but for homomorphisms.
+It can be thought of as incident, but for homomorphisms.
 """
 hom_inv(f::ACSetTransformation,Y::Subobject)::SubACSet = begin
   codom(hom(Y)) == codom(f) || error("Cannot apply $f to $X")
@@ -1155,8 +1157,8 @@ hom_inv(f::CSetTransformation,Y::StructACSet)::SubACSet =
 Takes a partially-specified ACSet subobject and completes it so that there are
 no undefined references.
 
-For example: `induce_subobject(my_wiring_diagram; Wire=[2])`
-will yield a subobject of `my_wiring_diagram` with Wire#2, as well as the
+For example: induce_subobject(my_wiring_diagram; Wire=[2])
+will yield a subobject of my_wiring_diagram with Wire#2, as well as the
 ports it's connected to and the boxes those ports are connected to.
 """
 function induce_subobject(X::StructACSet{S}; vs...) where {S}

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -1116,24 +1116,26 @@ function common_ob(A::Subobject, B::Subobject)
 end
 
 
-# A map f (from A to B) as a map of subobjects of A to subjects of B
-(f::ACSetTransformation)(X::SubACSet)::SubACSet = begin
+"""A map f (from A to B) as a map of subobjects of A to subjects of B"""
+(f::ACSetTransformation)(X::SubACSet) = begin
   codom(hom(X)) == dom(f) || error("Cannot apply $f to $X")
   Subobject(codom(f); Dict(
     [k=>f.(collect(components(X)[k])) for (k,f) in pairs(components(f))])...)
 end
 
 
-# A map f (from A to B) as a map from A to a subobject of B
+"""
+A map f (from A to B) as a map from A to a subobject of B
 # i.e. we cast the ACSet A to its top subobject
-(f::ACSetTransformation)(X::StructACSet)::SubACSet =
+"""
+(f::ACSetTransformation)(X::StructACSet) =
   X == dom(f) ? f(top(X)) : error("Cannot apply $f to $X")
 
-"""    hom_inv(f::ACSetTransformation,Y::Subobject)::SubACSet
+"""    hom_inv(f::ACSetTransformation,Y::Subobject)
 Inverse of f (from A to B) as a map of subobjects of B to subjects of A.
 It can be thought of as incident, but for homomorphisms.
 """
-hom_inv(f::ACSetTransformation,Y::Subobject)::SubACSet = begin
+hom_inv(f::ACSetTransformation,Y::Subobject) = begin
   codom(hom(Y)) == codom(f) || error("Cannot apply $f to $X")
 
   Subobject(dom(f); Dict{Symbol, Vector{Int}}(
@@ -1141,12 +1143,12 @@ hom_inv(f::ACSetTransformation,Y::Subobject)::SubACSet = begin
      for (k,f) in pairs(components(f))])...)
 end
 
-"""    hom_inv(f::CSetTransformation,Y::StructACSet)::SubACSet
+"""    hom_inv(f::CSetTransformation,Y::StructACSet)
 Inverse f (from A to B) as a map from subobjects of B to subobjects of A.
 Cast an ACSet to subobject, though this has a trivial answer when computing
 the preimage (it is necessarily the top subobject of A).
 """
-hom_inv(f::CSetTransformation,Y::StructACSet)::SubACSet =
+hom_inv(f::CSetTransformation,Y::StructACSet) =
   Y == codom(f) ? top(dom(f)) : error("Cannot apply inverse of $f to $Y")
 
 

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -476,6 +476,26 @@ A = Subobject(S, X=[3,4,5])
 @test ¬Subobject(ι₂) |> force == Subobject(ι₁)
 @test ~A |> force == ⊤(S) |> force
 
+# Image and preimage
+g1 = path_graph(Graph, 2)
+g2 = apex(coproduct(g1, g1))
+g3 = @acset Graph begin V=2; E=3; src=[1,1,2]; tgt=[1,2,2] end
+h = homomorphisms(g1,g2)[2] # V=[3,4], E=[2]
+ϕ = homomorphism(g2,g3; initial=(V=[1,1,2,2],))
+@test components(hom(h(g1))) == (
+  V = FinFunction([3, 4], 2, 4), E = FinFunction([2], 1, 2))
+@test hom_inv(h, Subobject(g2, V=[1])) |> force == bottom(g1) |> force
+@test hom_inv(h, Subobject(g2, V=[3])) |> force == Subobject(g1, V=[1]) |> force
+@test ϕ(h(g1)) == Subobject(g3, V=[2,2], E=[3])
+
+# Induce subobject
+e1 = Subobject(g2, V=[1,2], E=[1])
+@test induce_subobject(g2, E=[1]) |> force == e1 |> force
+@test induce_subobject(g2, V=[1]) |> force == Subobject(g2, V=[1]) |> force
+@test induce_subobject(g2, E=[2]) |> force == h(g1) |> force
+
+
+
 # Serialization
 ###############
 

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -484,6 +484,7 @@ h = homomorphisms(g1,g2)[2] # V=[3,4], E=[2]
 ϕ = homomorphism(g2,g3; initial=(V=[1,1,2,2],))
 @test components(hom(h(g1))) == (
   V = FinFunction([3, 4], 2, 4), E = FinFunction([2], 1, 2))
+@test hom_inv(h, g2) |> force == (top(g1) |> force)
 @test hom_inv(h, Subobject(g2, V=[1])) |> force == bottom(g1) |> force
 @test hom_inv(h, Subobject(g2, V=[3])) |> force == Subobject(g1, V=[1]) |> force
 @test ϕ(h(g1)) == Subobject(g3, V=[2,2], E=[3])

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -488,6 +488,16 @@ h = homomorphisms(g1,g2)[2] # V=[3,4], E=[2]
 @test hom_inv(h, Subobject(g2, V=[3])) |> force == Subobject(g1, V=[1]) |> force
 @test ϕ(h(g1)) == Subobject(g3, V=[2,2], E=[3])
 
+# Preimage
+G = path_graph(Graph, 1) ⊕ path_graph(Graph, 2) ⊕ path_graph(Graph, 3)
+H = let Loop=apex(terminal(Graph)); Loop ⊕ Loop ⊕ Loop end
+# Each path graph gets its own loop
+f = homomorphism(G, H; initial=(V=Dict([1=>1,2=>2,4=>3]),))
+for i in 1:3
+  @test is_isomorphic(dom(hom(hom_inv(f, Subobject(H, V=[i],E=[i])))),
+                      path_graph(Graph, i))
+end
+
 # Induce subobject
 e1 = Subobject(g2, V=[1,2], E=[1])
 @test induce_subobject(g2, E=[1]) |> force == e1 |> force


### PR DESCRIPTION
These functionalities for subobjects are code I find myself rewriting repeatedly, so they may be of use to others too (if they're not already in Catlab).

Because I often want to 'apply' a homomorphism to some concrete data, this becomes a map of subobjects from the domain to the codomain. We likewise can use preimages to get maps in the other direction (I'd like a better syntax for inverses, but for now it's a named function `hom_inv`).

Also, I often want, e.g., the wiring diagram induced by wires 3, 4, and 7 - so `induce_subobject` will do the iterative search so that the subobject doesn't have 0's everywhere.