### PR TITLE
Handle special case of pullback migration in `colimit_representables`

### DIFF
--- a/src/categorical_algebra/DataMigrations.jl
+++ b/src/categorical_algebra/DataMigrations.jl
@@ -423,6 +423,9 @@ take colimits of representables to construct a `op(J)`-shaped diagram of C-sets.
 Since every C-set is a colimit of representables, this is a generic way of
 constructing diagrams of C-sets.
 """
+function colimit_representables(F::DeltaSchemaMigration, y)
+  compose(op(F), y)
+end
 function colimit_representables(F::ConjSchemaMigration, y)
   C = dom(F)
   colimits = make_map(ob_generators(C)) do c

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -363,6 +363,19 @@ y_Graph = yoneda(Graph)
 @test hom_map(y_Graph, :tgt) == ACSetTransformation(yV, yE, V=[2])
 
 F = @migration TheoryGraph begin
+  X => E
+  (I, O) => V
+  (i: X → I) => src
+  (o: X → O) => tgt
+end
+G = colimit_representables(F, y_Graph) # Delta migration.
+X = ob_map(G, :X)
+@test X == path_graph(Graph, 2)
+i, o = hom_map(G, :i), hom_map(G, :o)
+@test only(collect(i[:V])) == 1
+@test only(collect(o[:V])) == 2
+
+F = @migration TheoryGraph begin
   X => @join begin
     (e₁, e₂)::E
     tgt(e₁) == src(e₂)
@@ -371,7 +384,7 @@ F = @migration TheoryGraph begin
   (i: X → I) => src(e₁)
   (o: X → O) => tgt(e₂)
 end
-G = colimit_representables(F, y_Graph)
+G = colimit_representables(F, y_Graph) # Conjunctive migration.
 X = ob_map(G, :X)
 @test is_isomorphic(X, path_graph(Graph, 3))
 i, o = hom_map(G, :i), hom_map(G, :o)


### PR DESCRIPTION
This is a degenerate case of a conjunctive data migration.