### PR TITLE
Epi mono factorization in terms of (co)limits

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -25,7 +25,7 @@ using ..FreeDiagrams, ..Limits, ..Subobjects, ..FinSets, ..FinCats
 import ..Limits: limit, colimit, universal
 import ..Subobjects: Subobject, implies, ⟹, subtract, \, negate, ¬, non, ~
 import ..Sets: SetOb, SetFunction, TypeSet
-import ..FinSets: FinSet, FinFunction, FinDomFunction, force, predicate
+import ..FinSets: FinSet, FinFunction, FinDomFunction, force, predicate, is_injective, is_surjective
 import ..FinCats: FinDomFunctor, components, is_natural
 
 # Sets interop
@@ -382,6 +382,20 @@ function is_natural(α::ACSetTransformation{S}) where {S}
                             zip(attr(S), adom(S), acodom(S))))
     Xf, Yf, α_c, α_d = subpart(X,f), subpart(Y,f), α[c], α[d]
     all(i -> Yf[α_c(i)] == α_d(Xf[i]), eachindex(Xf)) || return false
+  end
+  return true
+end
+
+function is_injective(α::CSetTransformation{S}) where {S}
+  for c in components(α)
+    if !is_injective(c) return false end
+  end
+  return true
+end
+
+function is_surjective(α::CSetTransformation{S}) where {S}
+  for c in components(α)
+    if !is_surjective(c) return false end
   end
   return true
 end

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -4,7 +4,7 @@ module FinSets
 export FinSet, FinFunction, FinDomFunction, TabularSet, TabularLimit,
   force, is_indexed, preimage,
   JoinAlgorithm, SmartJoin, NestedLoopJoin, SortMergeJoin, HashJoin,
-  SubFinSet, SubOpBoolean
+  SubFinSet, SubOpBoolean, is_injective, is_surjective
 
 using StructEquality
 using DataStructures: OrderedDict, IntDisjointSets, union!, find_root!
@@ -380,6 +380,12 @@ Base.show(io::IO, f::IndexedFinFunctionVector) =
 Sets.do_compose(f::Union{FinFunctionVector,IndexedFinFunctionVector},
                 g::Union{FinDomFunctionVector,IndexedFinDomFunctionVector}) =
   FinDomFunctionVector(g.func[f.func], codom(g))
+
+# These could be made to fail early if ever used in performance-critical areas
+is_surjective(f::FinFunction) =
+length(codom(f)) == length(Set(values(collect(f))))
+is_injective(f::FinFunction)  =
+length(dom(f)) == length(Set(values(collect(f))))
 
 # Dict-based functions
 #---------------------

--- a/src/categorical_algebra/Limits.jl
+++ b/src/categorical_algebra/Limits.jl
@@ -4,7 +4,7 @@ module Limits
 export AbstractLimit, AbstractColimit, Limit, Colimit,
   LimitAlgorithm, ColimitAlgorithm,
   ob, cone, cocone, apex, legs, limit, colimit, universal,
-  Terminal, Initial, terminal, initial, delete, create, factorize,
+  Terminal, Initial, terminal, initial, delete, create, factorize, image, coimage, epi_mono,
   BinaryProduct, Product, product, proj1, proj2, pair,
   BinaryPullback, Pullback, pullback,
   BinaryEqualizer, Equalizer, equalizer, incl,
@@ -263,6 +263,29 @@ define the method `universal(::Coequalizer{T}, ::SMulticospan{1,T})`.
 factorize(lim::Equalizer, h) = universal(lim, SMultispan{1}(h))
 factorize(colim::Coequalizer, h) = universal(colim, SMulticospan{1}(h))
 
