### PR TITLE
Gluing together Attributed CSets in limited scenario

### DIFF
--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -334,10 +334,26 @@ ac = LooseACSetTransformation(
 f1 = Dict(:D=>FinFunction(Dict(:x=>:q,:y=>:q)));
 f2 = Dict(:D=>FinFunction(Dict(:z=>:q,)));
 f3 = Dict(:D=>FinFunction(Dict(:z=>:b,)));
-res = glue(Span(ab,ac),[f1,f2]) |> apex
+res = glue(Span(ab,ac),[f1,f2])
+@test all(is_natural, legs(res))
 expected = @acset XAttr begin X=1; f=[:q] end;
-@test res == expected
+@test res |> apex == expected
 @test_throws(ErrorException, glue(Span(ab,ac),[f1,f3]))
+
+# Limit analogue
+A = @acset XAttr begin X=2; f=[:a,:b] end;
+B = @acset XAttr begin X=2; f=[:q,:z] end;
+C = @acset XAttr begin X=2; f=[:x,:y] end;
+ac = LooseACSetTransformation(
+  Dict([:X=>[1,2]]),Dict([:D=>FinFunction(Dict(:a=>:x,:b=>:y))]),A,C);
+bc = LooseACSetTransformation(
+  Dict([:X=>[1,1]]),Dict([:D=>FinFunction(Dict(:q=>:x,:z=>:x))]),B,C);
+f1 = Dict(:D=>FinFunction(Dict(:a_z=>:a,:a_q=>:a)));
+f2 = Dict(:D=>FinFunction(Dict(:a_z=>:z,:a_q=>:q)));
+@test all(is_natural,[ac,bc])
+res = coglue(Cospan(ac,bc),[f1,f2]);
+@test all(is_natural,legs(res))
+@test apex(res)[:f] == [:a_q,:a_z]
 
 # Finding C-set morphisms
 #########################

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -318,6 +318,27 @@ colim = pushout(α, β)
 @test !is_natural(α′) # Vertex labels don't match.
 @test_throws ErrorException pushout(α′, β)
 
+# "gluing" acsets
+#-----------------
+@present SchX(FreeSchema) begin X::Ob; D::AttrType; f::Attr(X,D) end;
+@acset_type XAttr_(SchX);
+const XAttr = XAttr_{Symbol};
+A = @acset XAttr begin X=2; f=[:a,:b] end;
+B = @acset XAttr begin X=2; f=[:x,:y] end;
+C = @acset XAttr begin X=1; f=[:z] end;
+ab = LooseACSetTransformation(
+  Dict([:X=>[1,2]]),Dict([:D=>FinFunction(Dict(:a=>:x,:b=>:y))]),A,B);
+ac = LooseACSetTransformation(
+  Dict([:X=>[1,1]]),Dict([:D=>FinFunction(Dict(:a=>:z,:b=>:z))]),A,C);
+@test all(is_natural,[ab,ac]);
+f1 = Dict(:D=>FinFunction(Dict(:x=>:q,:y=>:q)));
+f2 = Dict(:D=>FinFunction(Dict(:z=>:q,)));
+f3 = Dict(:D=>FinFunction(Dict(:z=>:b,)));
+res = glue(Span(ab,ac),[f1,f2]) |> apex
+expected = @acset XAttr begin X=1; f=[:q] end;
+@test res == expected
+@test_throws(ErrorException, glue(Span(ab,ac),[f1,f3]))
+
 # Finding C-set morphisms
 #########################
 


### PR DESCRIPTION
We currently support the ability to glue attributed C-sets where the merged parts agree completely on their attributes. This PR extends this colimit functionality with the ability to apply a fixed transformation to attributes. We require this to be known in advance and explicitly provided. 

This is called `glue` because it is not technically a colimit of LooseACSetTransformations, which is a shame because the code is 95% identical (perhaps a change can be made such that both `colimit` and `glue` share more code?).

There is an analogous operation (called `coglue` here) that performs a limit of LooseACSetTransformations where you can specify up front what the `type_components` of the resulting legs should be. 