### PR TITLE
Fix type ambiguities with empty diagrams in data migration

### DIFF
--- a/src/categorical_algebra/DataMigrations.jl
+++ b/src/categorical_algebra/DataMigrations.jl
@@ -167,14 +167,19 @@ function migrate(X::FinDomFunctor, F::ConjSchemaMigration;
   tgt_schema = dom(F)
   limits = make_map(ob_generators(tgt_schema)) do c
     Fc = ob_map(F, c)
-    # XXX: Must manually supply types to handle case of empty diagram.
-    diagram_types = c isa AttrTypeExpr ? (TypeSet, SetFunction) :
+    J = shape(Fc)
+    # XXX: Must supply object/morphism types to handle case of empty diagram.
+    diagram_types = if c isa AttrTypeExpr
+      (TypeSet, SetFunction)
+    elseif isempty(J)
+      (FinSet{Int}, FinFunction{Int})
+    else
       (SetOb, FinDomFunction{Int})
+    end
     # XXX: Disable domain check because acsets don't store schema equations.
     lim = limit(force(compose(Fc, X, strict=false), diagram_types...),
                 alg=SpecializeLimit(fallback=ToBipartiteLimit()))
     if tabular
-      J = shape(Fc)
       names = (ob_generator_name(J, j) for j in ob_generators(J))
       TabularLimit(lim, names=names)
     else

--- a/src/categorical_algebra/Diagrams.jl
+++ b/src/categorical_algebra/Diagrams.jl
@@ -52,7 +52,7 @@ hom_map(d::Diagram, f) = hom_map(diagram(d), f)
 collect_ob(d::Diagram) = collect_ob(diagram(d))
 collect_hom(d::Diagram) = collect_hom(diagram(d))
 
-force(d::Diagram{T}) where T = Diagram{T}(force(diagram(d)))
+force(d::Diagram{T}, args...) where T = Diagram{T}(force(diagram(d), args...))
 
 function Base.show(io::IO, d::Diagram{T}) where T
   print(io, "Diagram{$T}(")

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -721,8 +721,7 @@ ensure_indexed(f::FinFunction{Int,Int}) = is_indexed(f) ? f :
 ensure_indexed(f::FinDomFunction{Int}) = is_indexed(f) ? f :
   FinDomFunction(collect(f), index=true)
 
-function limit(d::BipartiteFreeDiagram{Ob,Hom}) where
-    {Ob<:SetOb, Hom<:FinDomFunction{Int}}
+function limit(d::BipartiteFreeDiagram{<:SetOb,<:FinDomFunction{Int}})
   # As in a pullback, this method assumes that all objects in layer 2 have
   # incoming morphisms.
   @assert !any(isempty(incident(d, v, :tgt)) for v in vertices₂(d))
@@ -774,7 +773,7 @@ function limit(d::BipartiteFreeDiagram{Ob,Hom}) where
     pb = pullback(SVector(hom(d, join_edges)...), alg=SmartJoin())
 
     # Create a new bipartite diagram with joined vertices.
-    d_joined = BipartiteFreeDiagram{Ob,Hom}()
+    d_joined = BipartiteFreeDiagram{SetOb,FinDomFunction{Int}}()
     copy_parts!(d_joined, d, V₁=to_keep, V₂=setdiff(vertices₂(d),v), E=edges(d))
     joined = add_vertex₁!(d_joined, ob₁=apex(pb))
     for (u, π) in zip(to_join, legs(pb))
@@ -788,7 +787,7 @@ function limit(d::BipartiteFreeDiagram{Ob,Hom}) where
     lim = limit(d_joined)
 
     # Assemble limit cone from cones for pullback and reduced limit.
-    πs = Vector{Hom}(undef, nv₁(d))
+    πs = Vector{FinDomFunction{Int}}(undef, nv₁(d))
     for (i, u) in enumerate(to_join)
       πs[u] = compose(last(legs(lim)), legs(pb)[i], ιs[u])
     end

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -368,10 +368,12 @@ end
 # Specialize (co)limits
 #----------------------
 
-""" Meta-algorithm attempting to reduce general limits to common special cases.
+""" Meta-algorithm that reduces general limits to common special cases.
 
-Specifically, reduce limits of free diagrams that happen to be discrete to
-products. TODO: Handle pullbacks similarly.
+Reduces limits of free diagrams that happen to be discrete to products. If this
+fails, fall back to the given algorithm (if any).
+
+TODO: Reduce free diagrams that are (multi)cospans to (wide) pullbacks.
 """
 @Base.kwdef struct SpecializeLimit <: LimitAlgorithm
   fallback::Union{LimitAlgorithm,Nothing} = nothing
@@ -382,9 +384,10 @@ limit(diagram, alg::SpecializeLimit) = limit(diagram, alg.fallback)
 function limit(F::FinDomFunctor{<:FinCat{Int},<:TypeCat{Ob,Hom}},
                alg::SpecializeLimit) where {Ob,Hom}
   if is_discrete(dom(F))
-    return limit(DiscreteDiagram(collect_ob(F), Hom), alg)
+    limit(DiscreteDiagram(collect_ob(F), Hom), SpecializeLimit())
+  else
+    limit(F, alg.fallback)
   end
-  limit(F, alg.fallback)
 end
 limit(diagram::FreeDiagram, alg::SpecializeLimit) =
   limit(FinDomFunctor(diagram), alg)
@@ -392,12 +395,13 @@ limit(diagram::FreeDiagram, alg::SpecializeLimit) =
 function limit(Xs::DiscreteDiagram{Ob,Hom,Obs},
                alg::SpecializeLimit) where {Ob,Hom,Obs}
   if !(Obs <: StaticVector) && length(Xs) <= 3
-    return limit(DiscreteDiagram(SVector{length(Xs)}(ob(Xs)), Hom), alg)
+    limit(DiscreteDiagram(SVector{length(Xs)}(ob(Xs)), Hom), SpecializeLimit())
+  else
+    limit(Xs, alg.fallback)
   end
-  limit(Xs, alg.fallback)
 end
 
-""" Meta-algorithm attempting to reduce general colimits to common special cases.
+""" Meta-algorithm that reduces general colimits to common special cases.
 
 Dual to [`SpecializeLimit`](@ref).
 """
@@ -410,9 +414,10 @@ colimit(diagram, alg::SpecializeColimit) = colimit(diagram, alg.fallback)
 function colimit(F::FinDomFunctor{<:FinCat{Int},<:TypeCat{Ob,Hom}},
                  alg::SpecializeColimit) where {Ob,Hom}
   if is_discrete(dom(F))
-    return colimit(DiscreteDiagram(collect_ob(F), Hom), alg)
+    colimit(DiscreteDiagram(collect_ob(F), Hom), SpecializeColimit())
+  else
+    colimit(F, alg.fallback)
   end
-  colimit(F, alg.fallback)
 end
 colimit(diagram::FreeDiagram, alg::SpecializeColimit) =
   colimit(FinDomFunctor(diagram), alg)
@@ -420,9 +425,10 @@ colimit(diagram::FreeDiagram, alg::SpecializeColimit) =
 function colimit(Xs::DiscreteDiagram{Ob,Hom,Obs},
                  alg::SpecializeColimit) where {Ob,Hom,Obs}
   if !(Obs <: StaticVector) && length(Xs) <= 3
-    return colimit(DiscreteDiagram(SVector{length(Xs)}(ob(Xs)), Hom), alg)
+    colimit(DiscreteDiagram(SVector{length(Xs)}(ob(Xs)), Hom), SpecializeColimit())
+  else
+    colimit(Xs, alg.fallback)
   end
-  colimit(Xs, alg.fallback)
 end
 
 """ Limit of a singleton diagram.

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -6,19 +6,21 @@ using Catlab.Programs.DiagrammaticPrograms
 using Catlab.Graphs.BasicGraphs: TheoryGraph, TheoryWeightedGraph
 using Catlab.Graphs.BipartiteGraphs: TheoryUndirectedBipartiteGraph
 
+@present TheorySet(FreeSchema) begin
+  X::Ob
+end
+@acset_type AcsetSet(TheorySet)
+
+@present TheoryDDS <: TheorySet begin
+  Φ::Hom(X,X)
+end
+@acset_type DDS(TheoryDDS, index=[:Φ])
+
 # Contravariant migration
 #########################
 
 # Pullback migration
 #-------------------
-
-@present TheoryDDS(FreeSchema) begin
-  X::Ob
-  Φ::Hom(X,X)
-end
-
-@abstract_acset_type AbstractDDS
-@acset_type DDS(TheoryDDS, index=[:Φ]) <: AbstractDDS
 
 h = Graph(3)
 add_parts!(h, :E, 3, src = [1,2,3], tgt = [2,3,1])
@@ -230,6 +232,16 @@ h = @migrate SymmetricReflexiveGraph g begin
   end
 end
 @test is_isomorphic(h, star_graph(SymmetricReflexiveGraph, 5))
+
+# Discrete graph on set.
+set = @acset AcsetSet begin
+  X = 5
+end
+g = @migrate Graph set begin
+  V => X
+  E => @empty
+end
+@test g == Graph(5)
 
 # Gluc migration
 #---------------

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -172,6 +172,20 @@ h = @migrate Graph g begin
 end
 @test h == path_graph(Graph, 4)
 
+# Bouquet graph on a set.
+set = @acset AcsetSet begin X = 5 end
+g = @migrate Graph set begin
+  V => @unit
+  E => X
+end
+g′ = @acset Graph begin
+  V = 1
+  E = 5
+  src = [1,1,1,1,1]
+  tgt = [1,1,1,1,1]
+end
+@test g == g′
+
 # Gluing migration
 #-----------------
 
@@ -234,9 +248,7 @@ end
 @test is_isomorphic(h, star_graph(SymmetricReflexiveGraph, 5))
 
 # Discrete graph on set.
-set = @acset AcsetSet begin
-  X = 5
-end
+set = @acset AcsetSet begin X = 5 end
 g = @migrate Graph set begin
   V => X
   E => @empty

--- a/test/programs/DiagrammaticPrograms.jl
+++ b/test/programs/DiagrammaticPrograms.jl
@@ -263,9 +263,7 @@ F = @migration TheoryGraph TheorySet begin
   tgt => begin end
 end
 @test F isa DataMigrations.ConjSchemaMigration
-F_V = ob_map(F, :V)
-@test isempty(ob_generators(shape(F_V)))
-@test isempty(hom_generators(shape(F_V)))
+@test isempty(shape(ob_map(F, :V)))
 
 # Syntactic variant of above.
 F′ = @migration TheoryGraph TheorySet begin
@@ -359,9 +357,7 @@ F = @migration TheoryGraph TheorySet begin
   E => @empty
 end
 @test F isa DataMigrations.GlueSchemaMigration
-F_E = ob_map(F, :E)
-@test isempty(ob_generators(shape(F_E)))
-@test isempty(hom_generators(shape(F_E)))
+@test isempty(shape(ob_map(F, :E)))
 
 # Coproduct of graph with itself.
 F = @migration TheoryGraph TheoryGraph begin


### PR DESCRIPTION
A prime example of how the Julia compiler's inability to reliably infer types in the base case of an empty `map` leads to bugs and general frustration.