### PR TITLE
Bump Documenter to v0.27

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -15,6 +15,6 @@ TikzPictures = "37f6aa50-8035-52d0-81c2-5a1d08754b2d"
 
 [compat]
 Convex = "^0.15"
-Documenter = "^0.25.3"
+Documenter = "^0.27"
 SCS = "^1"
 TikzCDs = "^0.2.1"


### PR DESCRIPTION
It was previously at v0.25, which is now quite outdated.