### PR TITLE
Option `product_attrs` for ACSet limits 

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -828,6 +828,21 @@ function limit(::Type{<:Tuple{ACS,TightACSetTransformation}}, diagram) where
   pack_limit(ACS, diagram, Xs, limits)
 end
 
+"""
+A limit of a diagram of ACSets with LooseACSetTransformations.
+
+For general diagram shapes, the apex of the categorical limit will not have
+clean Julia types for its attributes, i.e. predicates will be needed to further 
+constrain them. `product_attrs` must be turned on in order to avoid an error in 
+cases where predicates would be needed. 
+
+`product_attrs=true` will take a limit of the purely combinatorial data, and 
+the attribute data of the apex is dictated purely by the ACSets that are have 
+explicit cone legs: the value of an attribute (e.g. `f`) for the i'th part in  
+the apex is the product `(f(π₁(i)), ..., f(πₙ(i)))` where π maps come from 
+the combinatorial part of the limit legs. The type components of the j'th leg of 
+the limit is just the j'th cartesian projection.
+"""
 function limit(::Type{Tuple{ACS,Hom}}, diagram; product_attrs::Bool=false) where
     {S, ACS <: StructACSet{S}, Hom <: LooseACSetTransformation}
   limits = map(limit, unpack_diagram(diagram, all=!product_attrs))
@@ -841,7 +856,7 @@ function limit(::Type{Tuple{ACS,Hom}}, diagram; product_attrs::Bool=false) where
     ACSUnionAll = Base.typename(ACS).wrapper
     ACSUnionAll{(eltype(ob(attr_lims[d])) for d in attrtypes(S))...}
   end
-  
+
   type_components = [
     Dict(d=>legs(attr_lims[d])[i] for d in attrtypes(S)) for i in eachindex(Xs)]
   

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -309,6 +309,20 @@ pb = ob(pullback(ϕ, ψ))
 @test (nv(pb), ne(pb)) == (8, 2)
 @test Set(pb[:weight]) == Set([(+1, -1), (-1, +1)])
 
+# Limit with LooseACSetTransformations 
+A = @acset VELabeledGraph{Symbol} begin V=2; vlabel=[:a,:b] end;
+B = @acset VELabeledGraph{Symbol} begin V=2; vlabel=[:q,:z] end;
+C = @acset VELabeledGraph{Symbol} begin V=2; vlabel=[:x,:y] end;
+ac = LooseACSetTransformation(
+  Dict([:V=>[1,2]]),Dict([:Label=>FinFunction(Dict(:a=>:x,:b=>:y))]),A,C);
+bc = LooseACSetTransformation(
+  Dict([:V=>[1,1]]),Dict([:Label=>FinFunction(Dict(:q=>:x,:z=>:x))]),B,C);
+@test all(is_natural,[ac,bc])
+res = limit(Cospan(ac,bc); product_attrs=true);
+@test all(is_natural,legs(res))
+@test apex(res)[:vlabel] == [(:a,:q),(:a,:z)]
+
+
 # Colimits
 #---------
 


### PR DESCRIPTION
We may want to take a limit, such as a pullback, on ACSets where we are actually only computing the limit of the *combinatorial* data. The question is how to handle the attributes in a canonical way: this is addressed by making the attributes of the apex of the limit to be the product of all* the attributes of objects in the diagram.

*: This is not strictly true: we only take the product of objects in the diagram which apex has legs into. Limits mathematically have legs into all objects of the diagram that we compute the limit of, but the `cone_obs` picks out specific objects for which we want to explicitly represent the legs to. This is typically the objects in the diagram which have no incoming morphisms.