### PR TITLE
LooseAcsetTransformation type component coercion 

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -332,8 +332,9 @@ See [`ACSetTranformation`](@ref) for the distinction between tight and loose.
       for c in ob(S))
     type_components = NamedTuple(
       type => coerce_type_component(type, get(type_components, type, identity),
-                                    Dom.parameters[i], Codom.parameters[i])
-      for (type, i) in zip(attrtype(S), acodom_nums(S)))
+                                    Dom.parameters[attrtype_num(S,type)],
+                                    Codom.parameters[attrtype_num(S,type)])
+      for type in attrtype(S))
     new{S,typeof(components),typeof(type_components),Dom,Codom}(
       components, type_components, X, Y)
   end


### PR DESCRIPTION
The type_components of LooseACSetTransformations can be given the wrong types due to a bug which mixes  `acodom_nums` and `attrtype_num`. This leads to a runtime error when one tries to call an incorrectly-typed function.

In CSets.jl line 334, `attrtype(S)` and `acodom_nums` shouldn't be zipped, as `acodom_nums` is for each attr, not each attrtype. The "i" we want is actually there is `attrtype_num(S,type)`