### PR TITLE
Compile with generators

### DIFF
--- a/test/programs/GenerateJuliaPrograms.jl
+++ b/test/programs/GenerateJuliaPrograms.jl
@@ -23,6 +23,14 @@ x = collect(range(-2,stop=2,length=50))
 
 # Test generator assignment
 @test compile(f_hom,generators=Dict(:f => :cos)).(x) == cos.(x)
+@test compile(compose(f_hom, g_hom),generators=Dict(:f => :cos,:g => :sin)).(x) == @. sin(cos(x))
+@test compile(otimes(f_hom, g_hom),generators=Dict(:f => :cos, :g => :sin))(π/2, π/2) == (cos(π/2), sin(π/2))
+
+# Compile a local function using @__MODULE__
+local_f(x) = x + 1
+@test compile(@__MODULE__,f_hom,generators=Dict(:f => :local_f)).(x) == [xi+1 for xi in x]
+
+
 
 # Evaluation
 ############

--- a/test/programs/GenerateJuliaPrograms.jl
+++ b/test/programs/GenerateJuliaPrograms.jl
@@ -8,6 +8,7 @@ using Catlab.Programs.GenerateJuliaPrograms
 ℝ = Ob(FreeCartesianCategory, :ℝ)
 plus_hom = Hom(:+, ℝ⊗ℝ, ℝ)
 cos_hom, sin_hom = Hom(:cos, ℝ, ℝ), Hom(:sin, ℝ, ℝ)
+f_hom, g_hom = Hom(:f, ℝ, ℝ), Hom(:g, ℝ, ℝ)
 
 # Compilation
 #############
@@ -19,6 +20,9 @@ x = collect(range(-2,stop=2,length=50))
 @test compile(cos_hom).(x) == cos.(x)
 @test compile(compose(cos_hom, sin_hom)).(x) == @. sin(cos(x))
 @test compile(otimes(cos_hom, sin_hom))(π/2, π/2) == (cos(π/2), sin(π/2))
+
+# Test generator assignment
+@test compile(f_hom,generators=Dict(:f => :cos)).(x) == cos.(x)
 
 # Evaluation
 ############

--- a/test/programs/GenerateJuliaPrograms.jl
+++ b/test/programs/GenerateJuliaPrograms.jl
@@ -21,16 +21,15 @@ x = collect(range(-2,stop=2,length=50))
 @test compile(compose(cos_hom, sin_hom)).(x) == @. sin(cos(x))
 @test compile(otimes(cos_hom, sin_hom))(π/2, π/2) == (cos(π/2), sin(π/2))
 
-# Test generator assignment
-@test compile(f_hom,generators=Dict(:f => :cos)).(x) == cos.(x)
-@test compile(compose(f_hom, g_hom),generators=Dict(:f => :cos,:g => :sin)).(x) == @. sin(cos(x))
-@test compile(otimes(f_hom, g_hom),generators=Dict(:f => :cos, :g => :sin))(π/2, π/2) == (cos(π/2), sin(π/2))
+# Assignment of generators to function, possibly local ones.
+@test compile(f_hom, generators=Dict(:f => cos)).(x) == cos.(x)
+@test compile(compose(f_hom, g_hom),
+              generators=Dict(:f => cos,:g => sin)).(x) == @. sin(cos(x))
+@test compile(otimes(f_hom, g_hom),
+              generators=Dict(:f => cos, :g => sin))(π/2, π/2) == (cos(π/2), sin(π/2))
 
-# Compile a local function using @__MODULE__
 local_f(x) = x + 1
-@test compile(@__MODULE__,f_hom,generators=Dict(:f => :local_f)).(x) == [xi+1 for xi in x]
-
-
+@test compile(f_hom, generators=Dict(:f => local_f)).(x) == [xi+1 for xi in x]
 
 # Evaluation
 ############


### PR DESCRIPTION
Added a dictionary field to SimpleCompileState and a new kwarg to the `compile` method. If a generator name is in the keys, that symbol is replaced by the associated value in the `generator_expr` method.