+"""https://en.wikipedia.org/wiki/Image_(category_theory)#Second_definition"""
+image(f) = equalizer(legs(pushout(f,f))...)
+
+"""https://en.wikipedia.org/wiki/Coimage"""
+coimage(f) = coequalizer(legs(pullback(f,f))...)
+
+"""
+The image and coimage are isomorphic. We get this isomorphism using univeral
+properties.
+
+      CoIm′ ╌╌> I ↠ CoIm
+        ┆ ⌟     |
+        v       v
+        I   ⟶  R ↩ Im
+        |       ┆
+        v    ⌜  v
+        R ╌╌> Im′
+"""
+function epi_mono(f)
+  Im, CoIm = image(f), coimage(f)
+  iso = factorize(Im, factorize(CoIm, f))
+  return ComposablePair(proj(CoIm) ⋅ iso, incl(Im))
+end
 
 # (Co)cartesian monoidal categories
 ###################################

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -81,6 +81,21 @@ g, h = path_graph(Graph, 4), cycle_graph(Graph, 2)
 @test force(compose(id(g), α)) == α
 @test force(compose(α, id(h))) == α
 
+# Injectivity / surjectivity.
+G = @acset Graph begin V=2; E=1; src=1; tgt=2 end
+H = @acset Graph begin V=2; E=2; src=1; tgt=2 end
+I = @acset Graph begin V=2; E=2; src=[1,2]; tgt=[1,2] end
+f_ = homomorphism(G, H; monic=true)
+g_ = homomorphism(H, G)
+h_ = homomorphism(G, I)
+@test is_injective(f_)
+@test !is_surjective(f_)
+@test !is_injective(g_)
+@test is_surjective(g_)
+@test !is_injective(h_)
+@test !is_surjective(h_)
+
+
 # Limits
 #-------
 

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -106,6 +106,19 @@ g = FinFunction(5:-1:1)
 @test sshow(FinFunction(Dict(:a => 1, :b => 3), FinSet(3))) ==
   "FinFunction($(Dict(:a => 1, :b => 3)), FinSet(3))"
 
+# Injectivity / Surjectivity.
+f = FinFunction([1,3,4])
+g = FinFunction([1,1,2])
+X = FinSet(Set([:x,:y,:z]))
+k = FinFunction(Dict(:a => :x, :b => :y, :c => :z), X)
+
+@test is_injective(f)
+@test !is_surjective(f)
+@test is_surjective(g)
+@test !is_injective(g)
+@test is_injective(k)
+@test is_surjective(k)
+
 # Functions out of finite sets
 ##############################
 

--- a/test/categorical_algebra/Limits.jl
+++ b/test/categorical_algebra/Limits.jl
@@ -6,7 +6,7 @@ such as Set and FinSet.
 module TestLimits
 using Test
 
-using Catlab.Theories, Catlab.CategoricalAlgebra
+using Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.Graphs
 
 A, B, C = Ob(FreeCategory, :A, :B, :C)
 
@@ -47,5 +47,17 @@ colim = Colimit(DiscreteDiagram([A,B]), Cospan(f,g))
 d = FreeDiagram{FreeCategory.Ob,FreeCategory.Hom}(1, ob=A)
 colim = colimit(d, SpecializeColimit())
 @test ob(colim) == A
+
+# Epi mono.
+X = path_graph(Graph, 2) ⊕ path_graph(Graph, 2)
+Y = path_graph(Graph, 2) ⊕ apex(terminal(Graph))
+f = ACSetTransformation(X, Y; V=[1,2,1,2],E=[1,1])
+Im = path_graph(Graph, 2)
+epi, mono = epi_mono(f)
+@test is_isomorphic(codom(epi), Im)
+@test is_isomorphic(image(f)|>apex, Im)
+@test is_isomorphic(coimage(f)|>apex, Im)
+@test is_surjective(epi)
+@test is_injective(mono)
 
 end


### PR DESCRIPTION
I've found this construction useful in some other contexts, but this might be of general use.

This factors a morphism into a surjective map into an image and then an injective map into the codomain, where 'image' is defined in terms of limits (so this could be potentially applied in more general contexts than just CSetTransformations). 

Also included are `is_injective` / `is_surjective` test functions for CSetTransformations. (I'm not sure what those should do for attributes)