### PR TITLE
Representables and the Yoneda embedding

### DIFF
--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -43,7 +43,8 @@ end
 
 """ Create the struct declaration for a `StructACSet` from a Presentation
 """
-function struct_acset(name::Symbol, parent, p::Presentation{Schema}; index=[], unique_index=[])
+function struct_acset(name::Symbol, parent, p::Presentation{Schema};
+                      index=[], unique_index=[])
   obs = p.generators[:Ob]
   homs = p.generators[:Hom]
   attr_types = p.generators[:AttrType]
@@ -99,7 +100,8 @@ macro acset_type(head)
   end
   quote
     $(esc(:eval))($(GlobalRef(CSetDataStructures, :struct_acset))(
-      $(Expr(:quote, name)), $(Expr(:quote, parent)), $(esc(schema)), $(idx_args...)))
+      $(Expr(:quote, name)), $(Expr(:quote, parent)), $(esc(schema));
+      $((esc(arg) for arg in idx_args)...)))
     Core.@__doc__ $(esc(name))
   end
 end

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -875,6 +875,11 @@ function unpack_diagram(diag::Union{FreeDiagram{ACS},BipartiteFreeDiagram{ACS}};
   names = all ? flatten((ob(S), attrtype(S))) : ob(S)
   NamedTuple(c => map(diag, Ob=X->SetOb(X,c), Hom=α->α[c]) for c in names)
 end
+function unpack_diagram(F::Functor{<:FinCat,<:TypeCat{ACS}};
+                        all::Bool=false) where {S, ACS <: StructACSet{S}}
+  names = all ? flatten((ob(S), attrtype(S))) : ob(S)
+  NamedTuple(c => map(F, X->SetOb(X,c), α->α[c]) for c in names)
+end
 
 """ Vector of C-sets → named tuple of vectors of sets.
 """

--- a/src/categorical_algebra/Categories.jl
+++ b/src/categorical_algebra/Categories.jl
@@ -356,8 +356,11 @@ end
 dom(F::OppositeFunctor) = op(dom(F.func))
 codom(F::OppositeFunctor) = op(codom(F.func))
 
-ob_map(F::OppositeFunctor, x) = ob_map(F.func, x)
-hom_map(F::OppositeFunctor, f) = hom_map(F.func, f)
+do_ob_map(F::OppositeFunctor, x) = ob_map(F.func, x)
+do_hom_map(F::OppositeFunctor, f) = hom_map(F.func, f)
+
+do_compose(F::OppositeFunctor, G::OppositeFunctor) =
+  OppositeFunctor(do_compose(F.func, G.func))
 
 """ Opposite natural transformation between opposite functors.
 
@@ -373,6 +376,15 @@ dom(α::OppositeTransformation) = op(codom(α.trans))
 codom(α::OppositeTransformation) = op(dom(α.trans))
 
 component(α::OppositeTransformation, x) = component(α.trans, x)
+
+do_compose(α::OppositeTransformation, β::OppositeTransformation) =
+  OppositeTransformation(do_compose(β.trans, α.trans))
+do_composeH(α::OppositeTransformation, β::OppositeTransformation) =
+  OppositeTransformation(do_composeH(α.trans, β.trans))
+do_composeH(F::OppositeFunctor, β::OppositeTransformation) =
+  OppositeTransformation(do_composeH(F.func, β.trans))
+do_composeH(α::OppositeTransformation, H::OppositeFunctor) =
+  OppositeTransformation(do_composeH(α.trans, H.func))
 
 """ Oppositization 2-functor.
 

--- a/src/categorical_algebra/Categories.jl
+++ b/src/categorical_algebra/Categories.jl
@@ -186,6 +186,25 @@ function show_domains(io::IO, f; domain::Bool=true, codomain::Bool=true,
   end
 end
 
+# Callables
+#----------
+
+Functor(f::Function, g::Function, C::Cat, D::Cat) = FunctorCallable(f, g, C, D)
+
+""" Functor defined by two Julia callables, an object map and a morphism map.
+"""
+@auto_hash_equals struct FunctorCallable{Dom,Codom} <: Functor{Dom,Codom}
+  ob_map::Any
+  hom_map::Any
+  dom::Dom
+  codom::Codom
+end
+
+dom(F::FunctorCallable) = F.dom
+codom(F::FunctorCallable) = F.codom
+do_ob_map(F::FunctorCallable, x) = F.ob_map(x)
+do_hom_map(F::FunctorCallable, f) = F.hom_map(f)
+
 # Instances
 #----------
 

--- a/src/categorical_algebra/Categories.jl
+++ b/src/categorical_algebra/Categories.jl
@@ -14,7 +14,7 @@ presented categories are provided by another module, [`FinCats`](@ref).
 """
 module Categories
 export Cat, TypeCat, Functor, Transformation, dom, codom, compose, id,
-  ob, hom, is_hom_equal, ob_map, hom_map, dom_ob, codom_ob, component
+  ob, hom, is_hom_equal, ob_map, hom_map, dom_ob, codom_ob, component, op, co
 
 using AutoHashEquals
 
@@ -307,5 +307,67 @@ function do_composeH(α::Transformation, β::Transformation,
   F, K = dom(α), codom(β)
   compose_id(composeH_id(F, β), composeH_id(α, K))
 end
+
+# Oppositization 2-functor
+#-------------------------
+
+""" Opposite category, where morphism are reversed.
+"""
+@auto_hash_equals struct OppositeCat{Ob,Hom,C<:Cat{Ob,Hom}} <: Cat{Ob,Hom}
+  cat::C
+end
+
+ob(C::OppositeCat, x) = ob(C.cat, x)
+hom(C::OppositeCat, f) = hom(C.cat, f)
+
+dom(C::OppositeCat, f) = codom(C.cat, f)
+codom(C::OppositeCat, f) = dom(C.cat, f)
+id(C::OppositeCat, x) = id(C.cat, x)
+compose(C::OppositeCat, f, g) = compose(C.cat, g, f)
+
+""" Opposite functor, given by the same mapping between opposite categories.
+"""
+@auto_hash_equals struct OppositeFunctor{C,D,F<:Functor{C,D}} <: Functor{C,D}
+    # XXX: Requires more type parameters: ObC, HomC, ObD, HomD.
+    #Functor{OppositeCat{C},OppositeCat{D}}
+  func::F
+end
+
+dom(F::OppositeFunctor) = op(dom(F.func))
+codom(F::OppositeFunctor) = op(codom(F.func))
+
+ob_map(F::OppositeFunctor, x) = ob_map(F.func, x)
+hom_map(F::OppositeFunctor, f) = hom_map(F.func, f)
+
+""" Opposite natural transformation between opposite functors.
+"""
+@auto_hash_equals struct OppositeTransformation{C,D,F,G,T<:Transformation{C,D,F,G}} <: Transformation{C,D,F,G}
+    # XXX: Requires more type parameters: ObC, HomC, ObD, HomD.
+    #Transformation{OppositeCat{C},OppositeCat{D},OppositeFunctor{C,D,G},OppositeFunctor{C,D,F}}
+  trans::T
+end
+
+dom(α::OppositeTransformation) = op(codom(α.trans))
+codom(α::OppositeTransformation) = op(dom(α.trans))
+
+component(α::OppositeTransformation, x) = component(α.trans, x)
+
+""" Oppositization 2-functor.
+
+The oppositization endo-2-functor on Cat, sending a category to its opposite, is
+covariant on objects and morphisms and contravariant on 2-morphisms, i.e., is a
+2-functor ``op: Catᶜᵒ → Cat``. For more explanation, see the
+[nLab](https://ncatlab.org/nlab/show/opposite+category).
+"""
+op(C::Cat) = OppositeCat(C)
+op(F::Functor) = OppositeFunctor(F)
+op(α::Transformation) = OppositeTransformation(α)
+op(C::OppositeCat) = C.cat
+op(F::OppositeFunctor) = F.func
+op(α::OppositeTransformation) = α.trans
+
+""" 2-cell dual of a 2-category.
+"""
+function co end
 
 end

--- a/src/categorical_algebra/Categories.jl
+++ b/src/categorical_algebra/Categories.jl
@@ -15,7 +15,7 @@ presented categories are provided by another module, [`FinCats`](@ref).
 module Categories
 export Cat, TypeCat, Functor, Transformation, dom, codom, compose, id,
   ob, hom, is_hom_equal, ob_map, hom_map, dom_ob, codom_ob, component,
-  OppositeCat, OppositeFunctor, OppositeTransformation, op, co
+  OppositeCat, op, co
 
 using AutoHashEquals
 
@@ -362,6 +362,9 @@ do_hom_map(F::OppositeFunctor, f) = hom_map(F.func, f)
 do_compose(F::OppositeFunctor, G::OppositeFunctor) =
   OppositeFunctor(do_compose(F.func, G.func))
 
+#= Not yet needed because the only natural transformations we currently support
+#are `FinTransformationMap`, for which can just implement `op` directly.
+
 """ Opposite natural transformation between opposite functors.
 
 Call `op(::Transformation)` instead of directly instantiating this type.
@@ -385,6 +388,7 @@ do_composeH(F::OppositeFunctor, β::OppositeTransformation) =
   OppositeTransformation(do_composeH(F.func, β.trans))
 do_composeH(α::OppositeTransformation, H::OppositeFunctor) =
   OppositeTransformation(do_composeH(α.trans, H.func))
+=#
 
 """ Oppositization 2-functor.
 
@@ -395,10 +399,10 @@ covariant on objects and morphisms and contravariant on 2-morphisms, i.e., is a
 """
 op(C::Cat) = OppositeCat(C)
 op(F::Functor) = OppositeFunctor(F)
-op(α::Transformation) = OppositeTransformation(α)
+#op(α::Transformation) = OppositeTransformation(α)
 op(C::OppositeCat) = C.cat
 op(F::OppositeFunctor) = F.func
-op(α::OppositeTransformation) = α.trans
+#op(α::OppositeTransformation) = α.trans
 
 """ 2-cell dual of a 2-category.
 """

--- a/src/categorical_algebra/DataMigrations.jl
+++ b/src/categorical_algebra/DataMigrations.jl
@@ -1,7 +1,8 @@
 """ Functorial data migration for attributed C-sets.
 """
 module DataMigrations
-export DataMigration, DeltaMigration, SigmaMigration, migrate, migrate!
+export DataMigration, DeltaMigration, SigmaMigration, migrate, migrate!,
+  representable
 
 using ...Syntax, ...Present, ...Theories
 using ...Theories: SchemaDesc, ob, hom, dom, codom, attr, adom
@@ -60,7 +61,7 @@ const GlucSchemaMigration{D<:FinCat,C<:FinCat} =
 abstract type MigrationFunctor{Dom<:ACSet,Codom<:ACSet} <:
   Functor{TypeCat{Dom,ACSetTransformation},TypeCat{Codom,ACSetTransformation}} end
 
-ob_map(F::MigrationFunctor{Dom,Codom}, X::Dom) where {Dom,Codom} =
+ob_map(F::MigrationFunctor{Dom,Codom}, X) where {Dom,Codom} =
   ob_map(F, Codom, X)
 
 (F::MigrationFunctor)(X::ACSet) = ob_map(F, X)
@@ -259,9 +260,12 @@ struct SigmaMigration{Dom,Codom,F<:FinFunctor,CC} <: MigrationFunctor{Dom,Codom}
 end
 
 SigmaMigration(functor::FinFunctor, ::Type{Codom}) where Codom =
-  SigmaMigration(ACSet, Codom, functor)
+  SigmaMigration(functor, ACSet, Codom)
 
-function ob_map(ΣF::SigmaMigration, ::Type{T}, X::ACSet) where T <: ACSet
+ob_map(ΣF::SigmaMigration, ::Type{T}, X::ACSet) where T<:ACSet =
+  ob_map(ΣF, T, FinDomFunctor(X))
+
+function ob_map(ΣF::SigmaMigration, ::Type{T}, X::FinDomFunctor) where T<:ACSet
   comma_cats = ΣF.comma_cats
   diagramD = FreeDiagram(presentation(codom(ΣF.functor)))
 
@@ -269,12 +273,8 @@ function ob_map(ΣF::SigmaMigration, ::Type{T}, X::ACSet) where T <: ACSet
   Y = T()
   colimX = map(parts(diagramD, :V)) do i
     F∇d = ob(comma_cats, i)
-    Xobs = map(ob(F∇d)) do (c,_)
-      FinSet(X, nameof(c))
-    end
-    Xhoms = map(parts(F∇d, :E)) do g
-      FinFunction(X, nameof(hom(F∇d, g)))
-    end
+    Xobs = FinSet{Int,Int}[ ob_map(X, c) for (c,_) in ob(F∇d) ]
+    Xhoms = [ hom_map(X, hom(F∇d, g)) for g in parts(F∇d, :E) ]
     colimit(FreeDiagram(Xobs, collect(zip(Xhoms, src(F∇d), tgt(F∇d)))))
   end
 
@@ -369,6 +369,33 @@ function comma_cat_hom!(F∇d, F∇d′, id_d, g, FHomInv)
 
   # return the inclusion from F∇d′ to F∇d 
   return ACSetTransformation((V = collect(vs), E = collect(es)), F∇d′, F∇d)
+end
+
+# Applications of sigma migration
+#--------------------------------
+
+""" Construct a representable C-set.
+
+Recall that a *representable* C-set is one of form ``C(c,-): C → Set`` for some
+object ``c ∈ C``.
+
+This function computes the ``c`` representable as the left pushforward data
+migration of the singleton ``{c}``-set along the inclusion functor ``{c} ↪ C``,
+which works because left Kan extensions take representables to representables
+(Mac Lane 1978, Exercise X.3.2). Besides the intrinsic difficulties with
+representables (they can be infinite), this function thus inherits any
+limitations of our implementation of left pushforward data migrations.
+"""
+function representable(::Type{T}, ob::Symbol) where T <: ACSet
+  C = Presentation(T)
+  C₀ = Presentation{Symbol}(FreeSchema)
+  add_generator!(C₀, C[ob])
+  F = FinFunctor(Dict(ob => ob), Dict(), C₀, C)
+  ΣF = SigmaMigration(F, T)
+
+  X = FinDomFunctor(Dict(ob => FinSet(1)),
+                    Dict{Symbol,FinFunction{Int}}(), FinCat(C₀))
+  ob_map(ΣF, X)
 end
 
 # Schema translation

--- a/src/categorical_algebra/Diagrams.jl
+++ b/src/categorical_algebra/Diagrams.jl
@@ -200,10 +200,16 @@ end
   @import dom, codom, compose, id
 end
 
-op(d::Diagram{op}) = Diagram{co}(d)
-op(d::Diagram{co}) = Diagram{op}(d)
-op(f::DiagramHom{op}) = DiagramHom{co}(f)
-op(f::DiagramHom{co}) = DiagramHom{op}(f)
+# Oppositization 2-functor induces isomorphisms of diagram categories:
+#    op(Diag{id}(C)) ≅ Diag{op}(op(C))
+#    op(Diag{op}(C)) ≅ Diag{id}(op(C))
+
+op(d::Diagram{id}) = Diagram{op}(op(diagram(d)))
+op(d::Diagram{op}) = Diagram{id}(op(diagram(d)))
+op(f::DiagramHom{id}) = DiagramHom{op}(op(shape_map(f)), op(diagram_map(f)),
+                                       op(f.precomposed_diagram))
+op(f::DiagramHom{op}) = DiagramHom{id}(op(shape_map(f)), op(diagram_map(f)),
+                                       op(f.precomposed_diagram))
 
 # Any functor ``F: C → D`` induces a functor ``Diag(F): Diag(C) → Diag(D)`` by
 # post-composition and post-whiskering.

--- a/src/categorical_algebra/Diagrams.jl
+++ b/src/categorical_algebra/Diagrams.jl
@@ -6,21 +6,11 @@ export Diagram, DiagramHom, id, op, co, shape, diagram, shape_map, diagram_map
 using ...GAT
 import ...Theories: dom, codom, id, compose, ⋅, ∘, munit
 using ...Theories: Category, composeH
-import ..Categories: ob_map, hom_map
+import ..Categories: ob_map, hom_map, op, co
 using ..FinCats, ..FreeDiagrams
 using ..FinCats: mapvals
 import ..FinCats: force, collect_ob, collect_hom
 import ..Limits: limit, colimit, universal
-
-# TODO: Implement these functions more generally, and move elsewhere.
-
-""" Opposite of a category or, more generally, 1-cell dual of a 2-category.
-"""
-function op end
-
-""" 2-cell dual of a 2-category.
-"""
-function co end
 
 # Data types
 ############

--- a/src/categorical_algebra/FinCats.jl
+++ b/src/categorical_algebra/FinCats.jl
@@ -27,14 +27,18 @@ using ...Theories: Category, Schema, ObExpr, HomExpr, AttrExpr, AttrTypeExpr
 import ...Theories: dom, codom, id, compose, ⋅, ∘
 using ...CSetDataStructures, ...Graphs
 import ...Graphs: edges, src, tgt, enumerate_paths
-import ..Categories: OppositeCat, ob, hom, ob_map, hom_map, component
+import ..Categories: CatSize, ob, hom, ob_map, hom_map, component
 
 # Categories
 ############
 
-""" Abstract type for finitely presented category.
+""" Size of a finitely presented category.
 """
-abstract type FinCat{Ob,Hom} <: Cat{Ob,Hom} end
+struct FinCatSize <: CatSize end
+
+""" A finitely presented (but not necessarily finite!) category.
+"""
+const FinCat{Ob,Hom} = Cat{Ob,Hom,FinCatSize}
 
 FinCat(g::HasGraph, args...; kw...) = FinCatGraph(g, args...; kw...)
 FinCat(pres::Presentation, args...; kw...) =
@@ -65,8 +69,10 @@ is_free(C::FinCat) = isempty(equations(C))
 # Opposite FinCats
 #-----------------
 
-ob_generators(C::OppositeCat) = ob_generators(C.cat)
-hom_generators(C::OppositeCat) = hom_generators(C.cat)
+const OppositeFinCat{Ob,Hom} = OppositeCat{Ob,Hom,FinCatSize}
+
+ob_generators(C::OppositeFinCat) = ob_generators(C.cat)
+hom_generators(C::OppositeFinCat) = hom_generators(C.cat)
 
 # Categories on graphs
 ######################

--- a/src/categorical_algebra/FinCats.jl
+++ b/src/categorical_algebra/FinCats.jl
@@ -27,7 +27,7 @@ using ...Theories: Category, Schema, ObExpr, HomExpr, AttrExpr, AttrTypeExpr
 import ...Theories: dom, codom, id, compose, ⋅, ∘
 using ...CSetDataStructures, ...Graphs
 import ...Graphs: edges, src, tgt, enumerate_paths
-import ..Categories: ob, hom, ob_map, hom_map, component
+import ..Categories: OppositeCat, ob, hom, ob_map, hom_map, component
 
 # Categories
 ############
@@ -61,6 +61,12 @@ is_discrete(C::FinCat) = isempty(hom_generators(C))
 """ Is the category freely generated?
 """
 is_free(C::FinCat) = isempty(equations(C))
+
+# Opposite FinCats
+#-----------------
+
+ob_generators(C::OppositeCat) = ob_generators(C.cat)
+hom_generators(C::OppositeCat) = hom_generators(C.cat)
 
 # Categories on graphs
 ######################

--- a/src/categorical_algebra/FinCats.jl
+++ b/src/categorical_algebra/FinCats.jl
@@ -359,6 +359,12 @@ function is_functorial(F::FinDomFunctor; check_equations::Bool=false)
   true
 end
 
+function Base.map(F::Functor{<:FinCat,<:TypeCat}, f_ob, f_hom)
+  C = dom(F)
+  FinDomFunctor(map(x -> f_ob(ob_map(F, x)), ob_generators(C)),
+                map(f -> f_hom(hom_map(F, f)), hom_generators(C)), C)
+end
+
 """ A functor between finitely presented categories.
 """
 const FinFunctor{Dom<:FinCat,Codom<:FinCat} = FinDomFunctor{Dom,Codom}

--- a/src/categorical_algebra/FreeDiagrams.jl
+++ b/src/categorical_algebra/FreeDiagrams.jl
@@ -545,10 +545,15 @@ FreeDiagram(diagram::BipartiteFreeDiagram{Ob,Hom}) where {Ob,Hom} =
   FreeDiagram{Ob,Hom}(diagram)
 
 function FreeDiagram{Ob,Hom}(F::Functor{<:FinCat{Int}}) where {Ob,Hom}
+  J = dom(F)
+  js = ob_generators(J)
+  js == 1:length(js) || error("Objects must be numbers 1:n")
+
   diagram = FreeDiagram{Ob,Hom}()
-  copy_parts!(diagram, graph(dom(F)))
-  diagram[:ob] = collect_ob(F)
-  diagram[:hom] = collect_hom(F)
+  add_vertices!(diagram, length(js), ob=[ob_map(F,j) for j in js])
+  for f in hom_generators(J)
+    add_edge!(diagram, dom(J,f), codom(J,f), hom=hom_map(F,f))
+  end
   diagram
 end
 FreeDiagram(F::Functor{<:FinCat{Int},<:Cat{Ob,Hom}}) where {Ob,Hom} =

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -156,6 +156,8 @@ diagram = FreeDiagram([g1, g2, g0], [(ϕ,1,3), (ψ,2,3)])
 @test ob(lim′) == ob(lim)
 @test force(π1) == force(proj1(lim))
 @test force(π2) == force(proj2(lim))
+lim′ = limit(FinDomFunctor(diagram))
+@test ob(lim′) == ob(lim)
 
 # Colimits
 #---------

--- a/test/categorical_algebra/Categories.jl
+++ b/test/categorical_algebra/Categories.jl
@@ -1,15 +1,21 @@
 module TestCategories
 using Test
 
-using Catlab.Theories
+using Catlab, Catlab.Theories
 using Catlab.CategoricalAlgebra.Sets, Catlab.CategoricalAlgebra.Categories
 
-# Categories from Julia types
-#############################
+# Instances
+###########
+
+# Categories
+#-----------
 
 C = TypeCat(FreeCategory.Ob, FreeCategory.Hom)
 @test Ob(C) == TypeSet(FreeCategory.Ob)
 @test sprint(show, C) == "TypeCat($(FreeCategory.Ob), $(FreeCategory.Hom))"
+
+# Functors
+#---------
 
 F = id(C)
 @test (dom(F), codom(F)) == (C, C)
@@ -19,6 +25,33 @@ x, y = Ob(FreeCategory, :x, :y)
 f = Hom(:f, x, y)
 @test F(x) == x
 @test F(f) == f
+
+# Is this worth putting somewhere?
+struct InstanceFunctor{Ob,Hom} <:
+  Functor{TypeCat{FreeCategory.Ob,FreeCategory.Hom},TypeCat{Ob,Hom}}
+end
+Categories.dom(::InstanceFunctor) = TypeCat{FreeCategory.Ob,FreeCategory.Hom}()
+Categories.codom(::InstanceFunctor{Ob,Hom}) where {Ob,Hom} = TypeCat{Ob,Hom}()
+Categories.do_ob_map(::InstanceFunctor{Ob,Hom}, x) where {Ob,Hom} =
+  functor((Ob,Hom), x)::Ob
+Categories.do_hom_map(::InstanceFunctor{Ob,Hom}, f) where {Ob,Hom} =
+  functor((Ob,Hom), f)::Hom
+
+F = InstanceFunctor{FreeCategory2.Ob,FreeCategory2.Hom}()
+
+x′, y′ = Ob(FreeCategory2, :x, :y)
+f′ = Hom(:f, x′, y′)
+@test F(x) == x′
+@test F(f) == f′
+
+F_op = op(F)
+@test F_op isa Categories.OppositeFunctor
+@test (dom(F_op), codom(F_op)) == (op(dom(F)), op(codom(F)))
+@test F_op(x) == x′
+@test F_op(f) == f′
+
+# Transformations
+#----------------
 
 α = id(F)
 @test (dom(α), codom(α)) == (F, F)

--- a/test/categorical_algebra/Categories.jl
+++ b/test/categorical_algebra/Categories.jl
@@ -26,18 +26,12 @@ f = Hom(:f, x, y)
 @test F(x) == x
 @test F(f) == f
 
-# Is this worth putting somewhere?
-struct InstanceFunctor{Ob,Hom} <:
-  Functor{TypeCat{FreeCategory.Ob,FreeCategory.Hom},TypeCat{Ob,Hom}}
+function InstanceFunctor(T::TypeCat{Ob,Hom}) where {Ob, Hom}
+  Functor(x -> functor((Ob,Hom), x), f -> functor((Ob,Hom), f),
+          TypeCat{FreeCategory.Ob, FreeCategory.Hom}(), T)
 end
-Categories.dom(::InstanceFunctor) = TypeCat{FreeCategory.Ob,FreeCategory.Hom}()
-Categories.codom(::InstanceFunctor{Ob,Hom}) where {Ob,Hom} = TypeCat{Ob,Hom}()
-Categories.do_ob_map(::InstanceFunctor{Ob,Hom}, x) where {Ob,Hom} =
-  functor((Ob,Hom), x)::Ob
-Categories.do_hom_map(::InstanceFunctor{Ob,Hom}, f) where {Ob,Hom} =
-  functor((Ob,Hom), f)::Hom
-
-F = InstanceFunctor{FreeCategory2.Ob,FreeCategory2.Hom}()
+F = InstanceFunctor(TypeCat(FreeCategory2.Ob, FreeCategory2.Hom))
+@test dom(F) == C
 
 x′, y′ = Ob(FreeCategory2, :x, :y)
 f′ = Hom(:f, x′, y′)

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -349,4 +349,10 @@ Z = SigmaMigration(edge, Initial, Graph)(Y)
 @test nparts(Z, :E) == 4
 @test Z[:src] ∪ Z[:tgt] == 1:8
 
+# Representables
+#---------------
+
+@test representable(Graph, :V) == Graph(1)
+@test representable(Graph, :E) == path_graph(Graph, 2)
+
 end

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -349,10 +349,17 @@ Z = SigmaMigration(edge, Initial, Graph)(Y)
 @test nparts(Z, :E) == 4
 @test Z[:src] ∪ Z[:tgt] == 1:8
 
-# Representables
-#---------------
+# Applications of sigma migration
+#--------------------------------
 
-@test representable(Graph, :V) == Graph(1)
-@test representable(Graph, :E) == path_graph(Graph, 2)
+yV, yE = Graph(1), path_graph(Graph, 2)
+@test representable(Graph, :V) == yV
+@test representable(Graph, :E) == yE
+
+y_Graph = yoneda(Graph)
+@test ob_map(y_Graph, :V) == yV
+@test ob_map(y_Graph, :E) == yE
+@test hom_map(y_Graph, :src) == ACSetTransformation(yV, yE, V=[1])
+@test hom_map(y_Graph, :tgt) == ACSetTransformation(yV, yE, V=[2])
 
 end

--- a/test/categorical_algebra/Diagrams.jl
+++ b/test/categorical_algebra/Diagrams.jl
@@ -62,9 +62,8 @@ fg = f⋅g
 d = dom(f)
 @test op(op(d)) == d
 @test op(op(f)) == f
-@test dom(op(g)) == Diagram{co}(ιV)
-@test codom(op(g)) == Diagram{co}(D)
-@test op(g) == DiagramHom{co}([(1,:src)], ιV, D)
+@test dom(op(f)) == op(codom(f))
+@test codom(op(f)) == op(dom(f))
 @test op(g)⋅op(f) == op(f⋅g)
 
 # Monads of diagrams

--- a/test/categorical_algebra/FinCats.jl
+++ b/test/categorical_algebra/FinCats.jl
@@ -20,14 +20,27 @@ C = FinCat(g)
 @test hom_generators(C) == 1:3
 @test startswith(sprint(show, C), "FinCat($(Graph)")
 
+C_op = op(C)
+@test ob(C_op, 1) == 1
+@test hom(C_op, 1) == Path(g, 1)
+@test ob_generators(C_op) == 1:2
+@test hom_generators(C_op) == 1:3
+@test op(C_op) == C
+
 h = Graph(4)
 add_edges!(h, [1,1,2,3], [2,3,4,4])
 D = FinCat(h)
 f = id(D, 2)
 @test (src(f), tgt(f)) == (2, 2)
 @test isempty(edges(f))
-f = compose(D, 1, 3)
-@test edges(f) == [1,3]
+g = compose(D, 1, 3)
+@test edges(g) == [1,3]
+
+D_op = op(D)
+@test dom(D_op, 1) == 2
+@test codom(D_op, 1) == 1
+@test id(D_op, 2) == f
+@test compose(D_op, 3, 1) == g
 
 # Functors between free categories.
 C = FinCat(parallel_arrows(Graph, 2))
@@ -42,6 +55,13 @@ F = FinFunctor((V=[1,4], E=[[1,3], [2,4]]), C, D)
 @test hom_map(F, 1) == Path(h, [1,3])
 @test collect_ob(F) == [1,4]
 @test collect_hom(F) == [Path(h, [1,3]), Path(h, [2,4])]
+
+F_op = op(F)
+@test dom(F_op) == op(C)
+@test codom(F_op) == op(D)
+@test ob_map(F_op, 2) == 4
+@test hom_map(F_op, 1) == Path(h, [1,3])
+@test op(F_op) == F
 
 # Composition of functors.
 g, h, k = path_graph(Graph, 2), path_graph(Graph, 3), path_graph(Graph, 5)
@@ -146,6 +166,12 @@ G = FinDomFunctor(g)
 @test is_natural(α)
 @test α[:V](3) == 2
 @test startswith(sprint(show, α), "FinTransformation(")
+
+α_op = op(α)
+@test dom(α_op) == op(G)
+@test codom(α_op) == op(F)
+@test component(α, :V) == α[:V]
+@test op(α_op) == α
 
 σ = FinTransformation(G, G, V=id(FinSet(2)), E=FinFunction([2,1,4,3]))
 @test σ⋅σ == FinTransformation(G, G, V=id(FinSet(2)), E=FinFunction(1:4))

--- a/test/categorical_algebra/FinCats.jl
+++ b/test/categorical_algebra/FinCats.jl
@@ -202,10 +202,10 @@ G = FinDomFunctor(g)
 @test ob_map(G, :Weight) == TypeSet(Float64)
 @test hom_map(G, :weight) == FinDomFunction([0.5, 1.5])
 
-# Initiality of functors
-########################
+# Initial functors
+##################
 
-"Commutative square diagram: with 1→2→4 and 1→3→4"
+# Commutative square diagram: with 1→2→4 and 1→3→4
 S = FinCat(@acset Graph begin
   V = 4
   E = 4
@@ -213,7 +213,7 @@ S = FinCat(@acset Graph begin
   tgt = [2,3,4,4]
 end)
 
-"Equalizer diagram: 1→2⇉3"
+# Equalizer diagram: 1→2⇉3
 T = FinCat(@acset Graph begin
   V = 3
   E = 3
@@ -221,7 +221,7 @@ T = FinCat(@acset Graph begin
   tgt = [2,3,3]
 end)
 
-"Extra bit added to beginning equalizer diagram: 4→1→2⇉3"
+# Extra bit added to beginning equalizer diagram: 4→1→2⇉3
 T2 = FinCat(@acset Graph begin
   V = 4
   E = 4
@@ -229,14 +229,13 @@ T2 = FinCat(@acset Graph begin
   tgt = [2,3,3,1]
 end)
 
-"Extra bit added to end of equalizer diagram: 1→2⇉3→4"
+# Extra bit added to end of equalizer diagram: 1→2⇉3→4
 T3 = FinCat(@acset Graph begin
   V = 4
   E = 4
   src = [1,2,2,3]
   tgt = [2,3,3,4]
 end)
-
 
 # Opposite square corners folded on top of each other
 F1 = FinFunctor([1,2,2,3], [1,1,2,3], S, T)
@@ -252,7 +251,6 @@ F4 = FinFunctor([1,2,3], [1,2,3], T, T2)
 
 # Same as F1, but there is an additional piece of data in codomain, ignored
 F5 = FinFunctor([1,2,3], [1,2,3], T, T2)
-
 
 @test all(is_functorial.([F1,F2,F3,F4]))
 @test is_initial(F1)

--- a/test/categorical_algebra/FinCats.jl
+++ b/test/categorical_algebra/FinCats.jl
@@ -21,6 +21,7 @@ C = FinCat(g)
 @test startswith(sprint(show, C), "FinCat($(Graph)")
 
 C_op = op(C)
+@test C_op isa FinCat
 @test ob(C_op, 1) == 1
 @test hom(C_op, 1) == Path(g, 1)
 @test ob_generators(C_op) == 1:2
@@ -57,6 +58,7 @@ F = FinFunctor((V=[1,4], E=[[1,3], [2,4]]), C, D)
 @test collect_hom(F) == [Path(h, [1,3]), Path(h, [2,4])]
 
 F_op = op(F)
+@test F_op isa FinFunctor
 @test dom(F_op) == op(C)
 @test codom(F_op) == op(D)
 @test ob_map(F_op, 2) == 4
@@ -168,6 +170,7 @@ G = FinDomFunctor(g)
 @test startswith(sprint(show, α), "FinTransformation(")
 
 α_op = op(α)
+@test α_op isa FinTransformation
 @test dom(α_op) == op(G)
 @test codom(α_op) == op(F)
 @test component(α, :V) == α[:V]

--- a/test/categorical_algebra/FinCats.jl
+++ b/test/categorical_algebra/FinCats.jl
@@ -34,6 +34,7 @@ D = FinCat(h)
 f = id(D, 2)
 @test (src(f), tgt(f)) == (2, 2)
 @test isempty(edges(f))
+@test reverse(f) == f
 g = compose(D, 1, 3)
 @test edges(g) == [1,3]
 
@@ -58,11 +59,9 @@ F = FinFunctor((V=[1,4], E=[[1,3], [2,4]]), C, D)
 @test collect_hom(F) == [Path(h, [1,3]), Path(h, [2,4])]
 
 F_op = op(F)
-@test F_op isa FinFunctor
+@test F_op isa FinFunctor && F_op isa FinCats.FinDomFunctorMap
 @test dom(F_op) == op(C)
 @test codom(F_op) == op(D)
-@test ob_map(F_op, 2) == 4
-@test hom_map(F_op, 1) == Path(h, [1,3])
 @test op(F_op) == F
 
 # Composition of functors.
@@ -170,10 +169,9 @@ G = FinDomFunctor(g)
 @test startswith(sprint(show, α), "FinTransformation(")
 
 α_op = op(α)
-@test α_op isa FinTransformation
+@test α_op isa FinCats.FinTransformationMap
 @test dom(α_op) == op(G)
 @test codom(α_op) == op(F)
-@test component(α, :V) == α[:V]
 @test op(α_op) == α
 
 σ = FinTransformation(G, G, V=id(FinSet(2)), E=FinFunction([2,1,4,3]))


### PR DESCRIPTION
This PR implements:

- Representable C-sets, subject to the limitations of our current implementation of left pushforward data migration
- The contravariant Yoneda embedding
- The oppositization 2-functor
- Various small fixes and improvements encountered along the way while using this stuff