### PR TITLE
Hash method for ACSets

### DIFF
--- a/src/categorical_algebra/CSetDataStructures.jl
+++ b/src/categorical_algebra/CSetDataStructures.jl
@@ -412,6 +412,9 @@ ACSetInterface.acset_schema(acs::DynamicACSet) = acs.schema
 add_parts_with_indices!(acs::SimpleACSet, ob::Symbol, n::Int, index_sizes::NamedTuple) =
   add_parts!(acs, ob, n)
 
+Base.hash(x::T,h::UInt) where T <: StructACSet =
+  hash(x.parts, hash(x.subparts, h))
+
 @inline ACSetInterface.add_parts!(acs::StructACSet{S}, type::Symbol, n::Int) where {S} =
   _add_parts!(acs, Val{S}, Val{type}, n)
 

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -729,7 +729,7 @@ out_hom(S, c) = [f => codom(S,f) for f in hom(S) if dom(S,f) == c]
 
 """ Limit of attributed C-sets that stores the pointwise limits in Set.
 """
-struct ACSetLimit{Ob <: StructACSet, Diagram, Cone <: Multispan{Ob},
+@struct_hash_equal struct ACSetLimit{Ob <: StructACSet, Diagram, Cone <: Multispan{Ob},
                  Limits <: NamedTuple} <: AbstractLimit{Ob,Diagram}
   diagram::Diagram
   cone::Cone
@@ -738,7 +738,7 @@ end
 
 """ Colimit of attributed C-sets that stores the pointwise colimits in Set.
 """
-struct ACSetColimit{Ob <: StructACSet, Diagram, Cocone <: Multicospan{Ob},
+@struct_hash_equal struct ACSetColimit{Ob <: StructACSet, Diagram, Cocone <: Multicospan{Ob},
                     Colimits <: NamedTuple} <: AbstractColimit{Ob,Diagram}
   diagram::Diagram
   cocone::Cocone

--- a/test/categorical_algebra/CSetDataStructures.jl
+++ b/test/categorical_algebra/CSetDataStructures.jl
@@ -126,6 +126,18 @@ for dds_maker in dds_makers
   @test incident(dds, 3, :Φ) == []
 end
 
+# Hashing
+@test hash(DDS()) == hash(DDS())
+
+dds = DDS()
+add_parts!(dds, :X, 3, Φ=[2,3,3])
+@test hash(dds) != hash(DDS())
+
+dds2 = DDS()
+add_parts!(dds, :X, 3, Φ=[2,3,2])
+@test hash(dds) != hash(dds2)
+
+
 # Dendrograms
 #############
 

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -190,6 +190,9 @@ coprod = ob(colim)
 @test force(coproj1(colim)⋅γ) == α
 @test force(coproj2(colim)⋅γ) == force(β)
 
+colim2 = coproduct(path_graph(Graph, 4), cycle_graph(Graph, 2))
+@test hash(colim2) == hash(colim)
+
 # Coequalizer in Graph: collapsing a segment to a loop.
 g = Graph(2)
 add_edge!(g, 1, 2)

--- a/test/categorical_algebra/Diagrams.jl
+++ b/test/categorical_algebra/Diagrams.jl
@@ -25,6 +25,10 @@ d = Diagram(D)
 @test startswith(sprint(show, d), "Diagram{id}(")
 @test hash(D) != hash(Diagram{op}(D))
 
+C′ = FinCat(@acset Graph begin V = 3; E = 2; src = [1,2]; tgt = [3,3] end)
+d′ = Diagram(FinDomFunctor([:E,:E,:V], [:tgt,:src], C′, FinCat(SchSGraph)))
+@test hash(d) == hash(d′)
+
 # Diagram morphisms
 ###################
 

--- a/test/categorical_algebra/Limits.jl
+++ b/test/categorical_algebra/Limits.jl
@@ -21,6 +21,10 @@ lim = Limit(ObjectPair(A,B), Span(f,g))
 @test apex(lim) == C
 @test legs(lim) == [f,g]
 
+lim2 = Limit(ObjectPair(A,B), Span(Hom(:f, C, A),Hom(:g, C, B)))
+@test hash(lim2) == hash(lim)
+
+
 lim = Limit(DiscreteDiagram([A,B]), Span(f,g))
 @test lim isa Product
 


### PR DESCRIPTION
To avoid situations where `a==b` but `hash(a)!=hash(b)`, a hash method for C-Sets is added.

Addresses https://github.com/AlgebraicJulia/Catlab.jl/issues/656