### PR TITLE
Rename monic/epic and allow tight acset transformations

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -30,7 +30,7 @@ using ..FreeDiagrams, ..Limits, ..Subobjects, ..FinSets, ..FinCats
 import ..Limits: limit, colimit, universal
 import ..Subobjects: Subobject, implies, ⟹, subtract, \, negate, ¬, non, ~
 import ..Sets: SetOb, SetFunction, TypeSet
-import ..FinSets: FinSet, FinFunction, FinDomFunction, force, predicate, is_injective, is_surjective
+import ..FinSets: FinSet, FinFunction, FinDomFunction, force, predicate, is_monic, is_epic
 import ..FinCats: FinDomFunctor, components, is_natural
 
 # Sets interop
@@ -383,16 +383,16 @@ function is_natural(α::ACSetTransformation{S}) where {S}
   return true
 end
 
-function is_injective(α::CSetTransformation{S}) where {S}
+function is_monic(α::TightACSetTransformation{S}) where {S}
   for c in components(α)
-    if !is_injective(c) return false end
+    if !is_monic(c) return false end
   end
   return true
 end
 
-function is_surjective(α::CSetTransformation{S}) where {S}
+function is_epic(α::TightACSetTransformation{S}) where {S}
   for c in components(α)
-    if !is_surjective(c) return false end
+    if !is_epic(c) return false end
   end
   return true
 end

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -4,7 +4,7 @@ module FinSets
 export FinSet, FinFunction, FinDomFunction, TabularSet, TabularLimit,
   force, is_indexed, preimage,
   JoinAlgorithm, SmartJoin, NestedLoopJoin, SortMergeJoin, HashJoin,
-  SubFinSet, SubOpBoolean, is_injective, is_surjective
+  SubFinSet, SubOpBoolean, is_monic, is_epic
 
 using StructEquality
 using DataStructures: OrderedDict, IntDisjointSets, union!, find_root!
@@ -391,9 +391,9 @@ Sets.do_compose(f::Union{FinFunctionVector,IndexedFinFunctionVector},
   FinDomFunctionVector(g.func[f.func], codom(g))
 
 # These could be made to fail early if ever used in performance-critical areas
-is_surjective(f::FinFunction) =
+is_epic(f::FinFunction) =
 length(codom(f)) == length(Set(values(collect(f))))
-is_injective(f::FinFunction)  =
+is_monic(f::FinFunction)  =
 length(dom(f)) == length(Set(values(collect(f))))
 
 # Dict-based functions

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -91,12 +91,12 @@ I = @acset Graph begin V=2; E=2; src=[1,2]; tgt=[1,2] end
 f_ = homomorphism(G, H; monic=true)
 g_ = homomorphism(H, G)
 h_ = homomorphism(G, I)
-@test is_injective(f_)
-@test !is_surjective(f_)
-@test !is_injective(g_)
-@test is_surjective(g_)
-@test !is_injective(h_)
-@test !is_surjective(h_)
+@test is_monic(f_)
+@test !is_epic(f_)
+@test !is_monic(g_)
+@test is_epic(g_)
+@test !is_monic(h_)
+@test !is_epic(h_)
 
 
 # Limits

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -112,12 +112,12 @@ g = FinFunction([1,1,2])
 X = FinSet(Set([:x,:y,:z]))
 k = FinFunction(Dict(:a => :x, :b => :y, :c => :z), X)
 
-@test is_injective(f)
-@test !is_surjective(f)
-@test is_surjective(g)
-@test !is_injective(g)
-@test is_injective(k)
-@test is_surjective(k)
+@test is_monic(f)
+@test !is_epic(f)
+@test is_epic(g)
+@test !is_monic(g)
+@test is_monic(k)
+@test is_epic(k)
 
 # Functions out of finite sets
 ##############################

--- a/test/categorical_algebra/Limits.jl
+++ b/test/categorical_algebra/Limits.jl
@@ -57,7 +57,7 @@ epi, mono = epi_mono(f)
 @test is_isomorphic(codom(epi), Im)
 @test is_isomorphic(image(f)|>apex, Im)
 @test is_isomorphic(coimage(f)|>apex, Im)
-@test is_surjective(epi)
-@test is_injective(mono)
+@test is_epic(epi)
+@test is_monic(mono)
 
 end


### PR DESCRIPTION
Addressing both https://github.com/AlgebraicJulia/Catlab.jl/issues/684 and https://github.com/AlgebraicJulia/Catlab.jl/issues/683