### PR TITLE
Upgrade Convex.jl to v0.15

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -14,5 +14,7 @@ TikzCDs = "1e332c56-9431-4126-8a34-92cbdf251ae4"
 TikzPictures = "37f6aa50-8035-52d0-81c2-5a1d08754b2d"
 
 [compat]
+Convex = "^0.15"
 Documenter = "^0.25.3"
+SCS = "^1"
 TikzCDs = "^0.2.1"

--- a/src/graphics/ConvexExternal.jl
+++ b/src/graphics/ConvexExternal.jl
@@ -5,7 +5,7 @@ import .WiringDiagramLayouts: has_port_layout_method, solve_isotonic
 
 has_port_layout_method(::Type{Val{:isotonic}}) = true
 
-function solve_isotonic(y::Vector; solver=()->SCS.Optimizer(verbose=false),
+function solve_isotonic(y::Vector; solver=SCS.Optimizer,
                         loss=sumsquares, lower::Number=-Inf, upper::Number=Inf,
                         pad::Number=0)
   if isempty(y)
@@ -19,6 +19,7 @@ function solve_isotonic(y::Vector; solver=()->SCS.Optimizer(verbose=false),
   if upper != Inf
     push!(constraints, x[end] <= upper)
   end
-  solve!(minimize(loss(x-y), constraints), solver)
+  solve!(minimize(loss(x-y), constraints), solver;
+         verbose=false, silent_solver=true)
   length(x) == 1 ? [ x.value ] : dropdims(x.value, dims=2) # XXX: MATLAB-ism.
 end


### PR DESCRIPTION
The docs build has been failing lately because Convex.jl has been downgrading to v0.12, which is too old, yet when I upgrade to v0.14 (by downgrading other packages), I get a segfault. Luckily, v0.15 was just released this evening, which seems to resolve the issues.