### PR TITLE
Typo in type declaration of `FinDomFunctionDict`

### DIFF
--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -396,7 +396,7 @@ The domain is a `FinSet{S}` where `S` is the type of the dictionary's `keys`
 collection.
 """
 @struct_hash_equal struct FinDomFunctionDict{K,D<:AbstractDict{K},Codom<:SetOb} <:
-    SetFunction{FinSet{AbstractSet{K},K},Codom}
+    SetFunction{FinSetCollection{Base.KeySet{K,D},K},Codom}
   func::D
   codom::Codom
 end

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -237,7 +237,7 @@ The domain of this function is always of type `FinSet{Int}`, with elements of
 the form ``{1,...,n}``.
 """
 struct FinDomFunctionVector{T,V<:AbstractVector{T}, Codom<:SetOb{T}} <:
-    FinDomFunction{Int,FinSetInt,Codom}
+    SetFunction{FinSetInt,Codom}
   func::V
   codom::Codom
 end
@@ -286,7 +286,7 @@ Works in the same way as the special case of [`IndexedFinFunctionVector`](@ref),
 except that the index is typically a dictionary, not a vector.
 """
 struct IndexedFinDomFunctionVector{T,V<:AbstractVector{T},Index,Codom<:SetOb{T}} <:
-    FinDomFunction{Int,FinSetInt,Codom}
+    SetFunction{FinSetInt,Codom}
   func::V
   index::Index
   codom::Codom
@@ -396,7 +396,7 @@ The domain is a `FinSet{S}` where `S` is the type of the dictionary's `keys`
 collection.
 """
 @struct_hash_equal struct FinDomFunctionDict{K,D<:AbstractDict{K},Codom<:SetOb} <:
-    FinDomFunction{D,FinSet{AbstractSet{K},K},Codom}
+    SetFunction{FinSet{AbstractSet{K},K},Codom}
   func::D
   codom::Codom
 end

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -51,6 +51,7 @@ F = FinDomFunctor([FinSet(1), FinSet(3), FinSet(1)],
 f = FinFunction([1,3,4], 5)
 g = FinFunction([1,1,2,2,3], 3)
 h = FinFunction([3,1,2], 3)
+@test f isa FinFunction{Int,Int}
 @test (dom(f), codom(f)) == (FinSet(3), FinSet(5))
 @test force(f) === f
 @test codom(FinFunction([1,3,4])) == FinSet(4)
@@ -58,6 +59,7 @@ h = FinFunction([3,1,2], 3)
 X = FinSet(Set([:w,:x,:y,:z]))
 k = FinFunction(Dict(:a => :x, :b => :y, :c => :z), X)
 ℓ = FinFunction(Dict(:w => 2, :x => 1, :y => 1, :z => 4), FinSet(4))
+@test ℓ isa FinFunction{<:AbstractSet{Symbol},Int}
 @test (dom(k), codom(k)) == (FinSet(Set([:a, :b, :c])), X)
 @test (dom(ℓ), codom(ℓ)) == (X, FinSet(4))
 @test force(k) === k


### PR DESCRIPTION
I'm not sure why Julia didn't throw an error here given the type constraint on `FinDomFunction`, but the issue can be avoided entirely since `FinFunction` and `FinDomFunction` are just type aliases for `SetFunction` subject to certain constraints.