### PR TITLE
Replace half-baked function `roottype` with `Base.typename`

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -18,7 +18,7 @@ using Tables
 @reexport using ...CSetDataStructures
 using ...GAT, ...Present
 using ...Theories: Category, SchemaDescType, CSetSchemaDescType,
-  attrtype, attrtype_num, attr, adom, acodom, acodom_nums, roottype
+  attrtype, attrtype_num, attr, adom, acodom, acodom_nums
 import ...Theories: dom, codom, compose, ⋅, id,
   ob, hom, meet, ∧, join, ∨, top, ⊤, bottom, ⊥
 using ..FreeDiagrams, ..Limits, ..Subobjects, ..FinSets, ..FinCats
@@ -781,8 +781,10 @@ function limit(::Type{Tuple{ACS,Hom}}, diagram) where
     {S, ACS <: StructACSet{S}, Hom <: LooseACSetTransformation}
   limits = map(limit, unpack_diagram(diagram, all=true))
   Xs = cone_objects(diagram)
-  Y = isempty(attrtype(S)) ? ACS() :
-    roottype(ACS){(eltype(ob(limits[d])) for d in attrtype(S))...}()
+  Y = if isempty(attrtype(S)); ACS() else
+    ACSUnionAll = Base.typename(ACS).wrapper
+    ACSUnionAll{(eltype(ob(limits[d])) for d in attrtype(S))...}()
+  end
 
   result = limit!(Y, diagram, Xs, limits)
   for (f, c, d) in zip(attr(S), adom(S), acodom(S))

--- a/src/theories/Monoidal.jl
+++ b/src/theories/Monoidal.jl
@@ -60,11 +60,7 @@ otimes(x, y, z, xs...) = otimes([x, y, z, xs...])
 """
 collect(expr::ObExpr) = [ expr ]
 collect(expr::ObExpr{:otimes}) = vcat(map(collect, args(expr))...)
-collect(expr::ObExpr{:munit}) = roottypeof(expr)[]
-
-# XXX: We shouldn't have to do this.
-roottype(T) = T isa UnionAll ? T : T.name.wrapper
-roottypeof(x) = roottype(typeof(x))
+collect(expr::E) where E <: ObExpr{:munit} = Base.typename(E).wrapper[]
 
 """ Number of "dimensions" of object in monoidal category.
 """

--- a/src/theories/MonoidalAdditive.jl
+++ b/src/theories/MonoidalAdditive.jl
@@ -30,7 +30,7 @@ oplus(x, y, z, xs...) = oplus([x, y, z, xs...])
 
 # Overload `collect` and `ndims` as for multiplicative monoidal categories.
 collect(expr::ObExpr{:oplus}) = vcat(map(collect, args(expr))...)
-collect(expr::ObExpr{:mzero}) = roottypeof(expr)[]
+collect(expr::E) where E <: ObExpr{:mzero} = Base.typename(E).wrapper[]
 ndims(expr::ObExpr{:oplus}) = sum(map(ndims, args(expr)))
 ndims(expr::ObExpr{:mzero}) = 0
 


### PR DESCRIPTION
It's still feels a bit hacky to have to do this at all, but this PR is definitely an improvement over what we had before. The function `Base.typename` is available in recent versions of Julia.