### PR TITLE
Fix unused type parameters related to acset schemas

### DIFF
--- a/src/acsets/DenseACSets.jl
+++ b/src/acsets/DenseACSets.jl
@@ -256,7 +256,7 @@ function AnonACSetType(
   end
 end
 
-function ACSetTableSchema(s::Schema{Symbol}, ob::Symbol) where {S}
+function ACSetTableSchema(s::Schema{Symbol}, ob::Symbol)
   attrs = filter(Schemas.attrs(s)) do (f,d,c)
     d == ob
   end
@@ -396,7 +396,7 @@ end
 @inline ACSetInterface.incident(acs::StructACSet{S}, ::Colon, f::Symbol; unbox_injective=true) where {S} =
   _incident(acs, Val{S}, :, Val{f}, unbox_injective)
 
-ACSetInterface.incident(acs::DynamicACSet, ::Colon, f::Symbol; unbox_injective=true) where {S} =
+ACSetInterface.incident(acs::DynamicACSet, ::Colon, f::Symbol; unbox_injective=true) =
   runtime(_incident, acs, acs.schema, :, f, unbox_injective)
 
 @ct_enable function _incident(acs::SimpleACSet, @ct(S), ::Colon, @ct(f), unbox_injective)

--- a/src/categorical_algebra/DataMigrations.jl
+++ b/src/categorical_algebra/DataMigrations.jl
@@ -459,7 +459,7 @@ end
 Returns a `FreeDiagram` whose objects are the generating objects of `pres` and 
 whose homs are the generating homs of `pres`.
 """
-function FreeDiagrams.FreeDiagram(pres::Presentation{ThSchema, Symbol}) where Schema
+function FreeDiagrams.FreeDiagram(pres::Presentation{ThSchema, Symbol})
   obs = Array{FreeSchema.Ob}(generators(pres, :Ob))
   homs = Array{FreeSchema.Hom}(generators(pres, :Hom))
   doms = map(h -> generator_index(pres, nameof(dom(h))), homs)


### PR DESCRIPTION
These were triggering warnings during precompilation.

Follow up to #681.