### PR TITLE
Rename and export acset schemas

### DIFF
--- a/benchmark/Graphs.jl
+++ b/benchmark/Graphs.jl
@@ -8,7 +8,6 @@ import MetaGraphs
 const LG, MG = SimpleGraphs, MetaGraphs
 
 using Catlab, Catlab.CategoricalAlgebra, Catlab.Graphs
-using Catlab.Graphs.BasicGraphs: TheoryGraph, TheoryLabeledGraph
 using Catlab.WiringDiagrams: query
 using Catlab.Programs: @relation
 
@@ -304,7 +303,7 @@ bench = SUITE["LabeledGraph"] = BenchmarkGroup()
 clbench = bench["Catlab"] = BenchmarkGroup()
 lgbench = bench["LightGraphs"] = BenchmarkGroup()
 
-@acset_type IndexedLabeledGraph(TheoryLabeledGraph, index=[:src,:tgt],
+@acset_type IndexedLabeledGraph(SchLabeledGraph, index=[:src,:tgt],
                                 unique_index=[:label]) <: AbstractLabeledGraph
 
 function discrete_labeled_graph(n::Int; indexed::Bool=false)

--- a/docs/literate/diagrams/diagrams.jl
+++ b/docs/literate/diagrams/diagrams.jl
@@ -10,7 +10,6 @@
 
 using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra
 using Catlab.Graphs, Catlab.Graphics, Catlab.Programs
-using Catlab.Graphics.Graphviz
 
 draw(D::FinFunctor) = to_graphviz(D, node_labels=true, edge_labels=true, prog="neato")
 

--- a/docs/literate/diagrams/diagrams.jl
+++ b/docs/literate/diagrams/diagrams.jl
@@ -10,7 +10,6 @@
 
 using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra
 using Catlab.Graphs, Catlab.Graphics, Catlab.Programs
-using Catlab.Graphs.BasicGraphs: TheoryGraph
 using Catlab.Graphics.Graphviz
 
 draw(D::FinFunctor) = to_graphviz(D, node_labels=true, edge_labels=true, prog="neato")
@@ -27,7 +26,7 @@ draw(D::FinFunctor) = to_graphviz(D, node_labels=true, edge_labels=true, prog="n
 # For example, the limit of the following diagram consists of the paths of length
 # two in a graph:
 
-D₂ = @free_diagram TheoryGraph begin
+D₂ = @free_diagram SchGraph begin
   v::V
   (e₁, e₂)::E
   tgt(e₁) == v
@@ -46,7 +45,7 @@ draw(D₂)
 # For small equations the point-free notation commonly employed in functional programming is very convenient; however, there is a reason it is not the standard approach to presenting equations in mathematical writing. Variables are just too useful! As the size of the system of equations grows, it becomes more and more convenient to use variable names. This is why `Catlab.Programs.@program` exists to help people write SMC morphisms with the point-ful notation they are familiar with in imperative or procedural programming.
 
 # We can describe a triangle in a graph using the vertex variables v₁, v₂, v₃ and edge variables e₁, e₂, e₃. Then we use the equation notation to assert the `src` and `tgt` relationships between the edges and vertices. 
-D₃ = @free_diagram TheoryGraph begin
+D₃ = @free_diagram SchGraph begin
   (v₁, v₂, v₃)::V
   (e₁, e₂, e₃)::E
   src(e₁) == v₁

--- a/docs/literate/graphs/graphs.jl
+++ b/docs/literate/graphs/graphs.jl
@@ -2,7 +2,6 @@ using Catlab, Catlab.Theories
 using Catlab.CategoricalAlgebra
 using Catlab.Graphs
 using Catlab.Graphics
-using Catlab.Graphics.Graphviz
 
 using Colors
 draw(g) = to_graphviz(g, node_labels=true, edge_labels=true)
@@ -26,7 +25,7 @@ function GraphvizGraphs.to_graphviz_property_graph(f::ACSetTransformation; kw...
   pg
 end
 
-to_graphviz(Catlab.Graphs.BasicGraphs.SchGraph)
+to_graphviz(SchGraph)
 
 # # The Category of Graphs
 #
@@ -66,7 +65,7 @@ to_graphviz(Catlab.Graphs.BasicGraphs.SchGraph)
 # The theory of graphs has no equations, so there are no constraints on the data you provide, 
 # except for those that come from functoriality.
 
-e = @acset Graphs.Graph begin
+e = @acset Graph begin
     V = 2
     E = 1
     src = [1]
@@ -76,7 +75,7 @@ end
 draw(e)
 
 # a wedge is two edges that share a target
-w = @acset Graphs.Graph begin
+w = @acset Graph begin
     V = 3
     E = 2
     src=[1,3]
@@ -171,7 +170,7 @@ is_natural(ϕᵦ′)
 
 # CSet homomorphisms f:A→B are ways of finding a part of B that is shaped like A. You can view this as pattern matching. The graph A is the pattern and the graph B is the data. A morphism f:A→B is a collection of vertices and edges in B that is shaped like A. Note that you can ask Catlab to enforce constraints on the homomorphisms it will find including computing monic (injective) morphisms by passing the keyword `monic=true`. A monic morphism into B is a subobject of B.  You can pass `iso=true` to get isomorphisms.
 
-t = @acset Graphs.Graph begin
+t = @acset Graph begin
     V = 3
     E = 3
     src = [1,2,1]
@@ -180,7 +179,7 @@ end
 
 draw(t)
 
-T = @acset Graphs.Graph begin
+T = @acset Graph begin
     V = 6
     E = 9
     src = [1,2,1, 3, 1,5,2,2,4]
@@ -234,7 +233,7 @@ rem_parts!(sq, :E, [1,5,6,8,9])
 draw(sq)
 
 # We will use the symmetric edge graph to identify the bipartitions of this graph. 
-esym = @acset Graphs.Graph begin
+esym = @acset Graph begin
     V = 2
     E = 2
     src = [1,2]
@@ -261,7 +260,7 @@ draw(homomorphisms(sq, esym)[2])
 # We can generalize the notion of Bipartite graph to any number of parts. I like to call Kₖ the k-coloring classifier because homomorphims into α:G → Kₖ are k-colorings of G.
 
 clique(k::Int) = begin
-    Kₖ = Graphs.Graph(k)
+    Kₖ = Graph(k)
     for i in 1:k
         for j in 1:k
             if j ≠ i
@@ -288,7 +287,7 @@ draw(homomorphism(T, K₃))
 
 # ## Homomorphisms in [C, Set] are like Types
 # Any graph can play the role of the codomain. If you pick a graph that is incomplete, you get a more constrained notion of coloring where there are color combinations that are forbidden.
-triloop = @acset Graphs.Graph begin
+triloop = @acset Graph begin
     V = 3
     E = 3
     src = [1,2,3]
@@ -298,7 +297,7 @@ end
 draw(id(triloop))
 
 # With this graph, we can pick out directed 3-cycles in a graph like T2,
-T2 = @acset Graphs.Graph begin
+T2 = @acset Graph begin
     V = 6
     E = 6
     src = [1,2,3,4,5,6]
@@ -309,7 +308,7 @@ graphhoms(T2, triloop)
 # and we can draw those cyclic roles with colors
 draw(homomorphisms(T2, triloop)[1])
 
-T3 = @acset Graphs.Graph begin
+T3 = @acset Graph begin
     V = 6
     E = 7
     src = [1,2,3,4,5,6, 2]

--- a/docs/literate/graphs/graphs.jl
+++ b/docs/literate/graphs/graphs.jl
@@ -26,13 +26,13 @@ function GraphvizGraphs.to_graphviz_property_graph(f::ACSetTransformation; kw...
   pg
 end
 
-to_graphviz(Catlab.Graphs.BasicGraphs.TheoryGraph)
+to_graphviz(Catlab.Graphs.BasicGraphs.SchGraph)
 
 # # The Category of Graphs
 #
 # The Theory of Graphs is given by the following Schema:
 # ```julia
-# @present TheoryGraph(FreeSchema) begin
+# @present SchGraph(FreeSchema) begin
 #   V::Ob
 #   E::Ob
 #   src::Hom(E,V)
@@ -45,10 +45,10 @@ to_graphviz(Catlab.Graphs.BasicGraphs.TheoryGraph)
 
 # """ A graph, also known as a directed multigraph.
 # """
-# @acset_type Graph(TheoryGraph, index=[:src,:tgt]) <: AbstractGraph
+# @acset_type Graph(SchGraph, index=[:src,:tgt]) <: AbstractGraph
 # ```
 #
-# That is all we need to do to generate the functor category [TheoryGraph, FinSet].
+# That is all we need to do to generate the functor category [SchGraph, FinSet].
 # Catlab knows how to take a finitely presented category and generate all the data structures
 # that you need to represent functors into FinSet and natural transformations between those functors.
 # Note: the index=[:src, :tgt] keyword argument tells Catlab that you want to have an efficient index
@@ -164,7 +164,7 @@ is_natural(ϕᵦ′)
 # ### Exercise:
 # 1. Take your graph from the previous exercise and construct a graph homomorphism from the wedge (w) into it.
 # 2. Check that the naturality equations are satisfied.
-# 3. Explain why we don't need to specify any data for the source and target morphisms in TheoryGraph when definining a graph homomorphism
+# 3. Explain why we don't need to specify any data for the source and target morphisms in SchGraph when definining a graph homomorphism
 
 # ## Finding Homomorphisms Automatically
 # As you saw in the previous exercise, constructing a natural transformation can be quite tedious. We want computers to automate tedious things for us. So we use an algorithm to enumerate all the homomorphisms between two CSets.

--- a/docs/literate/graphs/graphs_label.jl
+++ b/docs/literate/graphs/graphs_label.jl
@@ -5,7 +5,6 @@ using Catlab, Catlab.Theories
 using Catlab.CategoricalAlgebra
 using Catlab.Graphs
 using Catlab.Graphics
-using Catlab.Graphics.Graphviz
 using Colors
 draw(g) = to_graphviz(g, node_labels=true, edge_labels=true)
 
@@ -35,7 +34,7 @@ to_graphviz(SchLGraph)
 
 # We need to tell Catlab how to convert our `LGraph` type into the normal `Graph` type by taking just the edges and vertices. This could be computed with Functorial Data Migration, but that is left for another sketch.
 to_graph(g::LGraph) = begin
-  h = Graphs.Graph(nparts(g,:V))
+  h = Graph(nparts(g,:V))
   for e in edges(g)
     add_edge!(h, g[e, :src], g[e,:tgt])
   end

--- a/docs/literate/graphs/graphs_label.jl
+++ b/docs/literate/graphs/graphs_label.jl
@@ -10,28 +10,28 @@ using Colors
 draw(g) = to_graphviz(g, node_labels=true, edge_labels=true)
 
 # We start with the theory of graphs, which is copied from `Catlab.Graphs.BasicGraphs`. The two objects are the edges and vertices and we have two functions `src,tgt` that assign to every edge the source vertex and target vertex respectively. Functors from this category to Set (diagrams in Set of this shape) are category theoretic graphs (directed multigraphs).
-@present TheoryGraph(FreeSchema) begin
+@present SchGraph(FreeSchema) begin
   V::Ob
   E::Ob
   src::Hom(E,V)
   tgt::Hom(E,V)
 end
 
-to_graphviz(TheoryGraph)
+to_graphviz(SchGraph)
 
 # To the theory of graphs we want to add a set of labels `L` and map that assigns to every vertex to its label in `L`.
-@present TheoryLGraph <: TheoryGraph begin
+@present SchLGraph <: SchGraph begin
   L::Ob
   label::Hom(V,L)
 end
 
-to_graphviz(TheoryLGraph)
+to_graphviz(SchLGraph)
 
-# Catlab will automatically generate all the data structure and algorithms (storing, mutating, serializing, etc.) our `LGraphs` for us. This snippet declares that the Julia type `LGraph` should be composed of objects of the functor category `TheoryLGraph → Skel(FinSet)`, where `Skel(FinSet)` is the subcategory of Set containing finite sets of form `1:n`. We want our Julia type `LGraph` to inherit from the type `AbstractGraph` so that we can run graph algorithms on it. And we want the generated data structures to make an index of the maps `src`, `tgt`, and `label` so that looking up the in and outneighbors of vertex is fast and accessing all vertices by label is also fast.
+# Catlab will automatically generate all the data structure and algorithms (storing, mutating, serializing, etc.) our `LGraphs` for us. This snippet declares that the Julia type `LGraph` should be composed of objects of the functor category `SchLGraph → Skel(FinSet)`, where `Skel(FinSet)` is the subcategory of Set containing finite sets of form `1:n`. We want our Julia type `LGraph` to inherit from the type `AbstractGraph` so that we can run graph algorithms on it. And we want the generated data structures to make an index of the maps `src`, `tgt`, and `label` so that looking up the in and outneighbors of vertex is fast and accessing all vertices by label is also fast.
 #
 # **Note**: This schema differs from that of `LabeledGraph` in `Catlab.Graphs` by making the label type an object (`Ob`) rather than attribute type (`AttrType`). In this case, the set of labels can vary from instance to instance and homomorphisms can rename labels; in the other case, the set of labels is fixed by a Julia type, such as `Int` or `Symbol`, and label values must be strictly preserved homomorphisms. The graph theory literature does not always distinguish very carefully between these two cases.
 
-@acset_type LGraph(TheoryLGraph, index=[:src,:tgt,:label]) <: AbstractGraph
+@acset_type LGraph(SchLGraph, index=[:src,:tgt,:label]) <: AbstractGraph
 
 # We need to tell Catlab how to convert our `LGraph` type into the normal `Graph` type by taking just the edges and vertices. This could be computed with Functorial Data Migration, but that is left for another sketch.
 to_graph(g::LGraph) = begin

--- a/docs/literate/sketches/cat_elements.jl
+++ b/docs/literate/sketches/cat_elements.jl
@@ -9,7 +9,7 @@ function graph(el::Elements)
   F = FinFunctor(
     Dict(:V => :El, :E => :Arr),
     Dict(:src => :src, :tgt => :tgt),
-    BasicGraphs.TheoryGraph, CatElements.ThElements
+    BasicGraphs.SchGraph, CatElements.ThElements
   )
   ΔF = DeltaMigration(F, Elements{Symbol}, BasicGraphs.Graph)
   return ΔF(el)
@@ -41,12 +41,12 @@ draw(g) = to_graphviz(g, node_labels=true, edge_labels=true, prog="neato")
 
 # ## The simplest schema 
 # First we will look at discrete dynamical systems. The set S is our state space and the funct nxt associates to every state, the next state in the system. This is a deterministic dynamical system with finitely many states and discrete time.
-@present TheoryDDS(FreeSchema) begin
+@present SchemaDDS(FreeSchema) begin
   S::Ob
   nxt::Hom(S, S)
 end
 
-@acset_type DDS(TheoryDDS, index=[:nxt])
+@acset_type DDS(SchemaDDS, index=[:nxt])
 
 fₓ = @acset DDS begin
   S = 3

--- a/docs/literate/sketches/cat_elements.jl
+++ b/docs/literate/sketches/cat_elements.jl
@@ -1,17 +1,13 @@
 # # The Category of Elements
 # A very useful construction in applied category theory is the Category of Elements, which is also called the Grothendieck construction. This is a very general technique in category theory, but we will look at how you can use it to explain why graphs are so useful in computer science. We have already seen that C-Sets are a model of relational databases that can be used to store data as a collection of interlocking tables. Relational databases are the bread and butter of the computing industry. Every company on earth uses software that is backed by a relational database. Most data that is not stored in a relational DB is often stored in some kind of graph data structure. This sketch will show how these approaches are interchangeable via the category of elements, which associates to every database instance a graph and a graph homomorphism into the schema of the graph.
 using Catlab, Catlab.CategoricalAlgebra, Catlab.Graphs, Catlab.Graphics
-using Catlab.Graphics.Graphviz
 using Colors
 
 # Let's tell Catlab how to draw categories of elements.
 function graph(el::Elements)
-  F = FinFunctor(
-    Dict(:V => :El, :E => :Arr),
-    Dict(:src => :src, :tgt => :tgt),
-    BasicGraphs.SchGraph, CatElements.ThElements
-  )
-  ΔF = DeltaMigration(F, Elements{Symbol}, BasicGraphs.Graph)
+  F = FinFunctor(Dict(:V => :El, :E => :Arr), Dict(:src => :src, :tgt => :tgt),
+                 SchGraph, SchElements)
+  ΔF = DeltaMigration(F, Elements{Symbol}, Graph)
   return ΔF(el)
 end
 
@@ -41,12 +37,12 @@ draw(g) = to_graphviz(g, node_labels=true, edge_labels=true, prog="neato")
 
 # ## The simplest schema 
 # First we will look at discrete dynamical systems. The set S is our state space and the funct nxt associates to every state, the next state in the system. This is a deterministic dynamical system with finitely many states and discrete time.
-@present SchemaDDS(FreeSchema) begin
+@present SchDDS(FreeSchema) begin
   S::Ob
   nxt::Hom(S, S)
 end
 
-@acset_type DDS(SchemaDDS, index=[:nxt])
+@acset_type DDS(SchDDS, index=[:nxt])
 
 fₓ = @acset DDS begin
   S = 3
@@ -70,14 +66,14 @@ end
 draw(elements(Fₓ))
 
 # A category of elements derived from a C-Set is stored as a C-Set of on a different schema. You can see that it is the data of a graph homomorphism where the codomain graph has vertex and edge labels. The two projections πₑ and πₐ are the components of a natural transformation between graphs viewed as functors into Set. The names are attributes usually of type Symbol.
-to_graphviz(ThElements)
+to_graphviz(SchElements)
 
 
 # In the case of a DDS, we have only one object and one morphism in the schema. Since the graph with one edge and one vertices is terminal in *Graph*, there is only one vertex and edge color being used.
 
 # ## The Elements of a Graph are its Vertices and Edges
 # In what might appear as primordial ooze, we can examine the category of elements of a graph. We will look at the commuting triangle graph. Notice how there are 3 vertices and three edges with each edge incident to 2 vertices.
-g = @acset BasicGraphs.Graph begin
+g = @acset Graph begin
   V = 3
   E = 3
   src = [1,2,1]
@@ -89,7 +85,7 @@ draw(g)
 elᵍ = elements(g)
 draw(elᵍ)
 
-g = @acset BasicGraphs.Graph begin
+g = @acset Graph begin
   V = 6
   E = 7
   src = [1,2,1,3,5,6,4]
@@ -102,7 +98,7 @@ draw(elements(g))
 
 # ## Generality of the construction
 # Discrete Dynamical Systems and Graphs are clearly data structures from mathematics and so it would make sense that they have a clean representation in the categorical language. But how about a database schema that comes not from mathematics, but from software engineering. We turn to everyone's favorite database example, the HR database at a fictitious company. 
-@present ThCompany(FreeSchema) begin
+@present SchCompany(FreeSchema) begin
   (P, D, S)::Ob # Person, Department, Salary
   worksin::Hom(P, D)    # Every Person works in a Department
   makes::Hom(P, S)      # Every Person makes a Salary
@@ -111,7 +107,7 @@ draw(elements(g))
   leq::Hom(S,S)         # Salaries are a finite total order
 end
 
-@acset_type Company(ThCompany, index=[])
+@acset_type Company(SchCompany, index=[])
 
 # We can draw a company that has 4 people, 2 departments, and 3 distinct salaries. 
 cmpy = @acset Company begin
@@ -174,7 +170,7 @@ cmpy == cset(Company, elᶜ)
 # ## The Slice-Elements Transform
 # An amazing fact about presheaf toposes is that they are closed under taking slices. In the graphs section of this documentation, you can find a description of bipartite and k-partite graphs as a morphisms into a clique. That definition is very mathematically pleasing because it gives you a category of partitioned graphs that are derived from commuting triangles in Graph. However, for application oriented practitioners, the definition of a bipartite graph as "a graph with two sets of vertices, where all the edges go between the groups with no edges within either group" is probably more explicit. For example a classic way to get a bipartite graph would be to look at the graph of authors and papers that those authors wrote. People write papers, people do not write people and papers do not write papers so the authorship graph is bipartite. These two equivalent definitions of a bipartite graph are related via an isomorphism you can find on the [nlab](https://ncatlab.org/nlab/show/category+of+presheaves#RelWithOvercategories). It shows that a slice category of [C,Set]/X is isomorphic to [El(X), Set] which is a cateogory of presheaves on a different schema. Catlab knows how to use this idea to turn a category of elements into a schema for a new category of presheaves. The two directions of the isomorphism are not yet implemented.
 
-e = @acset BasicGraphs.Graph begin
+e = @acset Graph begin
   V = 2
   E = 1
   src = 1
@@ -182,9 +178,11 @@ e = @acset BasicGraphs.Graph begin
 end
 
 draw(elements(e))
-ThBipartite = CatElements.presentation(elements(e))[1]
-to_graphviz(ThBipartite)
-@acset_type BipartiteGraph(ThBipartite)
+
+SchBipartite = CatElements.presentation(elements(e))[1]
+to_graphviz(SchBipartite)
+
+@acset_type BipartiteGraph(SchBipartite)
 b = @acset BipartiteGraph begin
   V_1 = 3
   V_2 = 2

--- a/docs/literate/sketches/meets.jl
+++ b/docs/literate/sketches/meets.jl
@@ -10,7 +10,7 @@ using Core: GeneratedFunctionStub
 using Test
 
 using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra
-using Catlab.Graphics, Catlab.Graphics.Graphviz
+using Catlab.Graphics
 
 import Catlab.Theories: compose
 using DataStructures

--- a/docs/literate/sketches/smc.jl
+++ b/docs/literate/sketches/smc.jl
@@ -6,10 +6,9 @@
 using Catlab, Catlab.Theories
 using Catlab.CategoricalAlgebra
 using Catlab.WiringDiagrams
-using Catlab.Graphics
-using Catlab.Graphics.Graphviz
 using Catlab.Programs
-using Catlab.WiringDiagrams
+using Catlab.Graphics
+using Catlab.Graphics: Graphviz
 
 draw(d::WiringDiagram) = to_graphviz(d,
   orientation=LeftToRight,

--- a/docs/literate/wiring_diagrams/wd_cset.jl
+++ b/docs/literate/wiring_diagrams/wd_cset.jl
@@ -3,10 +3,9 @@
 using Catlab, Catlab.Theories
 using Catlab.CategoricalAlgebra
 using Catlab.WiringDiagrams
-using Catlab.Graphics
-using Catlab.Graphics.Graphviz
 using Catlab.Programs
-using Catlab.WiringDiagrams
+using Catlab.Graphics
+using Catlab.Graphics: Graphviz
 
 draw(d::WiringDiagram) = to_graphviz(d,
   orientation=LeftToRight,
@@ -195,7 +194,7 @@ end
 
 # ## Undirected Wiring Diagrams
 # A much simpler structure than DWDs are known as undirected wiring diagrams. They are called undirected because ports boxes have one set of ports that aren't divided into inputs and outputs, and the wires are undirected. Wires connect junctions to ports (which live on boxes). 
-to_graphviz(WiringDiagrams.UndirectedWiringDiagrams.SchUWD)
+to_graphviz(SchUWD)
 
 # These UWDs are combinatorial syntax for relations. The junctions are variables and the boxes are the relations. A relation R ⊆ X × Y has two ports one for the value of X and one for the value of Y. The expression R(x:X, y:Y) says to connect the X port of R to the junction for the variable x, and the Y port of R to the y variable junction. If two ports are attached to the same junction, then you have a constraint that those values must be equal. The outer ports are the components of the final relation. For example the following UWD encodes the relation {(x,y,z) | R(x,y) and S(y,z) for all x∈X, y∈Y, z∈Z}. 
 uwd = @relation (x, y, z) begin

--- a/docs/src/apis/categorical_algebra.md
+++ b/docs/src/apis/categorical_algebra.md
@@ -66,7 +66,7 @@ We will now give an example of how this all works in practice.
 using Catlab, Catlab.CategoricalAlgebra
 
 # Write down the schema for a weighted graph
-@present TheoryWeightedGraph(FreeSchema) begin
+@present SchWeightedGraph(FreeSchema) begin
   V::Ob
   E::Ob
   src::Hom(E,V)
@@ -78,7 +78,7 @@ end
 # Construct the type used to store acsets on the previous schema
 # We *index* src and tgt, which means that we store not only
 # the forwards map, but also the backwards map.
-@acset_type WeightedGraph(TheoryWeightedGraph, index=[:src,:tgt])
+@acset_type WeightedGraph(SchWeightedGraph, index=[:src,:tgt])
 
 # Construct a weighted graph, with floats as edge weights
 g = @acset WeightedGraph{Float64} begin

--- a/src/categorical_algebra/CatElements.jl
+++ b/src/categorical_algebra/CatElements.jl
@@ -1,5 +1,5 @@
 module CatElements
-export ThElements, AbstractElements, Elements, elements, inverse_elements
+export SchElements, AbstractElements, Elements, elements, inverse_elements
 
 using DataStructures: OrderedDict
 
@@ -7,7 +7,7 @@ using ..CSets, ..FinSets
 using ...Present, ...Theories
 using ...Theories: Category, ob, hom, dom_nums, codom_nums
 
-@present ThElements(FreeSchema) begin
+@present SchElements(FreeSchema) begin
   (El, Arr, Ob, Hom)::Ob
   Name::AttrType
   src::Hom(Arr, El)
@@ -24,7 +24,7 @@ using ...Theories: Category, ob, hom, dom_nums, codom_nums
 end
 
 @abstract_acset_type AbstractElements
-@acset_type Elements(ThElements, index=[:src, :tgt, :πₑ, :πₐ]) <: AbstractElements
+@acset_type Elements(SchElements, index=[:src, :tgt, :πₑ, :πₐ]) <: AbstractElements
 
 """    elements(X::AbstractACSet)
 

--- a/src/categorical_algebra/FreeDiagrams.jl
+++ b/src/categorical_algebra/FreeDiagrams.jl
@@ -6,7 +6,8 @@ pairs of objects, discrete diagrams, parallel pairs, composable pairs, and spans
 and cospans. Limits and colimits are most commonly taken over free diagrams.
 """
 module FreeDiagrams
-export FreeDiagram, BipartiteFreeDiagram, FixedShapeFreeDiagram,
+export FixedShapeFreeDiagram, FreeDiagram, SchFreeDiagram,
+  BipartiteFreeDiagram, SchBipartiteFreeDiagram,
   DiscreteDiagram, EmptyDiagram, SingletonDiagram, ObjectPair,
   Span, Cospan, Multispan, Multicospan, SMultispan, SMulticospan,
   ParallelPair, ParallelMorphisms, ComposablePair, ComposableMorphisms,
@@ -22,8 +23,6 @@ using StaticArrays: StaticVector, SVector
 
 using ...Present, ...Theories, ...CSetDataStructures, ...Graphs, ..FinCats
 import ...Theories: ob, hom, dom, codom, left, right
-using ...Graphs.BasicGraphs: TheoryGraph
-using ...Graphs.BipartiteGraphs: TheoryUndirectedBipartiteGraph
 import ..FinCats: FreeCatGraph, FinDomFunctor, collect_ob, collect_hom
 
 # Diagram interface
@@ -336,7 +335,7 @@ Colimits are dual.
 """
 const BipartiteFreeDiagram{Ob,Hom,S} = _BipartiteFreeDiagram{S,Tuple{Ob,Hom}}
 
-@present TheoryBipartiteFreeDiagram <: TheoryUndirectedBipartiteGraph begin
+@present SchBipartiteFreeDiagram <: SchUndirectedBipartiteGraph begin
   Ob::AttrType
   Hom::AttrType
   ob₁::Attr(V₁, Ob)
@@ -346,10 +345,10 @@ end
 
 """ The default concrete type for bipartite free diagrams.
 """
-@acset_type BasicBipartiteFreeDiagram(TheoryBipartiteFreeDiagram,
+@acset_type BasicBipartiteFreeDiagram(SchBipartiteFreeDiagram,
   index=[:src, :tgt]) <: _BipartiteFreeDiagram
 
-@present TheoryFreeDiagramAsBipartite <: TheoryBipartiteFreeDiagram begin
+@present SchFreeDiagramAsBipartite <: SchBipartiteFreeDiagram begin
   V::Ob
   orig_vert₁::Hom(V₁, V)
   orig_vert₂::Hom(V₂, V)
@@ -357,7 +356,7 @@ end
 
 """ A free diagram that has been converted to a bipartite free diagram.
 """
-@acset_type FreeDiagramAsBipartite(TheoryFreeDiagramAsBipartite,
+@acset_type FreeDiagramAsBipartite(SchFreeDiagramAsBipartite,
   index=[:src, :tgt], unique_index=[:orig_vert₁, :orig_vert₂]) <: _BipartiteFreeDiagram
 
 ob₁(d::BipartiteFreeDiagram, args...) = subpart(d, args..., :ob₁)
@@ -464,7 +463,7 @@ BipartiteFreeDiagram(F::Functor{<:FinCat{Int},<:Cat{Ob,Hom}}; kw...) where {Ob,H
 # Free diagrams
 #--------------
 
-@present TheoryFreeDiagram <: TheoryGraph begin
+@present SchFreeDiagram <: SchGraph begin
   Ob::AttrType
   Hom::AttrType
   ob::Attr(V,Ob)
@@ -473,7 +472,7 @@ end
 
 @abstract_acset_type AbstractFreeDiagram <: AbstractGraph
 
-@acset_type FreeDiagram(TheoryFreeDiagram, index=[:src,:tgt]) <:
+@acset_type FreeDiagram(SchFreeDiagram, index=[:src,:tgt]) <:
   AbstractFreeDiagram
 
 ob(d::AbstractFreeDiagram, args...) = subpart(d, args..., :ob)

--- a/src/graphs/BipartiteGraphs.jl
+++ b/src/graphs/BipartiteGraphs.jl
@@ -8,9 +8,10 @@ shorter and more familiar.
 """
 module BipartiteGraphs
 export HasBipartiteVertices, HasBipartiteGraph,
-  AbstractUndirectedBipartiteGraph, UndirectedBipartiteGraph,
-  AbstractBipartiteGraph, BipartiteGraph, nv₁, nv₂, vertices₁, vertices₂,
-  ne₁₂, ne₂₁, edges₁₂, edges₂₁, src₁, src₂, tgt₁, tgt₂,
+  AbstractUndirectedBipartiteGraph, UndirectedBipartiteGraph, SchUndirectedBipartiteGraph,
+  AbstractBipartiteGraph, BipartiteGraph, SchBipartiteGraph,
+  nv₁, nv₂, vertices₁, vertices₂, ne₁₂, ne₂₁, edges₁₂, edges₂₁,
+  src₁, src₂, tgt₁, tgt₂,
   add_vertex₁!, add_vertex₂!, add_vertices₁!, add_vertices₂!,
   rem_vertex₁!, rem_vertex₂!, rem_vertices₁!, rem_vertices₂!,
   add_edge₁₂!, add_edge₂₁!, add_edges₁₂!, add_edges₂₁!,
@@ -18,7 +19,6 @@ export HasBipartiteVertices, HasBipartiteGraph,
 
 using ...Present, ...CSetDataStructures
 using ..BasicGraphs: flatten
-using ...Theories
 import ..BasicGraphs: nv, ne, vertices, edges, src, tgt, add_edge!, add_edges!,
   rem_edge!, rem_edges!, inneighbors, outneighbors
 
@@ -36,7 +36,7 @@ import ..BasicGraphs: nv, ne, vertices, edges, src, tgt, add_edge!, add_edges!,
 # Undirected bipartite graphs
 #############################
 
-@present TheoryUndirectedBipartiteGraph(FreeSchema) begin
+@present SchUndirectedBipartiteGraph(FreeSchema) begin
   (V₁, V₂)::Ob
   E::Ob
   src::Hom(E, V₁)
@@ -53,7 +53,7 @@ It is a matter of perspective whether to consider such graphs "undirected," in
 the sense that the edges have no orientation, or "unidirected," in the sense
 that all edges go from vertices of type 1 to vertices of type 2.
 """
-@acset_type UndirectedBipartiteGraph(TheoryUndirectedBipartiteGraph, index=[:src, :tgt]) <:
+@acset_type UndirectedBipartiteGraph(SchUndirectedBipartiteGraph, index=[:src, :tgt]) <:
   AbstractUndirectedBipartiteGraph
 
 function (::Type{T})(nv₁::Int, nv₂::Int) where T <: HasBipartiteVertices
@@ -159,7 +159,7 @@ outneighbors(g::AbstractUndirectedBipartiteGraph, v::Int) =
 # Bipartite graphs
 ##################
 
-@present TheoryBipartiteGraph(FreeSchema) begin
+@present SchBipartiteGraph(FreeSchema) begin
   (V₁, V₂)::Ob
   (E₁₂, E₂₁)::Ob
   src₁::Hom(E₁₂, V₁)
@@ -178,7 +178,7 @@ multigraph](https://cs.stackexchange.com/a/91521).
 Directed bipartite graphs are isomorphic to port hypergraphs and to whole grain
 Petri nets.
 """
-@acset_type BipartiteGraph(TheoryBipartiteGraph, index=[:src₁, :src₂, :tgt₁, :tgt₂]) <:
+@acset_type BipartiteGraph(SchBipartiteGraph, index=[:src₁, :src₂, :tgt₁, :tgt₂]) <:
   AbstractBipartiteGraph
 
 """ Number of edges from V₁ to V₂ in a bipartite graph.

--- a/src/graphs/PropertyGraphs.jl
+++ b/src/graphs/PropertyGraphs.jl
@@ -1,11 +1,11 @@
 module PropertyGraphs
-export AbstractPropertyGraph, PropertyGraph, SymmetricPropertyGraph,
-  ReflexiveEdgePropertyGraph,
+export AbstractPropertyGraph, PropertyGraph, SchPropertyGraph,
+  SymmetricPropertyGraph, SchSymmetricPropertyGraph,
+  ReflexiveEdgePropertyGraph, SchReflexivePropertyGraph,
   gprops, vprops, eprops, get_gprop, get_vprop, get_eprop,
   set_gprop!, set_vprop!, set_eprop!, set_gprops!, set_vprops!, set_eprops!
 
 using ...Present, ...CSetDataStructures, ..BasicGraphs
-using ..BasicGraphs: TheoryGraph, TheorySymmetricGraph, TheoryReflexiveGraph
 import ..BasicGraphs: nv, ne, src, tgt, inv, edges, vertices,
   has_edge, has_vertex, add_edge!, add_edges!, add_vertex!, add_vertices!
 
@@ -18,7 +18,7 @@ Concrete types are [`PropertyGraph`](@ref) and [`SymmetricPropertyGraph`](@ref).
 """
 abstract type AbstractPropertyGraph{T} end
 
-@present TheoryPropertyGraph <: TheoryGraph begin
+@present SchPropertyGraph <: SchGraph begin
   Props::AttrType
   vprops::Attr(V,Props)
   eprops::Attr(E,Props)
@@ -28,7 +28,7 @@ end
 
 const _AbstractPropertyGraph{T} = __AbstractPropertyGraph{S, Tuple{Dict{Symbol,T}}} where {S}
 
-@acset_type __PropertyGraph(TheoryPropertyGraph, index=[:src,:tgt]) <: __AbstractPropertyGraph
+@acset_type __PropertyGraph(SchPropertyGraph, index=[:src,:tgt]) <: __AbstractPropertyGraph
 
 const _PropertyGraph{T} = __PropertyGraph{Dict{Symbol,T}}
 
@@ -50,7 +50,7 @@ PropertyGraph{T,G}(; kw...) where {T,G<:_AbstractPropertyGraph{T}} =
   PropertyGraph(G(), Dict{Symbol,T}(kw...))
 PropertyGraph{T}(; kw...) where T = PropertyGraph{T,_PropertyGraph{T}}(; kw...)
 
-@present TheorySymmetricPropertyGraph <: TheorySymmetricGraph begin
+@present SchSymmetricPropertyGraph <: SchSymmetricGraph begin
   Props::AttrType
   vprops::Attr(V,Props)
   eprops::Attr(E,Props)
@@ -62,7 +62,7 @@ end
 
 const _AbstractSymmetricPropertyGraph{T} = __AbstractSymmetricPropertyGraph{S, Tuple{Dict{Symbol,T}}} where {S}
 
-@acset_type __SymmetricPropertyGraph(TheorySymmetricPropertyGraph, index=[:src,:tgt]) <:
+@acset_type __SymmetricPropertyGraph(SchSymmetricPropertyGraph, index=[:src,:tgt]) <:
   __AbstractSymmetricPropertyGraph
 
 const _SymmetricPropertyGraph{T} = __SymmetricPropertyGraph{Dict{Symbol,T}}
@@ -86,15 +86,14 @@ SymmetricPropertyGraph{T}(; kw...) where T =
   SymmetricPropertyGraph{T,_SymmetricPropertyGraph{T}}(; kw...)
 
 
-
-@present TheoryReflexiveEdgePropertyGraph <: TheoryReflexiveGraph begin
+@present SchReflexiveEdgePropertyGraph <: SchReflexiveGraph begin
   Props::AttrType
   eprops::Attr(E,Props)
 end
 
 @abstract_acset_type AbstractReflexiveEdgePropertyGraph <: HasGraph
-@acset_type ReflexiveEdgePropertyGraph(TheoryReflexiveEdgePropertyGraph, index=[:src,:tgt]) <:
-AbstractReflexiveEdgePropertyGraph
+@acset_type ReflexiveEdgePropertyGraph(SchReflexiveEdgePropertyGraph, index=[:src,:tgt]) <:
+  AbstractReflexiveEdgePropertyGraph
 
 # Accessors and mutators
 ########################

--- a/src/programs/DiagrammaticPrograms.jl
+++ b/src/programs/DiagrammaticPrograms.jl
@@ -15,14 +15,13 @@ using ...GAT, ...Present, ...Graphs, ...CategoricalAlgebra
 using ...Theories: munit
 using ...CategoricalAlgebra.FinCats: mapvals, make_map
 using ...CategoricalAlgebra.DataMigrations: ConjQuery, GlueQuery, GlucQuery
-using ...Graphs.BasicGraphs: TheoryGraph
 import ...CategoricalAlgebra.FinCats: vertex_name, vertex_named,
   edge_name, edge_named
 
 # Graphs
 ########
 
-@present TheoryNamedGraph <: TheoryGraph begin
+@present SchNamedGraph <: SchGraph begin
   VName::AttrType
   EName::AttrType
   vname::Attr(V, VName)
@@ -38,7 +37,7 @@ end
 The default graph type used by [`@graph`](@ref), [`@fincat`](@ref),
 [`@diagram`](@ref), and related macros.
 """
-@acset_type NamedGraph(TheoryNamedGraph, index=[:src,:tgt,:ename],
+@acset_type NamedGraph(SchNamedGraph, index=[:src,:tgt,:ename],
                        unique_index=[:vname]) <: AbstractNamedGraph
 # FIXME: The edge name should also be uniquely indexed, but this currently
 # doesn't play nicely with nullable attributes.
@@ -203,7 +202,7 @@ category. For example, the following functor embeds the schema for graphs into
 the schema for circular port graphs by ignoring the ports:
 
 ```julia
-@finfunctor TheoryGraph ThCPortGraph begin
+@finfunctor SchGraph SchCPortGraph begin
   V => Box
   E => Wire
   src => src ⨟ box
@@ -321,7 +320,7 @@ As an example, the limit of the following diagram consists of the paths of
 length two in a graph:
 
 ```julia
-@diagram TheoryGraph begin
+@diagram SchGraph begin
   v::V
   (e₁, e₂)::E
   (t: e₁ → v)::tgt
@@ -334,7 +333,7 @@ defining free diagrams (see also [`@free_diagram`](@ref)). For example, the
 following diagram is isomorphic to the previous one:
 
 ```julia
-@diagram TheoryGraph begin
+@diagram SchGraph begin
   v::V
   (e₁, e₂)::E
   (e₁ → v)::tgt
@@ -360,7 +359,7 @@ introduce anonymous morphisms in a "pointful" style. For example, the limit of
 the following diagram consists of the paths of length two in a graph:
 
 ```julia
-@free_diagram TheoryGraph begin
+@free_diagram SchGraph begin
   v::V
   (e₁, e₂)::E
   tgt(e₁) == v
@@ -372,7 +371,7 @@ Anonymous objects can also be introduced. For example, the previous diagram is
 isomorphic to this one:
 
 ```julia
-@free_diagram TheoryGraph begin
+@free_diagram SchGraph begin
   (e₁, e₂)::E
   tgt(e₁) == src(e₂)
 end

--- a/src/programs/RelationalPrograms.jl
+++ b/src/programs/RelationalPrograms.jl
@@ -2,13 +2,14 @@
 """
 module RelationalPrograms
 export RelationDiagram, UntypedRelationDiagram, TypedRelationDiagram,
+  SchRelationDiagram, SchTypedRelationDiagram,
+  SchNamedRelationDiagram, SchTypedNamedRelationDiagram,
   @relation, parse_relation_diagram
 
 using MLStyle: @match
 
 using ...CategoricalAlgebra.CSets, ...Present
 using ...WiringDiagrams.UndirectedWiringDiagrams
-using ...WiringDiagrams.UndirectedWiringDiagrams: TheoryUWD, TheoryTypedUWD
 
 # Data types
 ############
@@ -29,36 +30,36 @@ const UntypedRelationDiagram{Name,VarName} =
 const TypedRelationDiagram{T,Name,VarName} =
   _TypedRelationDiagram{S, Tuple{T,Name,VarName}} where S
 
-@present TheoryRelationDiagram <: TheoryUWD begin
+@present SchRelationDiagram <: SchUWD begin
   (Name, VarName)::AttrType
   name::Attr(Box, Name)
   variable::Attr(Junction, VarName)
 end
 
-@present TheoryTypedRelationDiagram <: TheoryTypedUWD begin
+@present SchTypedRelationDiagram <: SchTypedUWD begin
   (Name, VarName)::AttrType
   name::Attr(Box, Name)
   variable::Attr(Junction, VarName)
 end
 
-@acset_type UntypedUnnamedRelationDiagram(TheoryRelationDiagram,
+@acset_type UntypedUnnamedRelationDiagram(SchRelationDiagram,
   index=[:box, :junction, :outer_junction], unique_index=[:variable]) <: _UntypedRelationDiagram
-@acset_type TypedUnnamedRelationDiagram(TheoryTypedRelationDiagram,
+@acset_type TypedUnnamedRelationDiagram(SchTypedRelationDiagram,
   index=[:box, :junction, :outer_junction], unique_index=[:variable]) <: _TypedRelationDiagram
 
-@present TheoryNamedRelationDiagram <: TheoryRelationDiagram begin
+@present SchNamedRelationDiagram <: SchRelationDiagram begin
   port_name::Attr(Port, Name)
   outer_port_name::Attr(OuterPort, Name)
 end
 
-@present TheoryTypedNamedRelationDiagram <: TheoryTypedRelationDiagram begin
+@present SchTypedNamedRelationDiagram <: SchTypedRelationDiagram begin
   port_name::Attr(Port, Name)
   outer_port_name::Attr(OuterPort, Name)
 end
 
-@acset_type UntypedNamedRelationDiagram(TheoryNamedRelationDiagram,
+@acset_type UntypedNamedRelationDiagram(SchNamedRelationDiagram,
   index=[:box, :junction, :outer_junction], unique_index=[:variable]) <: _UntypedRelationDiagram
-@acset_type TypedNamedRelationDiagram(TheoryTypedNamedRelationDiagram,
+@acset_type TypedNamedRelationDiagram(SchTypedNamedRelationDiagram,
   index=[:box, :junction, :outer_junction], unique_index=[:variable]) <: _TypedRelationDiagram
 
 function UntypedRelationDiagram{Name,VarName}(

--- a/src/wiring_diagrams/Algebras.jl
+++ b/src/wiring_diagrams/Algebras.jl
@@ -10,7 +10,6 @@ using ...Theories: dom_nums, codom_nums, attr, adom, adom_nums
 using ...CategoricalAlgebra
 import ...CategoricalAlgebra.CSets: homomorphisms, homomorphism, is_homomorphic
 using ..UndirectedWiringDiagrams
-using ..UndirectedWiringDiagrams: TheoryUWD
 
 """ Compose morphisms according to UWD.
 
@@ -232,12 +231,12 @@ function homomorphism_query(X::StructACSet{S}; count::Bool=false) where S
   (diagram, params)
 end
 
-@present TheoryHomomorphismQueryDiagram <: TheoryUWD begin
+@present SchHomomorphismQueryDiagram <: SchUWD begin
   Name::AttrType
   name::Attr(Box, Name)
   port_name::Attr(Port, Name)
 end
-@acset_type HomomorphismQueryDiagram(TheoryHomomorphismQueryDiagram,
+@acset_type HomomorphismQueryDiagram(SchHomomorphismQueryDiagram,
   index=[:box, :junction, :outer_junction]) <: UndirectedWiringDiagram
 
 function homomorphisms(X::ACSet, Y::ACSet, ::HomomorphismQuery)

--- a/src/wiring_diagrams/CPortGraphs.jl
+++ b/src/wiring_diagrams/CPortGraphs.jl
@@ -1,15 +1,14 @@
 module CPortGraphs
-export ThCPortGraph, ThOpenCPortGraph, ThSymCPortGraph, ThOpenSymCPortGraph,
+export SchCPortGraph, SchOpenCPortGraph, SchSymCPortGraph, SchOpenSymCPortGraph,
   CPortGraph, OpenCPortGraph, SymCPortGraph, OpenSymCPortGraph,
   ThBundledCPG, BundledCPG
 
 using ...Theories, ...Present,  ...CategoricalAlgebra
 import ...CategoricalAlgebra: migrate!
 using ...Graphs
-import ...Graphs.BasicGraphs: TheoryGraph
 import ..DirectedWiringDiagrams: ocompose
 
-@present ThCPortGraph(FreeSchema) begin
+@present SchCPortGraph(FreeSchema) begin
   Box::Ob
   Port::Ob
   Wire::Ob
@@ -19,12 +18,12 @@ import ..DirectedWiringDiagrams: ocompose
   box::Hom(Port, Box)
 end
 
-@present ThOpenCPortGraph <: ThCPortGraph begin
+@present SchOpenCPortGraph <: SchCPortGraph begin
   OuterPort::Ob
   con::Hom(OuterPort, Port)
 end
 
-@present ThSymCPortGraph <: ThCPortGraph begin
+@present SchSymCPortGraph <: SchCPortGraph begin
   inv::Hom(Wire, Wire)
 
   compose(inv,inv) == id(Wire)
@@ -32,7 +31,7 @@ end
   compose(inv,tgt) == src
 end
 
-@present ThOpenSymCPortGraph <: ThSymCPortGraph begin
+@present SchOpenSymCPortGraph <: SchSymCPortGraph begin
   OuterPort::Ob
   con::Hom(OuterPort, Port)
 end
@@ -47,7 +46,7 @@ Circular port graphs consist of boxes with ports connected by directed wires.
 The ports are not seperated into inputs and outputs, so the "boxes" are actually
 circular, hence the name.
 """
-@acset_type CPortGraph(ThCPortGraph, index=[:box, :src, :tgt]) <: AbstractCPortGraph
+@acset_type CPortGraph(SchCPortGraph, index=[:box, :src, :tgt]) <: AbstractCPortGraph
 
 """ Abstract type for open circular port graphs.
 """
@@ -59,13 +58,13 @@ Open circular port graphs are circular port graphs with a distinguished set of
 outer ports. They have a natural operad structure and can be seen as a
 specialization of directed wiring diagrams.
 """
-@acset_type OpenCPortGraph(ThOpenCPortGraph, index=[:box, :src, :tgt]) <: AbstractOpenCPortGraph
+@acset_type OpenCPortGraph(SchOpenCPortGraph, index=[:box, :src, :tgt]) <: AbstractOpenCPortGraph
 
 @abstract_acset_type AbstractSymCPortGraph <: AbstractCPortGraph
-@acset_type SymCPortGraph(ThSymCPortGraph, index=[:box, :src]) <: AbstractSymCPortGraph
+@acset_type SymCPortGraph(SchSymCPortGraph, index=[:box, :src]) <: AbstractSymCPortGraph
 
 @abstract_acset_type AbstractOpenSymCPortGraph <: AbstractSymCPortGraph
-@acset_type OpenSymCPortGraph(ThOpenSymCPortGraph, index=[:box, :src]) <: AbstractOpenSymCPortGraph
+@acset_type OpenSymCPortGraph(SchOpenSymCPortGraph, index=[:box, :src]) <: AbstractOpenSymCPortGraph
 const OSCPGraph = OpenSymCPortGraph
 
 function OpenCPortGraph(g::AbstractCPortGraph)
@@ -77,8 +76,8 @@ end
 function migrate!(g::AbstractGraph, cpg::AbstractCPortGraph)
   migrate!(g, cpg,
     Dict(:E=>:Wire, :V=>:Box),
-    Dict(:src=>compose(ThCPortGraph[:src], ThCPortGraph[:box]),
-         :tgt=>compose(ThCPortGraph[:tgt], ThCPortGraph[:box])))
+    Dict(:src=>compose(SchCPortGraph[:src], SchCPortGraph[:box]),
+         :tgt=>compose(SchCPortGraph[:tgt], SchCPortGraph[:box])))
 end
 
 function migrate!(pg::AbstractCPortGraph, opg::AbstractOpenCPortGraph)
@@ -91,9 +90,9 @@ function migrate!(pg::AbstractCPortGraph, g::AbstractGraph)
   migrate!(pg, g,
     Dict(:Box=>:V, :Port=>:V, :Wire=>:E),
     Dict(
-      :box=>id(TheoryGraph[:V]),
-      :src=>TheoryGraph[:src],
-      :tgt=>TheoryGraph[:tgt],
+      :box=>id(SchGraph[:V]),
+      :src=>SchGraph[:src],
+      :tgt=>SchGraph[:tgt],
     )
   )
 end
@@ -105,7 +104,7 @@ function migrate!(og::AbstractOpenCPortGraph, g::AbstractCPortGraph)
       :src=>:src,
       :tgt=>:tgt,
       :box=>:box,
-      :con=>id(ThCPortGraph[:Port]),
+      :con=>id(SchCPortGraph[:Port]),
     )
   )
 end
@@ -116,10 +115,10 @@ function migrate!(pg::AbstractSymCPortGraph, g::AbstractSymmetricGraph)
   migrate!(pg, g,
     Dict(:Box=>:V, :Port=>:V, :Wire=>:E),
     Dict(
-      :box=>id(TheorySymmetricGraph[:V]),
-      :src=>id(TheorySymmetricGraph[:src]),
-      :tgt=>id(TheorySymmetricGraph[:tgt]),
-      :inv=>TheorySymmetricGraph[:inv],
+      :box=>id(SchSymmetricGraph[:V]),
+      :src=>id(SchSymmetricGraph[:src]),
+      :tgt=>id(SchSymmetricGraph[:tgt]),
+      :inv=>SchSymmetricGraph[:inv],
     )
   )
 end
@@ -147,7 +146,7 @@ function ocompose(g::AbstractOpenCPortGraph, xs::Vector)
   return sum
 end
 
-@present ThBundledCPG <: ThOpenCPortGraph begin
+@present ThBundledCPG <: SchOpenCPortGraph begin
   Bundle::Ob
   bun::Hom(OuterPort, Bundle)
 end
@@ -160,7 +159,7 @@ function migrate!(b::AbstractBundledCPG, g::AbstractOpenCPortGraph)
     Dict(:Box=>:Box, :Port=>:Port, :Wire=>:Wire, :OuterPort=>:OuterPort,
          :Bundle=>:OuterPort),
     Dict(:src=>:src, :tgt=>:tgt, :box=>:box,
-         :con=>:con, :bun=>id(ThOpenCPortGraph[:OuterPort])))
+         :con=>:con, :bun=>id(SchOpenCPortGraph[:OuterPort])))
 end
 
 function BundledCPG(g::AbstractOpenCPortGraph)

--- a/src/wiring_diagrams/Directed.jl
+++ b/src/wiring_diagrams/Directed.jl
@@ -16,8 +16,9 @@ representation that can be serialized to and from GraphML or translated into
 Graphviz or other declarative diagram languages.
 """
 module DirectedWiringDiagrams
-export AbstractBox, Box, WiringDiagram, Wire, Port, PortKind,
-  InputPort, OutputPort, input_ports, output_ports,
+export AbstractBox, Box, WiringDiagram, SchWiringDiagram,
+  SchTypedWiringDiagram, SchAttributedWiringDiagram,
+  Wire, Port, PortKind, InputPort, OutputPort, input_ports, output_ports,
   set_input_ports!, set_output_ports!, add_input_ports!, add_output_ports!,
   input_id, output_id, outer_ids, boxes, box_ids, nboxes, nwires, box, wires,
   has_wire, graph, internal_graph,
@@ -32,7 +33,6 @@ using AutoHashEquals
 using ...Present, ...Graphs.BasicGraphs, ...CategoricalAlgebra.CSets
 import ...CategoricalAlgebra.CSets: is_isomorphic
 import ...CategoricalAlgebra.FinCats: graph
-using ...Graphs.BasicGraphs: TheoryGraph
 import ...Graphs: all_neighbors, neighbors, outneighbors, inneighbors
 
 # Data types
@@ -137,7 +137,7 @@ function Base.show(io::IO, box::Box)
   print(io, "])")
 end
 
-@present TheoryWiringDiagram(FreeSchema) begin
+@present SchWiringDiagram(FreeSchema) begin
   Box::Ob
   (InPort, OutPort, OuterInPort, OuterOutPort)::Ob
   (Wire, InWire, OutWire, PassWire)::Ob
@@ -157,7 +157,7 @@ end
 
 @abstract_acset_type AbstractWiringDiagram <: AbstractGraph
 
-@present TheoryTypedWiringDiagram <: TheoryWiringDiagram begin
+@present SchTypedWiringDiagram <: SchWiringDiagram begin
   PortValue::AttrType
   in_port_type::Attr(InPort, PortValue)
   out_port_type::Attr(OutPort, PortValue)
@@ -165,7 +165,7 @@ end
   outer_out_port_type::Attr(OuterOutPort, PortValue)
 end
 
-@present TheoryAttributedWiringDiagram <: TheoryTypedWiringDiagram begin
+@present SchAttributedWiringDiagram <: SchTypedWiringDiagram begin
   WireValue::AttrType
   BoxValue::AttrType
   BoxType::AttrType
@@ -178,7 +178,7 @@ end
   pass_wire_value::Attr(PassWire, WireValue)
 end
 
-@acset_type WiringDiagramACSet(TheoryAttributedWiringDiagram,
+@acset_type WiringDiagramACSet(SchAttributedWiringDiagram,
   index=[:src, :tgt, :in_src, :in_tgt, :out_src, :out_tgt, :pass_src, :pass_tgt]) <: AbstractWiringDiagram
 
 """ A directed wiring diagram, also known as a string diagram.
@@ -264,7 +264,7 @@ function Base.show(io::IO, diagram::WiringDiagram{T}) where T
   print(io, ")")
 end
 
-@present TheoryWiringDiagramGraph <: TheoryGraph begin
+@present SchWiringDiagramGraph <: SchGraph begin
   ID::AttrType
   box::Attr(V,ID)
   wire::Attr(E,ID)
@@ -272,7 +272,7 @@ end
 
 """ Graph underlying a directed wiring diagram.
 """
-@acset_type WiringDiagramGraphACSet(TheoryWiringDiagramGraph,
+@acset_type WiringDiagramGraphACSet(SchWiringDiagramGraph,
   index=[:src, :tgt], unique_index=[:box]) <: AbstractWiringDiagram
 const WiringDiagramGraph = WiringDiagramGraphACSet{Int}
 

--- a/src/wiring_diagrams/MonoidalUndirected.jl
+++ b/src/wiring_diagrams/MonoidalUndirected.jl
@@ -1,7 +1,8 @@
 """ Undirected wiring diagrams as SMCs and hypergraph categories.
 """
 module MonoidalUndirectedWiringDiagrams
-export HypergraphDiagram, HypergraphDiagramOb, HypergraphDiagramHom,
+export HypergraphDiagram, SchUntypedHypergraphDiagram, SchHypergraphDiagram,
+  HypergraphDiagramOb, HypergraphDiagramHom,
   ObUWD, HomUWD, cospan_action, dom_mask, codom_mask
 
 using AutoHashEquals
@@ -12,13 +13,12 @@ import ...Theories: dom, codom, compose, id, ⋅, ∘, otimes, ⊗, munit, braid
   mcopy, Δ, mmerge, ∇, delete, ◊, create, □, dunit, dcounit, dagger
 using ...CategoricalAlgebra.CSets: disjoint_union
 using ..UndirectedWiringDiagrams
-using ..UndirectedWiringDiagrams: AbstractUWD, TheoryUWD, TheoryTypedUWD
 import ..UndirectedWiringDiagrams: singleton_diagram, junction_diagram
 
 # Data types
 ############
 
-@present TheoryUntypedHypergraphDiagram <: TheoryUWD begin
+@present SchUntypedHypergraphDiagram <: SchUWD begin
   Name::AttrType
   name::Attr(Box, Name)
 end
@@ -28,10 +28,10 @@ end
 By "single-sorted", we mean that the monoid of objects is free on one generator.
 See [`HypergraphDiagram`](@ref) for the more standard case.
 """
-@acset_type UntypedHypergraphDiagram(TheoryUntypedHypergraphDiagram, 
+@acset_type UntypedHypergraphDiagram(SchUntypedHypergraphDiagram,
   index=[:box, :junction, :outer_junction]) <: AbstractUWD
 
-@present TheoryHypergraphDiagram <: TheoryTypedUWD begin
+@present SchHypergraphDiagram <: SchTypedUWD begin
   Name::AttrType
   name::Attr(Box, Name)
 end
@@ -41,7 +41,7 @@ end
 An undirected wiring diagram where the ports and junctions are typed and the
 boxes have names identifying the morphisms.
 """
-@acset_type HypergraphDiagram(TheoryHypergraphDiagram,
+@acset_type HypergraphDiagram(SchHypergraphDiagram,
   index=[:box, :junction, :outer_junction]) <: AbstractUWD
 
 # Cospan algebra

--- a/src/wiring_diagrams/ScheduleUndirected.jl
+++ b/src/wiring_diagrams/ScheduleUndirected.jl
@@ -13,7 +13,7 @@ using DataStructures: IntDisjointSets, union!, in_same_set
 
 using ...Present, ...CategoricalAlgebra.CSets, ...CategoricalAlgebra.FinSets
 using ..UndirectedWiringDiagrams, ..WiringDiagramAlgebras
-using ..UndirectedWiringDiagrams: TheoryUWD, flat
+using ..UndirectedWiringDiagrams: flat
 
 # Data types
 ############
@@ -24,7 +24,7 @@ This type includes [`ScheduledUWD`](@ref) and [`NestedUWD`](@ref).
 """
 @abstract_acset_type HasScheduledUWD <: HasUWD
 
-@present TheoryScheduledUWD <: TheoryUWD begin
+@present SchScheduledUWD <: SchUWD begin
   Composite::Ob
 
   parent::Hom(Composite, Composite)
@@ -44,7 +44,7 @@ diagram's boxes.
 
 See also: [`NestedUWD`](@ref).
 """
-@acset_type ScheduledUWD(TheoryScheduledUWD,
+@acset_type ScheduledUWD(SchScheduledUWD,
   index=[:box, :junction, :outer_junction, :parent, :box_parent]) <: AbstractScheduledUWD
 
 ncomposites(x::HasScheduledUWD) = nparts(x, :Composite)
@@ -59,7 +59,7 @@ box_children(x::HasScheduledUWD, args...) = incident(x, args..., :box_parent)
 """
 @abstract_acset_type HasNestedUWD <: HasScheduledUWD
 
-@present TheoryNestedUWD <: TheoryScheduledUWD begin
+@present SchNestedUWD <: SchScheduledUWD begin
   CompositePort::Ob
 
   composite::Hom(CompositePort, Composite)
@@ -78,7 +78,7 @@ Nested UWDs are very similar but not quite identical to Robin Milner's
 
 See also: [`ScheduledUWD`](@ref).
 """
-@acset_type NestedUWD(TheoryNestedUWD,
+@acset_type NestedUWD(SchNestedUWD,
   index=[:box, :junction, :outer_junction,
          :composite, :composite_junction, :parent, :box_parent]) <: AbstractNestedUWD
 

--- a/src/wiring_diagrams/Undirected.jl
+++ b/src/wiring_diagrams/Undirected.jl
@@ -1,7 +1,8 @@
 """ Data structure for undirected wiring diagrams.
 """
 module UndirectedWiringDiagrams
-export UndirectedWiringDiagram, HasUWD, AbstractUWD, UntypedUWD, TypedUWD,
+export UndirectedWiringDiagram, HasUWD,
+  AbstractUWD, UntypedUWD, TypedUWD, SchUWD, SchTypedUWD,
   outer_box, box, junction, nboxes, njunctions, boxes, junctions,
   ports, ports_with_junction, junction_type, port_type,
   add_box!, add_junction!, add_junctions!, set_junction!, add_wire!,
@@ -23,7 +24,7 @@ This type includes UWDs, scheduled UWDs, and nested UWDs.
 """
 @abstract_acset_type HasUWD
 
-@present TheoryUWD(FreeSchema) begin
+@present SchUWD(FreeSchema) begin
   Box::Ob
   Port::Ob
   OuterPort::Ob
@@ -43,10 +44,10 @@ const UndirectedWiringDiagram = AbstractUWD
 
 The most basic kind of UWD, without types or other extra attributes.
 """
-@acset_type UntypedUWD(TheoryUWD, 
+@acset_type UntypedUWD(SchUWD,
   index=[:box, :junction, :outer_junction]) <: AbstractUWD
 
-@present TheoryTypedUWD <: TheoryUWD begin
+@present SchTypedUWD <: SchUWD begin
   Type::AttrType
 
   port_type::Attr(Port, Type)
@@ -61,7 +62,7 @@ end
 
 A UWD whose ports and junctions must be compatibly typed.
 """
-@acset_type TypedUWD(TheoryTypedUWD, 
+@acset_type TypedUWD(SchTypedUWD,
   index=[:box, :junction, :outer_junction]) <: AbstractUWD
 
 function (::Type{UWD})(nports::Int) where UWD <: AbstractUWD

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -9,13 +9,13 @@ using Tables
 # Discrete dynamical systems
 ############################
 
-@present SchemaDDS(FreeSchema) begin
+@present SchDDS(FreeSchema) begin
   X::Ob
   Φ::Hom(X,X)
 end
 
 @abstract_acset_type AbstractDDS
-@acset_type DDS(SchemaDDS, index=[:Φ]) <: AbstractDDS
+@acset_type DDS(SchDDS, index=[:Φ]) <: AbstractDDS
 @test DDS <: AbstractDDS
 @test DDS <: StructACSet
 @test DDS <: StructCSet
@@ -112,7 +112,7 @@ add_parts!(dds, :X, 3, Φ=[1,1,1])
 @test incident(dds, 3, :Φ) == []
 
 # Incidence without indexing.
-@acset_type UnindexedDDS(SchemaDDS)
+@acset_type UnindexedDDS(SchDDS)
 dds = UnindexedDDS()
 add_parts!(dds, :X, 4, Φ=[3,3,4,4])
 # @test isempty(keys(dds.indices))

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -9,13 +9,13 @@ using Tables
 # Discrete dynamical systems
 ############################
 
-@present TheoryDDS(FreeSchema) begin
+@present SchemaDDS(FreeSchema) begin
   X::Ob
   Φ::Hom(X,X)
 end
 
 @abstract_acset_type AbstractDDS
-@acset_type DDS(TheoryDDS, index=[:Φ]) <: AbstractDDS
+@acset_type DDS(SchemaDDS, index=[:Φ]) <: AbstractDDS
 @test DDS <: AbstractDDS
 @test DDS <: StructACSet
 @test DDS <: StructCSet
@@ -112,7 +112,7 @@ add_parts!(dds, :X, 3, Φ=[1,1,1])
 @test incident(dds, 3, :Φ) == []
 
 # Incidence without indexing.
-@acset_type UnindexedDDS(TheoryDDS)
+@acset_type UnindexedDDS(SchemaDDS)
 dds = UnindexedDDS()
 add_parts!(dds, :X, 4, Φ=[3,3,4,4])
 # @test isempty(keys(dds.indices))
@@ -127,7 +127,7 @@ add_parts!(dds, :X, 4, Φ=[3,3,4,4])
 # in order to be valid dendrograms, there must be no nontrivial cycles and the
 # `height` map must satisfy `compose(parent, height) ≥ height` pointwise.
 
-@present TheoryDendrogram(FreeSchema) begin
+@present SchDendrogram(FreeSchema) begin
   X::Ob
   R::AttrType
   parent::Hom(X,X)
@@ -136,7 +136,7 @@ end
 
 @abstract_acset_type AbstractDendrogram
 
-@acset_type Dendrogram(TheoryDendrogram, index=[:parent]) <: AbstractDendrogram
+@acset_type Dendrogram(SchDendrogram, index=[:parent]) <: AbstractDendrogram
 
 @test Dendrogram <: AbstractDendrogram
 @test Dendrogram <: ACSet
@@ -167,7 +167,7 @@ set_subpart!(d, [4,5], :parent, 5)
 @test incident(d, 5, [:parent, :parent]) == [1,2,3,4,5]
 @test incident(d, 10, [:parent, :height]) == [1,2,3]
 
-X, parent, height = TheoryDendrogram[[:X, :parent, :height]]
+X, parent, height = SchDendrogram[[:X, :parent, :height]]
 @test subpart(d, 3, parent) == 4
 @test subpart(d, 3, compose(parent, height)) == 10
 @test subpart(d, 3, id(X)) == 3
@@ -231,12 +231,12 @@ rows = [Tables.rows(td.X)...]
 # Dendrograms with leaves
 #------------------------
 
-@present TheoryLDendrogram <: TheoryDendrogram begin
+@present SchLDendrogram <: SchDendrogram begin
   L::Ob
   leafparent::Hom(L,X)
 end
 
-@acset_type LDendrogram(TheoryLDendrogram, index=[:parent, :leafparent]) <: AbstractDendrogram
+@acset_type LDendrogram(SchLDendrogram, index=[:parent, :leafparent]) <: AbstractDendrogram
 
 # Copying between C-sets and C′-sets with C != C′.
 ld = LDendrogram{Int}()
@@ -255,11 +255,11 @@ copy_parts!(d′, ld)
 
 # A set together with a subset, with unique indexing for fast membership checks.
 
-@present TheorySubset(FreeSchema) begin
+@present SchSubset(FreeSchema) begin
   (Set, Sub)::Ob
   ι::Hom(Sub, Set)
 end
-@acset_type Subset(TheorySubset, unique_index=[:ι])
+@acset_type Subset(SchSubset, unique_index=[:ι])
 
 Base.in(x, X::Subset) = incident(X, x, :ι) != 0
 
@@ -283,7 +283,7 @@ rem_part!(B, :Set, 1)
 
 # The simplest example of a C-set with a data attribute, to test data indexing.
 
-@present TheoryLabeledSet(FreeSchema) begin
+@present SchLabeledSet(FreeSchema) begin
   X::Ob
   Label::AttrType
   label::Attr(X,Label)
@@ -292,7 +292,7 @@ end
 # Labeled sets with index
 #------------------------
 
-@acset_type IndexedLabeledSet(TheoryLabeledSet, index=[:label])
+@acset_type IndexedLabeledSet(SchLabeledSet, index=[:label])
 
 lset = IndexedLabeledSet{Symbol}()
 # @test keys(lset.indices) == (:label,)
@@ -337,7 +337,7 @@ add_part!(lset, :X)
 # Labeled sets with unique index
 #-------------------------------
 
-@acset_type UniqueIndexedLabeledSet(TheoryLabeledSet, unique_index=[:label])
+@acset_type UniqueIndexedLabeledSet(SchLabeledSet, unique_index=[:label])
 
 lset = UniqueIndexedLabeledSet{Symbol}()
 add_parts!(lset, :X, 2, label=[:foo, :bar])
@@ -356,7 +356,7 @@ set_subpart!(lset, 1, :label, :baz)
 # @acset macro
 #-------------
 
-@present TheoryDecGraph(FreeSchema) begin
+@present SchDecGraph(FreeSchema) begin
   E::Ob
   V::Ob
   src::Hom(E,V)
@@ -366,7 +366,7 @@ set_subpart!(lset, 1, :label, :baz)
   dec::Attr(E,X)
 end
 
-@acset_type DecGraph(TheoryDecGraph, index=[:src,:tgt])
+@acset_type DecGraph(SchDecGraph, index=[:src,:tgt])
 
 g = @acset DecGraph{String} begin
   V = 4
@@ -417,11 +417,11 @@ h2 = map(g, X = f)
 @test typeof(h1).super.parameters[2] == Tuple{Int}
 @test subpart(h1,:dec) == f.(["a","b","c","d"])
 
-@present TheoryLabeledDecGraph <: TheoryDecGraph begin
+@present SchLabeledDecGraph <: SchDecGraph begin
   label::Attr(V,X)
 end
 
-@acset_type LabeledDecGraph(TheoryLabeledDecGraph, index=[:src,:tgt])
+@acset_type LabeledDecGraph(SchLabeledDecGraph, index=[:src,:tgt])
 
 g = @acset LabeledDecGraph{String} begin
   V = 4

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -3,11 +3,11 @@ using Test
 
 using Catlab, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
 
-@present SchemaDDS(FreeSchema) begin
+@present SchDDS(FreeSchema) begin
   X::Ob
   Φ::Hom(X,X)
 end
-@acset_type DDS(SchemaDDS, index=[:Φ])
+@acset_type DDS(SchDDS, index=[:Φ])
 
 @present SchSetAttr(FreeSchema) begin
   X::Ob
@@ -493,7 +493,7 @@ add_vertices!(g, 2, vlabel=[:u,:v])
 add_edge!(g, 1, 2, elabel=:e)
 @test roundtrip_json_acset(g) == g
 
-@present SchLabeledDDS <: SchemaDDS begin
+@present SchLabeledDDS <: SchDDS begin
   Label::AttrType
   label::Attr(X, Label)
 end

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -2,20 +2,19 @@ module TestCSets
 using Test
 
 using Catlab, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
-using Catlab.Graphs.BasicGraphs: TheoryGraph
 
-@present TheoryDDS(FreeSchema) begin
+@present SchemaDDS(FreeSchema) begin
   X::Ob
   Φ::Hom(X,X)
 end
-@acset_type DDS(TheoryDDS, index=[:Φ])
+@acset_type DDS(SchemaDDS, index=[:Φ])
 
-@present TheorySetAttr(FreeSchema) begin
+@present SchSetAttr(FreeSchema) begin
   X::Ob
   D::AttrType
   f::Attr(X,D)
 end
-@acset_type SetAttr(TheorySetAttr)
+@acset_type SetAttr(SchSetAttr)
 
 # Sets interop
 ##############
@@ -252,13 +251,13 @@ g = star_graph(WeightedGraph{Bool}, 3, E=(weight=[true,false],))
 # Limits
 #-------
 
-@present TheoryVELabeledGraph <: TheoryGraph begin
+@present SchVELabeledGraph <: SchGraph begin
   Label::AttrType
   vlabel::Attr(V,Label)
   elabel::Attr(E,Label)
 end
 
-@acset_type VELabeledGraph(TheoryVELabeledGraph,
+@acset_type VELabeledGraph(SchVELabeledGraph,
                            index=[:src,:tgt]) <: AbstractGraph
 
 # Terminal labeled graph.
@@ -494,11 +493,11 @@ add_vertices!(g, 2, vlabel=[:u,:v])
 add_edge!(g, 1, 2, elabel=:e)
 @test roundtrip_json_acset(g) == g
 
-@present TheoryLabeledDDS <: TheoryDDS begin
+@present SchLabeledDDS <: SchemaDDS begin
   Label::AttrType
   label::Attr(X, Label)
 end
-@acset_type LabeledDDS(TheoryLabeledDDS, index=[:Φ, :label])
+@acset_type LabeledDDS(SchLabeledDDS, index=[:Φ, :label])
 
 ldds = LabeledDDS{Int}()
 add_parts!(ldds, :X, 4, Φ=[2,3,4,1], label=[100, 101, 102, 103])

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -9,10 +9,10 @@ using Catlab.Programs.DiagrammaticPrograms
 end
 @acset_type AcsetSet(SchSet)
 
-@present SchemaDDS <: SchSet begin
+@present SchDDS <: SchSet begin
   Φ::Hom(X,X)
 end
-@acset_type DDS(SchemaDDS, index=[:Φ])
+@acset_type DDS(SchDDS, index=[:Φ])
 
 # Contravariant migration
 #########################
@@ -30,7 +30,7 @@ add_parts!(h, :E, 3, src = [1,2,3], tgt = [2,3,1])
 # Migrate DDS → Graph.
 dds = DDS()
 add_parts!(dds, :X, 3, Φ=[2,3,1])
-X = SchemaDDS[:X]
+X = SchDDS[:X]
 @test h == migrate(Graph, dds, Dict(:V => :X, :E => :X),
                    Dict(:src => id(X), :tgt => :Φ))
 
@@ -43,7 +43,7 @@ migrate!(h2, dds, Dict(:V => :X, :E => :X),
 @test dds == migrate(DDS, dds, Dict(:X => :X),
                      Dict(:Φ => [:Φ, :Φ, :Φ, :Φ]))
 
-@present SchLabeledDDS <: SchemaDDS begin
+@present SchLabeledDDS <: SchDDS begin
   Label::AttrType
   label::Attr(X, Label)
 end

--- a/test/categorical_algebra/Diagrams.jl
+++ b/test/categorical_algebra/Diagrams.jl
@@ -2,9 +2,8 @@ module TestDiagrams
 using Test
 
 using Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
-using Catlab.Graphs.BasicGraphs: TheoryGraph, TheorySymmetricGraph
 
-const SchSGraph = TheorySymmetricGraph
+const SchSGraph = SchSymmetricGraph
 
 # Diagrams
 ##########
@@ -70,11 +69,11 @@ d = dom(f)
 # Monads of diagrams
 ####################
 
-C = FinCat(TheoryGraph)
+C = FinCat(SchGraph)
 d = munit(Diagram{id}, C, :V)
 @test is_discrete(shape(d))
-@test only(collect_ob(d)) == TheoryGraph[:V]
+@test only(collect_ob(d)) == SchGraph[:V]
 f = munit(DiagramHom{id}, C, :src)
-@test only(components(diagram_map(f))) == TheoryGraph[:src]
+@test only(components(diagram_map(f))) == SchGraph[:src]
 
 end

--- a/test/categorical_algebra/FinCats.jl
+++ b/test/categorical_algebra/FinCats.jl
@@ -2,8 +2,6 @@ module TestFinCats
 using Test
 
 using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.Graphs
-using Catlab.Graphs.BasicGraphs: TheoryGraph, TheoryReflexiveGraph,
-  TheoryWeightedGraph
 
 # Categories on graphs
 ######################
@@ -141,7 +139,7 @@ end
 # Graph as set-valued functor on a free category.
 F = FinDomFunctor(path_graph(Graph, 3))
 C = dom(F)
-@test C == FinCat(TheoryGraph)
+@test C == FinCat(SchGraph)
 @test is_functorial(F)
 @test ob_map(F, :V) == FinSet(3)
 @test hom_map(F, :src) == FinFunction([1,2], 3)
@@ -153,9 +151,9 @@ C = dom(F)
 G_refl = FinDomFunctor(path_graph(ReflexiveGraph, 3))
 @test is_functorial(G_refl)
 G = compose(FinFunctor(Dict(:V=>:V, :E=>:E), Dict(:src=>:src, :tgt=>:tgt),
-                       TheoryGraph, TheoryReflexiveGraph),
+                       SchGraph, SchReflexiveGraph),
             G_refl, strict=false)
-@test dom(G) == FinCat(TheoryGraph)
+@test dom(G) == FinCat(SchGraph)
 @test codom(G) == codom(G_refl)
 @test ob_map(G, :V) == FinSet(3)
 @test hom_map(G, :src) isa FinFunction{Int}
@@ -183,21 +181,21 @@ G = FinDomFunctor(g)
 @test α⋅σ == FinTransformation(F, G, V=FinFunction([1,2,2]), E=FinFunction([2,4]))
 
 # Pullback data migration by pre-whiskering.
-ιV = FinFunctor([:V], FinCat(1), FinCat(TheoryGraph))
+ιV = FinFunctor([:V], FinCat(1), FinCat(SchGraph))
 αV = ιV * α
 @test ob_map(dom(αV), 1) == ob_map(F, :V)
 @test ob_map(codom(αV), 1) == ob_map(G, :V)
 @test component(αV, 1) == component(α, :V)
 
 # Post-whiskering and horizontal composition.
-ιE = FinFunctor([:E], FinCat(1), FinCat(TheoryGraph))
+ιE = FinFunctor([:E], FinCat(1), FinCat(SchGraph))
 ϕ = FinTransformation([:src], ιE, ιV)
 @test is_natural(ϕ)
 @test component(ϕ*F, 1) == hom_map(F, :src)
 @test component(ϕ*α, 1) == hom_map(F, :src) ⋅ α[:V]
 
 # Schemas as categories.
-C = FinCat(TheoryWeightedGraph)
+C = FinCat(SchWeightedGraph)
 @test first.(ob_generators(C)) == [:V, :E, :Weight]
 @test first.(hom_generators(C)) == [:src, :tgt, :weight]
 g = path_graph(WeightedGraph{Float64}, 3, E=(weight=[0.5,1.5],))

--- a/test/categorical_algebra/StructuredCospans.jl
+++ b/test/categorical_algebra/StructuredCospans.jl
@@ -2,7 +2,6 @@ module TestStructuredCospans
 using Test
 
 using Catlab, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
-using Catlab.Graphs.BasicGraphs: AbstractGraph, TheoryGraph
 
 # Structured cospans of C-sets
 ##############################
@@ -100,13 +99,13 @@ k0 = apex(k)
 # Attributed boundary
 #--------------------
 
-@present TheoryVELabeledGraph <: TheoryGraph begin
+@present SchVELabeledGraph <: SchGraph begin
   Label::AttrType
   vlabel::Attr(V,Label)
   elabel::Attr(E,Label)
 end
 
-@acset_type VELabeledGraph(TheoryVELabeledGraph, index=[:src,:tgt]) <: AbstractGraph
+@acset_type VELabeledGraph(SchVELabeledGraph, index=[:src,:tgt]) <: AbstractGraph
 const VELGraph = VELabeledGraph
 
 const OpenVELGraphOb, OpenVELGraph = OpenACSetTypes(VELGraph, :V)
@@ -160,7 +159,7 @@ b = OpenVELGraphOb{Symbol}(FinSet(3), vlabel=[:x,:y,:z])
 # Attributed boundary
 #--------------------
 
-@present TheoryMultiplyAttributedGraph <: TheoryGraph begin
+@present SchMultiplyAttributedGraph <: SchGraph begin
   Length::AttrType
   Size::AttrType
   Label::AttrType
@@ -170,7 +169,7 @@ b = OpenVELGraphOb{Symbol}(FinSet(3), vlabel=[:x,:y,:z])
   elength::Attr(E, Length)
 end
 
-@acset_type MAGraph(TheoryMultiplyAttributedGraph, index=[:src,:tgt]) <: AbstractGraph
+@acset_type MAGraph(SchMultiplyAttributedGraph, index=[:src,:tgt]) <: AbstractGraph
 const OpenMAGraphOb, OpenMAGraph = OpenACSetTypes(MAGraph, :V)
 
 g0 = @acset MAGraph{Int, Float64, Symbol} begin

--- a/test/core/Present.jl
+++ b/test/core/Present.jl
@@ -105,13 +105,13 @@ I = munit(FreeSymmetricMonoidalCategory.Ob)
 @present SchSet(FreeCategory) begin
   X::Ob
 end
-@present SchemaDDS <: SchSet begin
+@present SchDDS <: SchSet begin
   Φ::Hom(X,X)
 end
 X = Ob(FreeCategory, :X)
 Φ = Hom(:Φ, X, X)
-@test generators(SchemaDDS, :Ob) == [X]
-@test generators(SchemaDDS, :Hom) == [Φ]
+@test generators(SchDDS, :Ob) == [X]
+@test generators(SchDDS, :Hom) == [Φ]
 
 # Abbreviated syntax.
 @present SchGraph(FreeCategory) begin

--- a/test/core/Present.jl
+++ b/test/core/Present.jl
@@ -102,29 +102,29 @@ I = munit(FreeSymmetricMonoidalCategory.Ob)
 @test generator(C, :scalar) == Hom(:scalar, I, I)
 
 # Inheritance.
-@present TheorySet(FreeCategory) begin
+@present SchSet(FreeCategory) begin
   X::Ob
 end
-@present TheoryDDS <: TheorySet begin
+@present SchemaDDS <: SchSet begin
   Φ::Hom(X,X)
 end
 X = Ob(FreeCategory, :X)
 Φ = Hom(:Φ, X, X)
-@test generators(TheoryDDS, :Ob) == [X]
-@test generators(TheoryDDS, :Hom) == [Φ]
+@test generators(SchemaDDS, :Ob) == [X]
+@test generators(SchemaDDS, :Hom) == [Φ]
 
 # Abbreviated syntax.
-@present TheoryGraph(FreeCategory) begin
+@present SchGraph(FreeCategory) begin
   V::Ob
   E::Ob
   src::Hom(E,V)
   tgt::Hom(E,V)
 end
-@present TheoryGraph′(FreeCategory) begin
+@present SchGraph′(FreeCategory) begin
   (V, E)::Ob
   (src, tgt)::Hom(E,V)
 end
-@test TheoryGraph == TheoryGraph′
+@test SchGraph == SchGraph′
 
 # Serialization
 ###############

--- a/test/graphics/GraphvizCategories.jl
+++ b/test/graphics/GraphvizCategories.jl
@@ -2,7 +2,6 @@ module TestGraphvizCategories
 using Test
 
 using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.Graphs
-using Catlab.Graphs.BasicGraphs: TheoryWeightedGraph
 using Catlab.Graphics.GraphvizCategories
 using Catlab.Graphics: Graphviz
 
@@ -54,7 +53,7 @@ gv = to_graphviz(el, node_labels=true, edge_labels=true)
 # Schemas
 #########
 
-gv = to_graphviz(TheoryWeightedGraph)
+gv = to_graphviz(SchWeightedGraph)
 @test length(stmts(gv, Graphviz.Node)) == 3
 @test stmts(gv, Graphviz.Node, :label) == ["V", "E"]
 @test stmts(gv, Graphviz.Node, :xlabel) == ["Weight"]

--- a/test/graphics/GraphvizCategories.jl
+++ b/test/graphics/GraphvizCategories.jl
@@ -10,33 +10,33 @@ const stmts = Graphviz.filter_statements
 # Categories
 ############
 
-@present TheorySectionRetract(FreeCategory) begin
+@present SchSectionRetract(FreeCategory) begin
   (A, B)::Ob
   i::Hom(A, B)
   r::Hom(B, A)
   compose(i, r) == id(A)
 end
 
-gv = to_graphviz(TheorySectionRetract)
+gv = to_graphviz(SchSectionRetract)
 @test stmts(gv, Graphviz.Node, :label) == ["A", "B"]
 @test stmts(gv, Graphviz.Edge, :label) == ["i", "r"]
 
 # ℳ-categories.
-@present TheorySubobject₀(FreeMCategory) begin
+@present SchSubobject₀(FreeMCategory) begin
   (A, X)::Ob
   ι::Hom(A, X)
 end
 
-gv = to_graphviz(TheorySubobject₀, edge_attrs=Dict(:arrowhead => "vee"),
+gv = to_graphviz(SchSubobject₀, edge_attrs=Dict(:arrowhead => "vee"),
                  tight_attrs=Dict(:dir => "both", :arrowtail => "crow"))
 @test stmts(gv, Graphviz.Node, :label) == ["A", "X"]
 @test stmts(gv, Graphviz.Edge, :arrowtail) == []
 
-@present TheorySubobject <: TheorySubobject₀ begin
+@present SchSubobject <: SchSubobject₀ begin
   ::Tight(ι)
 end
 
-gv = to_graphviz(TheorySubobject, edge_attrs=Dict(:arrowhead => "vee"),
+gv = to_graphviz(SchSubobject, edge_attrs=Dict(:arrowhead => "vee"),
                  tight_attrs=Dict(:dir => "both", :arrowtail => "crow"))
 @test stmts(gv, Graphviz.Edge, :arrowtail) == ["crow"]
 

--- a/test/programs/DiagrammaticPrograms.jl
+++ b/test/programs/DiagrammaticPrograms.jl
@@ -9,7 +9,7 @@ using Catlab.WiringDiagrams.CPortGraphs
 @present SchSet(FreeSchema) begin
   X::Ob
 end
-@present SchemaDDS <: SchSet begin
+@present SchDDS <: SchSet begin
   Φ::Hom(X,X)
 end
 
@@ -116,10 +116,10 @@ end
 end
 
 # GAT expressions.
-F = @finfunctor SchemaDDS SchemaDDS begin
+F = @finfunctor SchDDS SchDDS begin
   X => X; Φ => id(X)
 end
-F′ = @finfunctor SchemaDDS SchemaDDS begin
+F′ = @finfunctor SchDDS SchDDS begin
   X => X; Φ => id{X}
 end
 @test F == F′
@@ -180,12 +180,12 @@ end
 @test collect_ob(F) == [SchGraph[:E], SchGraph[:E], SchGraph[:V]]
 @test collect_hom(F) == [SchGraph[:tgt], SchGraph[:src]]
 
-F = @diagram SchemaDDS begin
+F = @diagram SchDDS begin
   x::X
   (f: x → x)::(Φ⋅Φ)
 end
-@test only(collect_ob(F)) == SchemaDDS[:X]
-@test only(collect_hom(F)) == compose(SchemaDDS[:Φ], SchemaDDS[:Φ])
+@test only(collect_ob(F)) == SchDDS[:X]
+@test only(collect_hom(F)) == compose(SchDDS[:Φ], SchDDS[:Φ])
 
 # Migrations
 ############

--- a/test/programs/DiagrammaticPrograms.jl
+++ b/test/programs/DiagrammaticPrograms.jl
@@ -4,14 +4,12 @@ using Test
 using Catlab, Catlab.Graphs, Catlab.CategoricalAlgebra
 using Catlab.Programs.DiagrammaticPrograms
 using Catlab.Programs.DiagrammaticPrograms: NamedGraph
-using Catlab.Graphs.BasicGraphs: TheoryGraph, TheoryReflexiveGraph
-using Catlab.Graphs.BipartiteGraphs: TheoryBipartiteGraph
-using Catlab.WiringDiagrams.CPortGraphs: ThCPortGraph
+using Catlab.WiringDiagrams.CPortGraphs
 
-@present TheorySet(FreeSchema) begin
+@present SchSet(FreeSchema) begin
   X::Ob
 end
-@present TheoryDDS <: TheorySet begin
+@present SchemaDDS <: SchSet begin
   Φ::Hom(X,X)
 end
 
@@ -77,7 +75,7 @@ end
 ##########
 
 # Underlying graph of circular port graph.
-F = @finfunctor TheoryGraph ThCPortGraph begin
+F = @finfunctor SchGraph SchCPortGraph begin
   V => Box
   E => Wire
   src => src ⨟ box
@@ -85,11 +83,11 @@ F = @finfunctor TheoryGraph ThCPortGraph begin
 end
 @test F == FinFunctor(Dict(:V => :Box, :E => :Wire),
                       Dict(:src => [:src, :box], :tgt => [:tgt, :box]),
-                      TheoryGraph, ThCPortGraph)
+                      SchGraph, SchCPortGraph)
 
 # Incomplete definition.
 @test_throws ErrorException begin
-  @finfunctor TheoryGraph ThCPortGraph begin
+  @finfunctor SchGraph SchCPortGraph begin
     V => Box
     src => src ⨟ box
     tgt => tgt ⨟ box
@@ -98,7 +96,7 @@ end
 
 # Failure of functorality.
 @test_throws ErrorException begin
-  @finfunctor TheoryGraph ThCPortGraph begin
+  @finfunctor SchGraph SchCPortGraph begin
     V => Box
     E => Wire
     src => src
@@ -108,7 +106,7 @@ end
 
 # Extra definitions.
 @test_throws ErrorException begin
-  @finfunctor TheoryGraph TheoryReflexiveGraph begin
+  @finfunctor SchGraph SchReflexiveGraph begin
     V => Box
     E => Wire
     src => src
@@ -118,10 +116,10 @@ end
 end
 
 # GAT expressions.
-F = @finfunctor TheoryDDS TheoryDDS begin
+F = @finfunctor SchemaDDS SchemaDDS begin
   X => X; Φ => id(X)
 end
-F′ = @finfunctor TheoryDDS TheoryDDS begin
+F′ = @finfunctor SchemaDDS SchemaDDS begin
   X => X; Φ => id{X}
 end
 @test F == F′
@@ -129,7 +127,7 @@ end
 # Diagrams
 ##########
 
-C = FinCat(TheoryGraph)
+C = FinCat(SchGraph)
 F_parsed = @diagram C begin
   v::V
   (e1, e2)::E
@@ -148,7 +146,7 @@ end)
 F = FinFunctor([:V,:E,:E], [:tgt, :src], J, C)
 @test F_parsed == F
 
-F_parsed = @diagram TheoryGraph begin
+F_parsed = @diagram SchGraph begin
   v => V
   (e1, e2) => E
   t: e1 → v => tgt
@@ -156,7 +154,7 @@ F_parsed = @diagram TheoryGraph begin
 end
 @test F_parsed == F
 
-F_parsed = @diagram TheoryGraph begin
+F_parsed = @diagram SchGraph begin
   v::V
   (e1, e2)::E
   (e1 → v)::tgt
@@ -166,7 +164,7 @@ J_parsed = dom(F_parsed)
 @test src(graph(J_parsed)) == src(graph(J))
 @test tgt(graph(J_parsed)) == tgt(graph(J))
 
-F_parsed′ = @free_diagram TheoryGraph begin
+F_parsed′ = @free_diagram SchGraph begin
   v::V
   (e1, e2)::E
   tgt(e1) == v
@@ -174,20 +172,20 @@ F_parsed′ = @free_diagram TheoryGraph begin
 end
 @test F_parsed′ == F_parsed
 
-F = @free_diagram TheoryGraph begin
+F = @free_diagram SchGraph begin
   (e1, e2)::E
   tgt(e1) == src(e2)
 end
 @test is_functorial(F)
-@test collect_ob(F) == [TheoryGraph[:E], TheoryGraph[:E], TheoryGraph[:V]]
-@test collect_hom(F) == [TheoryGraph[:tgt], TheoryGraph[:src]]
+@test collect_ob(F) == [SchGraph[:E], SchGraph[:E], SchGraph[:V]]
+@test collect_hom(F) == [SchGraph[:tgt], SchGraph[:src]]
 
-F = @diagram TheoryDDS begin
+F = @diagram SchemaDDS begin
   x::X
   (f: x → x)::(Φ⋅Φ)
 end
-@test only(collect_ob(F)) == TheoryDDS[:X]
-@test only(collect_hom(F)) == compose(TheoryDDS[:Φ], TheoryDDS[:Φ])
+@test only(collect_ob(F)) == SchemaDDS[:X]
+@test only(collect_hom(F)) == compose(SchemaDDS[:Φ], SchemaDDS[:Φ])
 
 # Migrations
 ############
@@ -196,7 +194,7 @@ end
 #-------------------
 
 # Graph with reversed edges.
-F = @migration TheoryGraph TheoryGraph begin
+F = @migration SchGraph SchGraph begin
   V => V
   E => E
   src => tgt
@@ -205,10 +203,10 @@ end
 @test F isa DataMigrations.DeltaSchemaMigration
 @test F == FinFunctor(Dict(:V => :V, :E => :E),
                       Dict(:src => :tgt, :tgt => :src),
-                      TheoryGraph, TheoryGraph)
+                      SchGraph, SchGraph)
 
 # Variant where target schema is not given.
-F = @migration TheoryGraph begin
+F = @migration SchGraph begin
   E => E
   V => V
   (src: E → V) => tgt
@@ -216,13 +214,13 @@ F = @migration TheoryGraph begin
 end
 J = FinCat(parallel_arrows(NamedGraph{Symbol,Union{Symbol,Nothing}}, 2,
                            V=(vname=[:E,:V],), E=(ename=[:src,:tgt],)))
-@test F == FinDomFunctor([:E,:V], [:tgt,:src], J, FinCat(TheoryGraph))
+@test F == FinDomFunctor([:E,:V], [:tgt,:src], J, FinCat(SchGraph))
 
 # Conjunctive migration
 #----------------------
 
 # Graph with edges that are paths of length 2.
-F = @migration TheoryGraph TheoryGraph begin
+F = @migration SchGraph SchGraph begin
   V => V
   E => @join begin
     v::V
@@ -238,10 +236,10 @@ F_E = diagram(ob_map(F, :E))
 @test nameof.(collect_ob(F_E)) == [:V, :E, :E]
 @test nameof.(collect_hom(F_E)) == [:tgt, :src]
 F_tgt = hom_map(F, :tgt)
-@test collect_ob(F_tgt) == [(3, TheoryGraph[:tgt])]
+@test collect_ob(F_tgt) == [(3, SchGraph[:tgt])]
 
 # Syntactic variant of above.
-F′ = @migration TheoryGraph TheoryGraph begin
+F′ = @migration SchGraph SchGraph begin
   V => V
   E => @join begin
     v::V
@@ -256,7 +254,7 @@ end
 
 # "Bouquet graph" on set.
 # This is the right adjoint to the underlying edge set functor.
-F = @migration TheoryGraph TheorySet begin
+F = @migration SchGraph SchSet begin
   V => @product begin end
   E => X
   src => begin end
@@ -266,26 +264,26 @@ end
 @test isempty(shape(ob_map(F, :V)))
 
 # Syntactic variant of above.
-F′ = @migration TheoryGraph TheorySet begin
+F′ = @migration SchGraph SchSet begin
   V => @unit
   E => X
 end
 @test F′ == F
 
 # Cartesian product of graph with itself.
-F = @migration TheoryGraph TheoryGraph begin
+F = @migration SchGraph SchGraph begin
   V => @product (v₁::V; v₂::V)
   E => @product (e₁::E; e₂::E)
   src => (v₁ => e₁⋅src; v₂ => e₂⋅src)
   tgt => (v₁ => e₁⋅tgt; v₂ => e₂⋅tgt)
 end
 F_V = diagram(ob_map(F, :V))
-@test collect_ob(F_V) == fill(TheoryGraph[:V], 2)
+@test collect_ob(F_V) == fill(SchGraph[:V], 2)
 F_src = hom_map(F, :src)
-@test collect_ob(F_src) == [(1, TheoryGraph[:src]), (2, TheoryGraph[:src])]
+@test collect_ob(F_src) == [(1, SchGraph[:src]), (2, SchGraph[:src])]
 
 # Reflexive graph from graph.
-F = @migration TheoryReflexiveGraph TheoryGraph begin
+F = @migration SchReflexiveGraph SchGraph begin
   V => @join begin
     v::V
     ℓ::E
@@ -316,12 +314,12 @@ F = @migration TheoryReflexiveGraph TheoryGraph begin
   end
 end
 F_tgt = hom_map(F, :tgt)
-@test ob_map(F_tgt, :v) == (2, id(TheoryGraph[:V]))
+@test ob_map(F_tgt, :v) == (2, id(SchGraph[:V]))
 @test hom_map(F_tgt, :t) |> edges |> only == 4
 
 # Free/initial port graph on a graph.
 # This is the left adjoint to the underlying graph functor.
-F = @migration TheoryGraph begin
+F = @migration SchGraph begin
   Box => V
   Wire => E
   InPort => @join begin
@@ -344,7 +342,7 @@ F = @migration TheoryGraph begin
   end
 end
 F_src = hom_map(F, :src)
-@test collect_ob(F_src) == [(1, TheoryGraph[:src]), (1, id(TheoryGraph[:E]))]
+@test collect_ob(F_src) == [(1, SchGraph[:src]), (1, id(SchGraph[:E]))]
 @test collect_hom(F_src) == [id(shape(codom(F_src)), 1)]
 
 # Gluing migration
@@ -352,7 +350,7 @@ F_src = hom_map(F, :src)
 
 # Discrete graph on set.
 # This is the left adjoint to the underlying vertex set functor.
-F = @migration TheoryGraph TheorySet begin
+F = @migration SchGraph SchSet begin
   V => X
   E => @empty
 end
@@ -360,7 +358,7 @@ end
 @test isempty(shape(ob_map(F, :E)))
 
 # Coproduct of graph with itself.
-F = @migration TheoryGraph TheoryGraph begin
+F = @migration SchGraph SchGraph begin
   V => @cases (v₁::V; v₂::V)
   E => @cases (e₁::E; e₂::E)
   src => begin
@@ -374,12 +372,12 @@ F = @migration TheoryGraph TheoryGraph begin
 end
 @test F isa DataMigrations.GlueSchemaMigration
 F_V = diagram(ob_map(F, :V))
-@test collect_ob(F_V) == fill(TheoryGraph[:V], 2)
+@test collect_ob(F_V) == fill(SchGraph[:V], 2)
 F_src = hom_map(F, :src)
-@test collect_ob(F_src) == [(1, TheoryGraph[:src]), (2, TheoryGraph[:src])]
+@test collect_ob(F_src) == [(1, SchGraph[:src]), (2, SchGraph[:src])]
 
 # Free reflexive graph on a graph.
-F = @migration TheoryReflexiveGraph TheoryGraph begin
+F = @migration SchReflexiveGraph SchGraph begin
   V => V
   E => @cases (e::E; v::V)
   src => (e => src)
@@ -387,10 +385,10 @@ F = @migration TheoryReflexiveGraph TheoryGraph begin
   refl => v
 end
 F_tgt = hom_map(F, :tgt)
-@test collect_ob(F_tgt) == [(1, TheoryGraph[:tgt]), (1, id(TheoryGraph[:V]))]
+@test collect_ob(F_tgt) == [(1, SchGraph[:tgt]), (1, id(SchGraph[:V]))]
 
 # Vertices in a graph and their connected components.
-F = @migration TheoryGraph begin
+F = @migration SchGraph begin
   V => V
   Component => @glue begin
     e::E; v::V
@@ -407,7 +405,7 @@ F_C = diagram(ob_map(F, :Component))
 #---------------
 
 # Graph with edges that are paths of length <= 2.
-F = @migration TheoryGraph TheoryGraph begin
+F = @migration SchGraph SchGraph begin
   V => V
   E => @cases begin
     v => V
@@ -433,12 +431,12 @@ end
 F_src = hom_map(F, :src)
 @test collect_ob(shape_map(F_src)) == [1,1,1]
 F_src_v, F_src_e, F_src_path = components(diagram_map(F_src))
-@test collect_ob(F_src_v) == [(1, id(TheoryGraph[:V]))]
-@test collect_ob(F_src_e) == [(1, TheoryGraph[:src])]
-@test collect_ob(F_src_path) == [(2, TheoryGraph[:src])]
+@test collect_ob(F_src_v) == [(1, id(SchGraph[:V]))]
+@test collect_ob(F_src_e) == [(1, SchGraph[:src])]
+@test collect_ob(F_src_path) == [(2, SchGraph[:src])]
 
 # Graph with edges that are minimal paths b/w like vertices in bipartite graph.
-F = @migration TheoryGraph TheoryBipartiteGraph begin
+F = @migration SchGraph SchBipartiteGraph begin
   V => @cases (v₁::V₁; v₂::V₂)
   E => @cases begin
     e₁ => @join begin
@@ -466,11 +464,11 @@ end
 F_src = hom_map(F, :src)
 @test collect_ob(shape_map(F_src)) == [1,2]
 F_src1, F_src2 = components(diagram_map(F_src))
-@test collect_ob(F_src1) == [(2, TheoryBipartiteGraph[:src₁])]
-@test collect_ob(F_src2) == [(2, TheoryBipartiteGraph[:src₂])]
+@test collect_ob(F_src1) == [(2, SchBipartiteGraph[:src₁])]
+@test collect_ob(F_src2) == [(2, SchBipartiteGraph[:src₂])]
 
 # Box product of reflexive graph with itself.
-F = @migration TheoryReflexiveGraph TheoryReflexiveGraph begin
+F = @migration SchReflexiveGraph SchReflexiveGraph begin
   V => @product (v₁::V; v₂::V)
   E => @glue begin
     vv => @product (v₁::V; v₂::V)
@@ -494,7 +492,7 @@ end
 F_src = hom_map(F, :src)
 @test collect_ob(shape_map(F_src)) == [1,1,1]
 F_src_vv, F_src_ev, F_src_ve = components(diagram_map(F_src))
-@test collect_ob(F_src_ev) == [(1, TheoryReflexiveGraph[:src]),
-                               (2, id(TheoryReflexiveGraph[:V]))]
+@test collect_ob(F_src_ev) == [(1, SchReflexiveGraph[:src]),
+                               (2, id(SchReflexiveGraph[:V]))]
 
 end


### PR DESCRIPTION
- Prefix for acset schemas changed from `Theory` (or `Th`) to `Sch`
- Acsets schemas for graphs and wiring diagrams are publicly exported

Finally resolves #331.