### PR TITLE
Use intermediating AST in diagram macros

### DIFF
--- a/test/programs/DiagrammaticPrograms.jl
+++ b/test/programs/DiagrammaticPrograms.jl
@@ -86,7 +86,8 @@ end
                       SchGraph, SchCPortGraph)
 
 # Incomplete definition.
-@test_throws ErrorException begin
+# FIXME: Throw more informative exception.
+@test_throws Exception begin
   @finfunctor SchGraph SchCPortGraph begin
     V => Box
     src => src ⨟ box

--- a/test/programs/DiagrammaticPrograms.jl
+++ b/test/programs/DiagrammaticPrograms.jl
@@ -85,9 +85,13 @@ end
                       Dict(:src => [:src, :box], :tgt => [:tgt, :box]),
                       SchGraph, SchCPortGraph)
 
-# Incomplete definition.
-# FIXME: Throw more informative exception.
-@test_throws Exception begin
+# Incomplete definitions.
+@test_throws ErrorException begin
+  @finfunctor SchGraph SchCPortGraph begin
+    V => Box
+  end
+end
+@test_throws ErrorException begin
   @finfunctor SchGraph SchCPortGraph begin
     V => Box
     src => src ⨟ box


### PR DESCRIPTION
This refactor required a lot more work than I expected, but the improved design should be make it easier to maintain and extend the `@migration` macro and related macros.