### PR TITLE
Small fix for Presentation -> SchemaDesc function 

### DIFF
--- a/src/theories/Schema.jl
+++ b/src/theories/Schema.jl
@@ -163,8 +163,8 @@ function SchemaDesc(p::Presentation)
   obs,homs,attrtypes,attrs = map(t -> p.generators[t],[:Ob,:Hom,:AttrType,:Attr])
   ob_syms,hom_syms,attrtype_syms,attr_syms = map(xs -> Symbol[nameof.(xs)...],
                                                  [obs,homs,attrtypes,attrs])
-  doms = Dict(nameof(f) => nameof(dom(f)) for f in [homs; attrs])
-  codoms = Dict(nameof(f) => nameof(codom(f)) for f in [homs; attrs])
+  doms = Dict{Symbol,Symbol}(nameof(f) => nameof(dom(f)) for f in [homs; attrs])
+  codoms = Dict{Symbol,Symbol}(nameof(f) => nameof(codom(f)) for f in [homs; attrs])
   SchemaDesc(ob_syms, hom_syms, attrtype_syms, attr_syms, doms, codoms)
 end
 


### PR DESCRIPTION
If the presentation has no homs/attrs, then the type of `doms` passed to `SchemaDesc` is `Dict{Any,Any}` when `Dict{Symbol,Symbol}` is required by `SchemaDesc`. Just explicitly marking the type of the dictionary solves this.