### PR TITLE
Delta migration of acset transformations

### DIFF
--- a/src/categorical_algebra/Chase.jl
+++ b/src/categorical_algebra/Chase.jl
@@ -347,6 +347,26 @@ end
 
 # Sigma migration
 #################
+"""
+Convert a CSet morphism X->Y into a CSet on the schema C->C 
+(collage of id functor on C).
+"""
+collage(f::ACSetTransformation{S}) where S = collage(f, Presentation(S))
+function collage(f::ACSetTransformation, S::Presentation)
+  colim, col_pres = collage(id(FinCat(S)))
+  colimL, colimR = colim
+  res = AnonACSet(col_pres)
+  for o in ob(Schema(S))
+    add_parts!(res, nameof(ob_map(colimL,o)), nparts(dom(f), o))
+    add_parts!(res, nameof(ob_map(colimR,o)), nparts(codom(f), o))
+    set_subpart!(res, Symbol("α_$o"), collect(f[o]))
+  end
+  for h in homs(Schema(S); just_names=true)
+    set_subpart!(res, nameof(hom_map(colimL,h)), dom(f)[h])
+    set_subpart!(res, nameof(hom_map(colimR,h)), codom(f)[h])
+  end
+  colim, res
+end 
 
 """
 A collage of a functor is a schema encoding the data of the functor

--- a/src/categorical_algebra/FunctorialDataMigrations.jl
+++ b/src/categorical_algebra/FunctorialDataMigrations.jl
@@ -117,6 +117,25 @@ function migrate!(X::ACSet, Y::ACSet, FOb, FHom)
   migrate!(X, Y, M)
 end
 
+# On morphisms
+migrate(t::Type{T}, f::ACSetTransformation, M::DeltaMigration) where T <: ACSet = 
+  migrate(t, f, M.functor)
+
+migrate(t::Type{T}, f::ACSetTransformation, F::FinFunctor) where T <: ACSet = 
+  migrate(t, f, ob_map(F), hom_map(F))
+
+function migrate(::Type{T}, f::TightACSetTransformation,
+                FOb::AbstractDict, FHom::AbstractDict) where T <: ACSet
+  d = Dict()
+  for (ob_dom,ob_codom) in pairs(FOb)
+    if Symbol(ob_codom) ∈ keys(components(f))
+      d[Symbol(ob_dom)] = f[Symbol(ob_codom)]
+    end
+  end
+  Fd, Fcd = migrate(T, dom(f), FOb, FHom), migrate(T, codom(f), FOb, FHom)
+  TightACSetTransformation(NamedTuple(d), Fd, Fcd)
+end
+
 """ Abstract type for a data migration functor.
 
 This allows a data migration to behave as an actual model of the theory 

--- a/test/categorical_algebra/Chase.jl
+++ b/test/categorical_algebra/Chase.jl
@@ -3,7 +3,16 @@ using Test
 
 using Catlab.GATs, Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.Graphs
 using Catlab.CategoricalAlgebra.Chase: egd, tgd, crel_type, pres_to_eds,
-  from_c_rel
+  from_c_rel, collage
+
+# ACSetTransformations as ACSets on the collage
+###############################################
+
+h = homomorphism(path_graph(Graph, 2), path_graph(Graph, 3))
+_, col = collage(h)
+col[Symbol("α_V")] == h[:V] |> collect
+col[Symbol("α_E")] == h[:E] |> collect
+
 
 # Factorizing EDs
 #----------------

--- a/test/categorical_algebra/FunctorialDataMigrations.jl
+++ b/test/categorical_algebra/FunctorialDataMigrations.jl
@@ -30,12 +30,23 @@ add_parts!(h, :E, 3, src = [1,2,3], tgt = [2,3,1])
 dds = DDS()
 add_parts!(dds, :X, 3, Φ=[2,3,1])
 X = SchDDS[:X]
-@test h == migrate(Graph, dds, Dict(:V => :X, :E => :X),
-                   Dict(:src => id(X), :tgt => :Φ))
+FOb = Dict(:V => :X, :E => :X)
+FHom = Dict(:src => id(X), :tgt => :Φ)
+F = DeltaMigration(FinFunctor(FOb,FHom,SchGraph,SchDDS))
+Δ(x) = migrate(Graph, x, FOb,FHom)
 
+@test h == Δ(dds)
+
+# test on morphisms
+dds′ = @acset DDS begin X=5; Φ=[2,3,4,4,3] end
+dds2 = @acset DDS begin X=3; Φ=[2,3,3] end 
+f = ACSetTransformation(dds′,dds2; X=[1,2,3,3,3])
+Δf = homomorphism(Δ(dds′),Δ(dds2); initial=(V=[1,2,3,3,3],))
+@test Δf == migrate(Graph, f, F)
+
+# Mutating migration
 h2 = copy(h)
-migrate!(h2, dds, Dict(:V => :X, :E => :X),
-                  Dict(:src => id(X), :tgt => :Φ))
+migrate!(h2, dds, FOb, FHom)
 @test h2 == ob(coproduct(h, h))
 
 # Migrate DDS → DDS by advancing four steps.


### PR DESCRIPTION
Functorial data migration should work on morphisms of ACSets too. It seems simple to work this out for delta - I'm not sure how other migrations might look. In the case of delta, it is straightforward to apply the functor to the domain and codomain and then copy the components (or type components) based on the data of the functor. 

One interesting thing I noticed is that it's not possible to apply a DeltaMigration to a LooseACSetTransformation `f: WeightedGraph{Int} -> WeightedGraph{Symbol}`, for example. This is because the data of a DeltaTransformation requires you to specify the concrete ACSet types, which means you can't apply the same DeltaMigration to both the domain and codomain of `f`. 