### PR TITLE
add hash method for diagram/diagram hom

### DIFF
--- a/src/categorical_algebra/Diagrams.jl
+++ b/src/categorical_algebra/Diagrams.jl
@@ -51,7 +51,7 @@ This is the domain of the underlying functor.
 """
 shape(d::Diagram) = dom(diagram(d))
 
-Base.hash(d::Diagram{T}, h::UInt) where {T} = hash(hash(T), hash(diagram(d), h))
+Base.hash(d::Diagram{T}, h::UInt) where {T} = hash(T, hash(diagram(d), h))
 
 Base.:(==)(d1::Diagram{T}, d2::Diagram{S}) where {T,S} =
   T == S && diagram(d1) == diagram(d2)

--- a/src/categorical_algebra/Diagrams.jl
+++ b/src/categorical_algebra/Diagrams.jl
@@ -51,6 +51,8 @@ This is the domain of the underlying functor.
 """
 shape(d::Diagram) = dom(diagram(d))
 
+Base.hash(d::Diagram{T}, h::UInt) where {T} = hash(hash(T), hash(diagram(d), h))
+
 Base.:(==)(d1::Diagram{T}, d2::Diagram{S}) where {T,S} =
   T == S && diagram(d1) == diagram(d2)
 
@@ -136,6 +138,9 @@ cell2(D::FinDomFunctor, x) = id(codom(D), ob_map(D, x))
 
 shape_map(f::DiagramHom) = f.shape_map
 diagram_map(f::DiagramHom) = f.diagram_map
+
+Base.hash(f::DiagramHom{T}, h::UInt) where {T} = hash(T, hash(f.shape_map,
+  hash(f.diagram_map, hash(f.precomposed_diagram, h))))
 
 Base.:(==)(f::DiagramHom{T}, g::DiagramHom{S}) where {T,S} =
   T == S && shape_map(f) == shape_map(g) && diagram_map(f) == diagram_map(g) &&

--- a/test/categorical_algebra/Diagrams.jl
+++ b/test/categorical_algebra/Diagrams.jl
@@ -22,6 +22,8 @@ d = Diagram(D)
 @test ob_map(d, 3) == SchSGraph[:V]
 @test hom_map(d, 1) == SchSGraph[:tgt]
 @test startswith(sprint(show, d), "Diagram{id}(")
+@test hash(D) == hash(D)
+@test hash(D) != hash(Diagram{op}(D))
 
 # Diagram morphisms
 ###################
@@ -29,6 +31,7 @@ d = Diagram(D)
 f = DiagramHom([(2,:inv), (1,:inv), 3], [2,1], d, d)
 @test dom(f) == d
 @test codom(f) == d
+@test hash(f) == hash(DiagramHom([(2,:inv), (1,:inv), 3], [2,1], d, d))
 @test is_functorial(shape_map(f))
 @test shape_map(f) == FinFunctor([2,1,3], [2,1], C, C)
 ϕ = diagram_map(f)
@@ -41,6 +44,7 @@ f = DiagramHom([(2,:inv), (1,:inv), 3], [2,1], d, d)
 @test collect_hom(f) == [Path(graph(C), 2), Path(graph(C), 1)]
 f² = f⋅f
 @test shape_map(f²) == FinFunctor(1:3, 1:2, C, C)
+@test hash(f) != hash(f²)
 
 f = DiagramHom{op}([(2,:inv), (1,:inv), 3], [2,1], D, D)
 ιV = FinDomFunctor([:V], FinCat(1), FinCat(SchSGraph))


### PR DESCRIPTION
Diagrams/diagram homs do not use auto hash equals, so this must be defined manually.