### PR TITLE
factoring morphisms into composites 

### DIFF
--- a/src/categorical_algebra/Slices.jl
+++ b/src/categorical_algebra/Slices.jl
@@ -8,6 +8,8 @@ using ...Theories: ThCategory
 import ...Theories: dom, codom, compose, id
 import ..Limits: limit, colimit, universal
 import ..FinSets: force
+import ..CSets: factorize_constraints, is_natural, homomorphism, homomorphisms, 
+                components, factorize
 
 """
 The data of the object of a slice category (say, some category C sliced over an
@@ -86,6 +88,9 @@ function slice_diagram(f::FreeDiagram)::FreeDiagram
   FreeDiagram(obs,homs)
 end
 
+factorize_constraints(f::SliceHom,g::SliceHom; initial=Dict()) = 
+  factorize_constraints(f.f,g.f; initial=initial)
+
 """
 Convert a limit problem in the slice category to a limit problem of the
 underlying category.
@@ -126,5 +131,52 @@ function universal(lim::SliceLimit, sp::Multispan)
   apx2 = Slice(first(legs(lim.underlying.cone)))
   return SliceHom(apx, apx2, u)
 end
+
+is_natural(x::SliceHom) = is_natural(x.f)
+components(x::SliceHom) = components(x.f)
+Base.getindex(α::SliceHom, c) = x.f[c]
+
+"""
+This could be made more efficient as a constraint *during* homomorphism finding.
+
+This would require implementing a new constraint to homomorphism search that 
+restricts the codomain for each part of A, i.e. ∀ a ∈ A: h(a) ∈ g⁻¹(f(a)).
+"""
+function homomorphisms(X::Slice,Y::Slice; kw...)
+  map(filter(h->force(X.slice)==force(compose(h,Y.slice)),
+         homomorphisms(dom(X), dom(Y); kw...)) ) do h
+    SliceHom(X, Y, h)
+  end |> collect
+end
+
+"""
+Because the constraint isn't incorporated into the search process, we cannot 
+stop early.
+"""
+function homomorphism(X::Slice,Y::Slice; kw...)
+  hs = homomorphisms(X,Y; kw...)
+  return isempty(hs) ? nothing : first(hs)
+end
+
+"""
+Factorizing a cospan is equivalent to looking for a slice morphism. f->g
+
+         B
+  h = ? ↗ ↘ g 
+       A ⟶ C
+         f
+"""
+function factorize(s::Cospan; initial=Dict(), single::Bool=true, kw...)
+  f, g = Slice.(s)
+  search = single ? homomorphism : homomorphisms
+  res = search(f, g; initial=NamedTuple(initial), kw...)
+  if isnothing(res) 
+    return nothing 
+  else 
+    return [x.f for x in res]
+  end
+end
+
+
 
 end # module

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -98,6 +98,19 @@ h_ = homomorphism(G, I)
 @test !is_monic(h_)
 @test !is_epic(h_)
 
+# Factorizing morphisms 
+#----------------------
+
+p2, p3 = path_graph(Graph, 2), path_graph(Graph, 3)
+loop = apex(terminal(Graph))
+f = CSetTransformation(Graph(2), p3; V=[2,1])
+g1 = CSetTransformation(Graph(2), p2; V=[1,2])
+g2 = CSetTransformation(Graph(2), p2; V=[2,1])
+@test isnothing(factorize(Span(f, g1)))
+@test length(factorize(Span(f, g2); single=false)) == 1
+f2 = homomorphism(Graph(2), loop)
+@test isnothing(factorize(Span(f2, id(Graph(2))); monic=true))
+@test factorize(Span(f2, id(Graph(2)))) == f2
 
 # Limits
 #-------

--- a/test/categorical_algebra/Slices.jl
+++ b/test/categorical_algebra/Slices.jl
@@ -59,4 +59,32 @@ slice_dia = FreeDiagram{Slice,SliceHom}(Multispan(A, [f, g]))
 clim = colimit(slice_dia)
 @test is_isomorphic(dom(apex(clim)), d)
 
+
+# Factorizing morphisms (morally same tests as in CSets) 
+#-------------------------------------------------------
+p2G, p3G = [path_graph(Graph, x) for x in [3,5]]
+p2, p3 = [Slice(homomorphism(p, two)) for p in [p2G,p3G]] #  ⊚→□→⊚ and  ⊚→□→⊚□→⊚
+loop = Slice(id(two)) # ⊚ ↔ □
+g2G = Slice(ACSetTransformation(Graph(2), two; V=[1,1])) # ⊚ ⊚
+f = SliceHom(g2G, p3, ACSetTransformation(Graph(2), p3G; V=[3,1]))
+g1 = SliceHom(g2G, p2, CSetTransformation(Graph(2), p2G; V=[1,3]))
+g2 = SliceHom(g2G, p2, CSetTransformation(Graph(2), p2G; V=[3,1]))
+@test isnothing(factorize(Span(f, g1)))
+@test length(factorize(Span(f, g2); single=false)) == 1
+f2 = homomorphism(g2G, loop)
+@test isnothing(factorize(Span(f2, id(g2G)); monic=true))
+@test factorize(Span(f2, id(g2G))) == f2
+
+# factorize C-set morphisms where the second one is known
+#--------------------------------------------------------
+
+A = path_graph(Graph, 2)
+B = @acset Graph begin V=4; E=3; src=[1,1,3]; tgt=[2,4,4] end
+C = @acset Graph begin V=2; E=2; src=1; tgt=2 end
+
+f = CSetTransformation(A, C; V=[1,2], E=[1])
+g = CSetTransformation(B, C; V=[1,2,1,2], E=[1,2,1])
+
+@test length(factorize(Cospan(f,g); single=false)) == 2
+
 end # module


### PR DESCRIPTION
The general problem solved is that we have an `f: A -> C` and want to factor it into `g;h` or `h;g` (where `g` is known and `h` is being solved for). 

This is implemented in C-**Set** as well as slice cats. The hope is that the main code can be written agnostic to what category we are working in, and whether or not one's particular types implement `homomorphisms` and `factorize_constraints` dictates how `factorize` behaves on a (co)span of morphisms in a given category.