### PR TITLE
Structured cospans of acsets with multiple objects in interface

### DIFF
--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -602,7 +602,7 @@ ACSetInterface.copy_parts!(to::StructACSet, from::StructACSet, parts::NamedTuple
   end
 end
 
-""" Copy parts from a C-set to a C′-set, ignoring all non-data subparts.
+""" Copy parts from a C-set to a C′-set, ignoring all non-attribute subparts.
 
 The selected parts must belong to both schemas. Attributes common to both
 schemas are also copied, but no other subparts are copied.

--- a/src/categorical_algebra/StructuredCospans.jl
+++ b/src/categorical_algebra/StructuredCospans.jl
@@ -221,24 +221,19 @@ end
 #SF **********************
 """ Create types for open attributed C-sets from an attributed C-set type.
 
-Note: the difference between this function and the "OpenACSetTypes" is in the 
-small part (category A), it includes more than 1 objects; while in function "OpenACSetTypes"
-the category A  only includes one object
+Note: the difference between this function and the "OpenACSetTypes(::Type{X}, ob₀::Symbol)" 
+is in the substructure part (category A), it includes more than 1 objects; while in function
+"OpenACSetTypes(::Type{X}, ob₀::Symbol)" the category A  only includes one object
 """
-
 function OpenACSetTypes(::Type{X}, ::Type{A}) where
   {S<:SchemaDescType, X<:StructACSet{S}, S0<:SchemaDescType, A<:StructACSet{S0}}
-#    {S<:SchemaDescType, X<:StructACSet{S}, S0<:SchemaDescType, A<:StructACSet{S0}}
-  # TODO: assert: A include X
-  println(attrtype(S0))
-  println(attrtype(S))
   @assert attrtype(S0) ⊆ attrtype(S)
   type_vars = map(TypeVar, attrtype(S))
   type_vars0 = map(TypeVar, attrtype(S0))
-  L = SubStructACSet{A{type_vars0...}, X{type_vars...}}
-  (foldr(UnionAll, type_vars, init=StructuredCospanOb{L}),
-   foldr(UnionAll, type_vars, init=StructuredMulticospan{L}))
+  L = SubStructACSet{A, X}
+  (StructuredCospanOb{L}, StructuredMulticospan{L})
 end
+# **********************
 
 
 """ Abstract type for functor L: A → X giving a discrete C-set.
@@ -250,7 +245,7 @@ codom(::Type{<:AbstractDiscreteACSet{X}}) where
 
 
 #SF **********************
-""" A functor L: C₀-Set → C-Set giving the discrete C-set for C₀.
+""" A functor L: C₀-Set → C-Set giving the sub-structure C-set for C₀.
 
 Here C₀ is assumed to contain a substructure of C (more than one objects). 
 The functor L has a right adjoint R: C-Set → C₀-Set

--- a/src/categorical_algebra/StructuredCospans.jl
+++ b/src/categorical_algebra/StructuredCospans.jl
@@ -218,12 +218,38 @@ function OpenACSetTypes(::Type{X}, ob₀::Symbol) where
    foldr(UnionAll, type_vars, init=StructuredMulticospan{L}))
 end
 
+#SF
+""" Create types for open attributed C-sets from an attributed C-set type.
+
+Note: the difference between this function and the "OpenACSetTypes" is in the 
+small part (category A), it includes more than 1 objects; while in function "OpenACSetTypes"
+the category A  only includes one object
+"""
+function OpenACSetTypes(::Type{X}, ::Type{A}) where
+  {S<:SchemaDescType, X<:StructACSet{S}, S0<:SchemaDescType, A<:StructACSet{S0}}
+#    {S<:SchemaDescType, X<:StructACSet{S}, S0<:SchemaDescType, A<:StructACSet{S0}}
+  # TODO: assert: A \include X
+  println(attrtype(S0))
+  println(attrtype(S))
+  @assert attrtype(S0) ⊆ attrtype(S)
+  type_vars = map(TypeVar, attrtype(S))
+  type_vars0 = map(TypeVar, attrtype(S0))
+  L = DiscreteACSet{A{type_vars0...}, X{type_vars...}}
+  (foldr(UnionAll, type_vars, init=StructuredCospanOb{L}),
+   foldr(UnionAll, type_vars, init=StructuredMulticospan{L}))
+end
+
 """ Abstract type for functor L: A → X giving a discrete C-set.
 """
 abstract type AbstractDiscreteACSet{X <: StructACSet} end
 
 codom(::Type{<:AbstractDiscreteACSet{X}}) where
   {S, X<:StructACSet{S}} = (X, TightACSetTransformation{S})
+
+#SF
+StructuredCospan{L}(x::StructACSet, f::ACSetTransformation,
+                    g::ACSetTransformation) where {L<:AbstractDiscreteACSet} =
+  StructuredCospan{L}(x, Cospan(f, g))
 
 StructuredCospan{L}(x::StructACSet, f::FinFunction{Int,Int},
                     g::FinFunction{Int,Int}) where {L<:AbstractDiscreteACSet} =
@@ -232,6 +258,12 @@ StructuredCospan{L}(x::StructACSet, f::FinFunction{Int,Int},
 StructuredMulticospan{L}(x::StructACSet,
                          fs::Vararg{<:FinFunction{Int,Int},N}) where
     {L<:AbstractDiscreteACSet, N} =
+  StructuredMulticospan{L}(x, SMulticospan{N}(fs...))
+
+#SF
+StructuredMulticospan{L}(x::StructACSet,
+                         fs::Vararg{<:ACSetTransformation,N}) where
+    {L<:AbstractDiscreteACSet,N} =
   StructuredMulticospan{L}(x, SMulticospan{N}(fs...))
 
 function force(M::StructuredMulticospan{L}) where {L<:AbstractDiscreteACSet}

--- a/src/categorical_algebra/StructuredCospans.jl
+++ b/src/categorical_algebra/StructuredCospans.jl
@@ -5,14 +5,14 @@ implementation for attributed C-sets.
 """
 module StructuredCospans
 export StructuredMulticospan, StructuredCospan, StructuredCospanOb,
-  OpenCSetTypes, OpenACSetTypes
+  OpenCSetTypes, OpenACSetTypes, OpenACSetLeg
 
 using StructEquality
 using StaticArrays: StaticVector, SVector
 
 using ...GAT, ..FreeDiagrams, ..Limits, ..FinSets, ..CSets
 import ..FreeDiagrams: apex, legs, feet, left, right, bundle_legs
-import ..CSets: force
+import ..CSets: components, force
 using ...Theories: ThCategory, SchemaDesc, SchemaDescType, CSetSchemaDescType, SchemaDescTypeType,
   attrtype, attr, adom, adom_nums, acodom
 import ...Theories: dom, codom, compose, ⋅, id, otimes, ⊗, munit, braid, σ,
@@ -183,10 +183,7 @@ munit_like(a::StructuredCospanOb{L}) where L = munit(StructuredCospanOb{L})
 
 """ Create types for open C-sets from a C-set type.
 
-Returns two types, one for objects, a subtype of [`StructuredCospanOb`](@ref),
-and one for morphisms, a subtype of [`StructuredMulticospan`](@ref).
-
-For attributed C-sets, see [`OpenACSetTypes`](@ref).
+A special case of [`OpenACSetTypes`](@ref). See there for details.
 """
 function OpenCSetTypes(::Type{X}, args...) where X<:StructCSet
   OpenACSetTypes(X, args...)
@@ -194,58 +191,76 @@ end
 
 """ Create types for open attributed C-sets from an attributed C-set type.
 
-The given type should *not* be instantiated with concrete attribute types.
+The given acset type should *not* be instantiated with concrete attribute types.
 
-The two resulting types, one for objects and one for morphisms, each have the
-same type parameters for data types as the original type.
+Returns two types, one for objects, a subtype of [`StructuredCospanOb`](@ref),
+and one for morphisms, a subtype of [`StructuredMulticospan`](@ref). Both types
+have the same type parameters for attribute types as the given acset type.
+
+Mathematically speaking, this function sets up structured (multi)cospans with a
+functor ``L: A → X`` between categories of acsets that creates "discrete
+acsets." Such a "discrete acset functor" is a functor that is left adjoint to a
+certain kind of forgetful functor between categories of acsets, namely one that
+is a pullback along an inclusion of schemas such that the image of inclusion has
+no outgoing arrows. For example, the schema inclusion ``{V} ↪ {E ⇉ V}`` has this
+property but ``{E} ↪ {E ⇉ V}`` does not.
 
 See also: [`OpenCSetTypes`](@ref).
 """
 function OpenACSetTypes(::Type{X}, ob₀::Symbol) where
     {S<:SchemaDescType, X<:StructACSet{S}}
   @assert ob₀ ∈ ob(S)
-  type_vars = map(TypeVar, attrtype(S))
+  vars = map(TypeVar, attrtype(S))
   L = if any(ob(S)[j] == ob₀ for (i,j) in enumerate(adom_nums(S)))
     A = ACSetTableType(X, ob₀, union_all=true)
-    DiscreteACSet{A{type_vars...}, X{type_vars...}}
+    DiscreteACSet{A{vars...}, X{vars...}}
   else
-    FinSetDiscreteACSet{ob₀, isempty(type_vars) ? X : X{type_vars...}}
+    FinSetDiscreteACSet{ob₀, isempty(vars) ? X : X{vars...}}
   end
-  (foldr(UnionAll, type_vars, init=StructuredCospanOb{L}),
-   foldr(UnionAll, type_vars, init=StructuredMulticospan{L}))
+  (foldr(UnionAll, vars, init=StructuredCospanOb{L}),
+   foldr(UnionAll, vars, init=StructuredMulticospan{L}))
 end
 
 function OpenACSetTypes(::Type{X}, ::Type{A}) where
     {S<:SchemaDescType, X<:StructACSet{S}, S₀<:SchemaDescType, A<:StructACSet{S₀}}
   @assert ob(S₀) ⊆ ob(S) && hom(S₀) ⊆ hom(S)
   @assert attrtype(S₀) ⊆ attrtype(S) && attr(S₀) ⊆ attr(S)
-  type_vars = map(TypeVar, attrtype(S))
-  #type_vars₀ = map(TypeVar, attrtype(S₀))
-  L = DiscreteACSet{A{type_vars...}, X{type_vars...}}
-  (foldr(UnionAll, type_vars, init=StructuredCospanOb{L}),
-   foldr(UnionAll, type_vars, init=StructuredMulticospan{L}))
+  vars = map(TypeVar, attrtype(S))
+  L = isempty(vars) ? DiscreteACSet{A,X} : DiscreteACSet{A{vars...}, X{vars...}}
+  (foldr(UnionAll, vars, init=StructuredCospanOb{L}),
+   foldr(UnionAll, vars, init=StructuredMulticospan{L}))
 end
 
-""" Abstract type for functor L: A → X giving a discrete attribute C-set.
+""" Leg of a structured (multi)cospan of acsets in R-form.
 
-A "discrete acset functor" is a functor between categories of acsets that is
-left adjoint to a certain kind of forgetful functor, namely one that is a
-pullback along an inclusion of schemas such that the image of inclusion has no
-outgoing arrows. For example, the schema inclusion ``{V} ↪ {E ⇉ V}`` has this
-property but ``{E} ↪ {E ⇉ V}`` does not.
+A convenience type that contains the data of an acset transformation, except for
+the codomain, since that data is already given by the decoration of the R-form
+structured cospan.
+"""
+@struct_hash_equal struct OpenACSetLeg{Comp<:NamedTuple, Dom<:StructACSet}
+  components::Comp
+  dom::Dom
+end
+OpenACSetLeg(a::StructACSet; components...) = OpenACSetLeg((; components...), a)
+
+components(ϕ::OpenACSetLeg) = ϕ.components
+dom(ϕ::OpenACSetLeg) = ϕ.dom
+codom(::OpenACSetLeg) = nothing
+
+""" Abstract type for functor L: A → X giving a discrete attribute C-set.
 """
 abstract type AbstractDiscreteACSet{X <: StructACSet} end
 
 codom(::Type{<:AbstractDiscreteACSet{X}}) where
   {S, X<:StructACSet{S}} = (X, TightACSetTransformation{S})
 
-StructuredCospan{L}(x::StructACSet, f::Union{FinFunction,ACSetTransformation},
+StructuredCospan{L}(x::StructACSet, f::Union{FinFunction,OpenACSetLeg},
                     g::Union{FinFunction,ACSetTransformation}) where
     {L<:AbstractDiscreteACSet} =
   StructuredCospan{L}(x, Cospan(f, g))
 
 StructuredMulticospan{L}(x::StructACSet,
-                         fs::Vararg{<:Union{FinFunction,ACSetTransformation},N}) where
+                         fs::Vararg{<:Union{FinFunction,OpenACSetLeg},N}) where
     {L<:AbstractDiscreteACSet, N} =
   StructuredMulticospan{L}(x, SMulticospan{N}(fs...))
 
@@ -257,8 +272,7 @@ end
 """ A functor L: FinSet → C-Set giving the discrete C-set wrt an object in C.
 
 This functor has a right adjoint R: C-Set → FinSet giving the underlying set at
-that object. Instead of instantiating this type directly, you should use
-[`OpenCSetTypes`](@ref) or [`OpenACSetTypes`](@ref).
+that object.
 """
 struct FinSetDiscreteACSet{ob₀, X} <: AbstractDiscreteACSet{X} end
 
@@ -266,12 +280,10 @@ dom(::Type{<:FinSetDiscreteACSet}) = (FinSet{Int}, FinFunction{Int,Int})
 
 """ A functor L: C₀-Set → C-Set giving the discrete C-set for C₀.
 
-TODO Here C₀ is assumed to contain a single object {x₀} from C and the discreteness
-is with respect to this object. The functor L has a right adjoint R: C-Set →
-C₀-Set forgetting the rest of C.
-
-Unlike [`FinSetDiscreteACSet`](@ref), this type supports data attributes.
-
+Unlike [`FinSetDiscreteACSet`](@ref), this type supports data attributes. In
+addition, the sub-schema C₀ may contain more than one object. In all cases, the
+inclusion of schemas ``C₀ → C`` must satisfy the property described in
+[`OpenACSetTypes`](@ref).
 """
 struct DiscreteACSet{A <: StructACSet, X} <: AbstractDiscreteACSet{X} end
 
@@ -282,7 +294,7 @@ function StructuredMulticospan{L}(x::StructACSet,
                                   cospan::Multicospan{<:FinSet{Int}}) where
     {A, L <: DiscreteACSet{A}}
   a = A()
-  copy_parts_only!(a, x)
+  copy_parts!(a, x)
   induced_legs = map(leg -> induced_transformation(a, leg), legs(cospan))
   StructuredMulticospan{L}(x, Multicospan(a, induced_legs))
 end
@@ -321,7 +333,7 @@ end
 """
 function (::Type{L})(a::StructACSet) where {A,X,L<:DiscreteACSet{A,X}}
   x = X()
-  copy_parts_only!(x, a)
+  copy_parts!(x, a)
   x
 end
 
@@ -345,7 +357,8 @@ function shift_left(::Type{L}, x::StructACSet, f::FinFunction{Int,Int}) where
     {ob₀, L <: FinSetDiscreteACSet{ob₀}}
   ACSetTransformation((; ob₀ => f), L(dom(f)), x)
 end
-function shift_left(::Type{L}, x::StructACSet, ϕ::ACSetTransformation) where
+function shift_left(::Type{L}, x::StructACSet,
+                    ϕ::Union{ACSetTransformation,OpenACSetLeg}) where
     {L <: DiscreteACSet}
   ACSetTransformation(components(ϕ), L(dom(ϕ)), x)
 end

--- a/src/categorical_algebra/StructuredCospans.jl
+++ b/src/categorical_algebra/StructuredCospans.jl
@@ -226,12 +226,13 @@ is in the substructure part (category A), it includes more than 1 objects; while
 "OpenACSetTypes(::Type{X}, ob₀::Symbol)" the category A  only includes one object
 """
 function OpenACSetTypes(::Type{X}, ::Type{A}) where
-  {S<:SchemaDescType, X<:StructACSet{S}, S0<:SchemaDescType, A<:StructACSet{S0}}
-  @assert attrtype(S0) ⊆ attrtype(S)
+  {S<:SchemaDescType, X<:StructACSet{S}, S₀<:SchemaDescType, A<:StructACSet{S₀}}
+  @assert attrtype(S₀) ⊆ attrtype(S)
   type_vars = map(TypeVar, attrtype(S))
-  type_vars0 = map(TypeVar, attrtype(S0))
-  L = SubStructACSet{A, X}
-  (StructuredCospanOb{L}, StructuredMulticospan{L})
+  #type_vars₀ = map(TypeVar, attrtype(S₀))
+  L = SubStructACSet{A{type_vars...}, X{type_vars...}}
+  (foldr(UnionAll, type_vars, init=StructuredCospanOb{L}),
+   foldr(UnionAll, type_vars, init=StructuredMulticospan{L}))
 end
 # **********************
 

--- a/test/categorical_algebra/StructuredCospans.jl
+++ b/test/categorical_algebra/StructuredCospans.jl
@@ -177,12 +177,12 @@ g′ = OpenWLGraph{Float64,Symbol}(g0, FinFunction([1],5),
 
 # This is actually a semi-globular set because there are no degeneracies.
 @present SchWeighted2DGlobularSet <: SchWeightedGraph begin
-  Cell2::Ob
-  (src2, tgt2)::Hom(Cell2, E)
+  Cell::Ob
+  (src2, tgt2)::Hom(Cell, E)
   compose(src2, src) == compose(tgt2, src)
   compose(src2, tgt) == compose(tgt2, tgt)
 
-  weight2::Attr(Cell2,Weight)
+  weight2::Attr(Cell, Weight)
 end
 
 @acset_type Weighted2DGlobularSet(SchWeighted2DGlobularSet) <: HasGraph
@@ -194,10 +194,10 @@ e1, e2 = WeightedGraph{Float64}(2), WeightedGraph{Float64}(2)
 add_edge!(e1, 1, 2, weight=1)
 add_edge!(e2, 1, 2, weight=2)
 
-cell2 = @acset Weighted2DGlobularSet{Float64} begin
+cell = @acset Weighted2DGlobularSet{Float64} begin
   V = 2
   E = 2
-  Cell2 = 1
+  Cell = 1
   src = [1,1]; tgt = [2,2]
   src2 = [1]; tgt2 = [2]
   weight = [1., 2.]
@@ -205,7 +205,7 @@ cell2 = @acset Weighted2DGlobularSet{Float64} begin
 end
 
 # Composing along vertices.
-g = OpenWeighted2DGlobularSet{Float64}(cell2, OpenACSetLeg(v, V=[1]),
+g = OpenWeighted2DGlobularSet{Float64}(cell, OpenACSetLeg(v, V=[1]),
                                        OpenACSetLeg(v, V=[2]))
 h = apex(compose(g, g))
 @test (src(h), tgt(h)) == ([1,1,2,2], [2,2,3,3])
@@ -213,7 +213,7 @@ h = apex(compose(g, g))
 @test (h[:weight], h[:weight2]) == ([1.,2.,1.,2.], [1.,1.])
 
 # Composing along edges.
-g = OpenWeighted2DGlobularSet{Float64}(cell2, OpenACSetLeg(e1, V=[1,2], E=[1]),
+g = OpenWeighted2DGlobularSet{Float64}(cell, OpenACSetLeg(e1, V=[1,2], E=[1]),
                                        OpenACSetLeg(e2, V=[1,2], E=[2]))
 h = apex(compose(g, dagger(g)))
 @test (src(h), tgt(h)) == ([1,1,1], [2,2,2])

--- a/test/categorical_algebra/StructuredCospans.jl
+++ b/test/categorical_algebra/StructuredCospans.jl
@@ -2,10 +2,6 @@ module TestStructuredCospans
 using Test
 
 using Catlab, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
-<<<<<<< HEAD
-=======
-using Catlab.Graphs.BasicGraphs: AbstractGraph, TheoryGraph, TheoryWeightedGraph
->>>>>>> da88bf26 (TST: Structured cospans of acsets with multiple objects in interface.)
 
 # Structured cospans of C-sets
 ##############################
@@ -100,8 +96,8 @@ k0 = apex(k)
 @test tgt(k0) == [2,3,4]
 @test subpart(k0, :weight) == [1.5, 1.0, 2.0]
 
-# Interface schema: one object, one attribute
-#--------------------------------------------
+# Interface schema: one object, with attributes
+#----------------------------------------------
 
 @present SchVELabeledGraph <: SchGraph begin
   Label::AttrType
@@ -153,33 +149,26 @@ b = OpenVELGraphOb{Symbol}(FinSet(3), vlabel=[:x,:y,:z])
 @test dom(braid(a, b)) == a⊗b
 @test codom(braid(a, b)) == b⊗a
 
-# Interface schema: one object, many attributes
-#----------------------------------------------
-
-@present SchMultiplyAttributedGraph <: TheoryGraph begin
-  Weight::AttrType
+@present SchWeightedLabeledGraph <: SchWeightedGraph begin
   Label::AttrType
   vlabel::Attr(V,Label)
   elabel::Attr(E,Label)
-  vsize::Attr(V,Weight)
-  elength::Attr(E,Weight)
 end
 
-@acset_type MAGraph(SchMultiplyAttributedGraph, index=[:src,:tgt]) <: AbstractGraph
-const OpenMAGraphOb, OpenMAGraph = OpenACSetTypes(MAGraph, :V)
+@acset_type WeightedLabeledGraph(SchWeightedLabeledGraph) <: AbstractGraph
+const OpenWLGraphOb, OpenWLGraph = OpenACSetTypes(WeightedLabeledGraph, :V)
 
-g0 = @acset MAGraph{Float64,Symbol} begin
+g0 = @acset WeightedLabeledGraph{Float64,Symbol} begin
   V = 5
   E = 3
-  vlabel = [:a, :b, :c, :d, :e]
-  elabel = [:a, :b, :c]
-  vsize = [0., 1., 3., 3., 4.]
-  elength = [1., 2., 3.]
   src = [1, 2, 3]
   tgt = [3, 4, 5]
+  vlabel = [:a, :b, :c, :d, :e]
+  elabel = [:a, :b, :c]
+  weight = [1., 2., 3.]
 end
-g = OpenMAGraph{Float64,Symbol}(g0, FinFunction([1],5), FinFunction([3,4],5))
-g′ = OpenMAGraph{Float64,Symbol}(g0, FinFunction([1],5),
+g = OpenWLGraph{Float64,Symbol}(g0, FinFunction([1],5), FinFunction([3,4],5))
+g′ = OpenWLGraph{Float64,Symbol}(g0, FinFunction([1],5),
                                  FinFunction([3],5), FinFunction([4],5))
 @test bundle_legs(g′, [1, (2,3)]) == g
 
@@ -187,7 +176,7 @@ g′ = OpenMAGraph{Float64,Symbol}(g0, FinFunction([1],5),
 #------------------------------------------------
 
 # This is actually a semi-globular set because there are no degeneracies.
-@present TheoryWeighted2DGlobularSet <: TheoryWeightedGraph begin
+@present SchWeighted2DGlobularSet <: SchWeightedGraph begin
   Cell2::Ob
   (src2, tgt2)::Hom(Cell2, E)
   compose(src2, src) == compose(tgt2, src)
@@ -196,7 +185,7 @@ g′ = OpenMAGraph{Float64,Symbol}(g0, FinFunction([1],5),
   weight2::Attr(Cell2,Weight)
 end
 
-@acset_type Weighted2DGlobularSet(TheoryWeighted2DGlobularSet) <: HasGraph
+@acset_type Weighted2DGlobularSet(SchWeighted2DGlobularSet) <: HasGraph
 const OpenWeighted2DGlobularSetOb, OpenWeighted2DGlobularSet =
   OpenACSetTypes(Weighted2DGlobularSet, WeightedGraph)
 

--- a/test/categorical_algebra/StructuredCospans.jl
+++ b/test/categorical_algebra/StructuredCospans.jl
@@ -203,21 +203,18 @@ cell2 = @acset Weighted2DGlobularSet{Float64} begin
   weight = [1., 2.]
   weight2 = [1.]
 end
-g₀ = WeightedGraph{Float64}() # FIXME: Shouldn't need to do this.
-copy_parts!(g₀, cell2)
 
 # Composing along vertices.
-g = OpenWeighted2DGlobularSet{Float64}(cell2, ACSetTransformation(v, g₀, V=[1]),
-                                       ACSetTransformation(v, g₀, V=[2]))
+g = OpenWeighted2DGlobularSet{Float64}(cell2, OpenACSetLeg(v, V=[1]),
+                                       OpenACSetLeg(v, V=[2]))
 h = apex(compose(g, g))
 @test (src(h), tgt(h)) == ([1,1,2,2], [2,2,3,3])
 @test (h[:src2], h[:tgt2]) == ([1,3], [2,4])
 @test (h[:weight], h[:weight2]) == ([1.,2.,1.,2.], [1.,1.])
 
 # Composing along edges.
-g = OpenWeighted2DGlobularSet{Float64}(cell2,
-   ACSetTransformation(e1, g₀, V=[1,2], E=[1]),
-   ACSetTransformation(e2, g₀, V=[1,2], E=[2]))
+g = OpenWeighted2DGlobularSet{Float64}(cell2, OpenACSetLeg(e1, V=[1,2], E=[1]),
+                                       OpenACSetLeg(e2, V=[1,2], E=[2]))
 h = apex(compose(g, dagger(g)))
 @test (src(h), tgt(h)) == ([1,1,1], [2,2,2])
 @test (h[:src2], h[:tgt2]) == ([1,3], [2,2])


### PR DESCRIPTION
This PR was started from work by @Xiaoyan-Li. We can now use structured cospans to, for example, glue 2D simplicial sets along edges. (The unit tests show the slightly simpler case of 2D globular sets.)