### PR TITLE
Bug fix for `permute` function

### DIFF
--- a/src/wiring_diagrams/MonoidalDirected.jl
+++ b/src/wiring_diagrams/MonoidalDirected.jl
@@ -130,9 +130,9 @@ munit(::Type{Ports{T,V}}) where {T,V} = Ports{T}(V[])
 
 # Unbiased version of braiding (permutation).
 
-function permute(A::Ports, σ::Vector{Int}; inverse::Bool=false)
+function permute(A::Ports{T}, σ::Vector{Int}; inverse::Bool=false) where T
   @assert length(A) == length(σ)
-  B = Ports([ A[σ[i]] for i in eachindex(σ) ])
+  B = Ports{T}([ A[σ[i]] for i in eachindex(σ) ])
   if inverse
     f = WiringDiagram(B, A)
     add_wires!(f, ((input_id(f),σ[i]) => (output_id(f),i) for i in eachindex(σ)))

--- a/test/wiring_diagrams/MonoidalDirected.jl
+++ b/test/wiring_diagrams/MonoidalDirected.jl
@@ -1,7 +1,7 @@
 module TestMonoidalDirectedWiringDiagrams
 using Test
 
-using Catlab.Theories, Catlab.WiringDiagrams
+using Catlab.Theories, Catlab.WiringDiagrams, Catlab.Present
 
 # Categorical interface
 #######################
@@ -55,6 +55,24 @@ I = munit(Ports)
 
 # Permutations
 W = otimes(X,Y)
+@test permute(W, [1,2,3,4]) == id(W)
+@test permute(W, [1,2,3,4], inverse=true) == id(W)
+@test permute(W, [3,4,1,2]) == braid(X,Y)
+@test permute(W, [3,4,1,2], inverse=true) == braid(Y,X)
+@test_throws AssertionError permute(W, [1,2])
+
+# Permutations on DWDs over presentations of SMCs
+@present TestSMC(FreeSymmetricMonoidalCategory) begin
+  A::Ob
+  B::Ob
+  C::Ob
+  D::Ob
+end
+X_expr, Y_expr = otimes(TestSMC[:A], TestSMC[:B]), otimes(TestSMC[:C], TestSMC[:D])
+W_expr = otimes(X_expr, Y_expr)
+X = to_wiring_diagram(X_expr)
+Y = to_wiring_diagram(Y_expr)
+W = to_wiring_diagram(W_expr)
 @test permute(W, [1,2,3,4]) == id(W)
 @test permute(W, [1,2,3,4], inverse=true) == id(W)
 @test permute(W, [3,4,1,2]) == braid(X,Y)

--- a/test/wiring_diagrams/MonoidalDirected.jl
+++ b/test/wiring_diagrams/MonoidalDirected.jl
@@ -1,7 +1,7 @@
 module TestMonoidalDirectedWiringDiagrams
 using Test
 
-using Catlab.Theories, Catlab.WiringDiagrams, Catlab.Present
+using Catlab.Theories, Catlab.WiringDiagrams
 
 # Categorical interface
 #######################
@@ -61,23 +61,13 @@ W = otimes(X,Y)
 @test permute(W, [3,4,1,2], inverse=true) == braid(Y,X)
 @test_throws AssertionError permute(W, [1,2])
 
-# Permutations on DWDs over presentations of SMCs
-@present TestSMC(FreeSymmetricMonoidalCategory) begin
-  A::Ob
-  B::Ob
-  C::Ob
-  D::Ob
-end
-X_expr, Y_expr = otimes(TestSMC[:A], TestSMC[:B]), otimes(TestSMC[:C], TestSMC[:D])
+# Permutations on DWDs with GAT exprs.
+A, B, C, D = Ob(FreeSymmetricMonoidalCategory, :A, :B, :C, :D)
+X_expr, Y_expr = otimes(A, B), otimes(C, D)
 W_expr = otimes(X_expr, Y_expr)
-X = to_wiring_diagram(X_expr)
-Y = to_wiring_diagram(Y_expr)
-W = to_wiring_diagram(W_expr)
+X, Y, W = to_wiring_diagram.([X_expr, Y_expr, W_expr])
 @test permute(W, [1,2,3,4]) == id(W)
-@test permute(W, [1,2,3,4], inverse=true) == id(W)
 @test permute(W, [3,4,1,2]) == braid(X,Y)
-@test permute(W, [3,4,1,2], inverse=true) == braid(Y,X)
-@test_throws AssertionError permute(W, [1,2])
 
 # Diagonals
 #----------


### PR DESCRIPTION
This small change allows the `permute` function to be called on wiring diagrams constructed by calling `to_wiring_diagram` on expressions over presentations of Free SMCs.