### PR TITLE
Drawing FinFunctions using Graphviz

### DIFF
--- a/docs/literate/graphics/graphviz_graphs.jl
+++ b/docs/literate/graphics/graphviz_graphs.jl
@@ -57,3 +57,39 @@ to_graphviz(f, edge_colors=true)
 to_graphviz(f, draw_codom=false)
 #-
 to_graphviz(f, draw_codom=false, edge_colors=false)
+
+# ## Drawing maps between finite sets
+# 
+# It is also possible to visualize maps between finite sets (`FinFunction`s between
+# `FinSet`s) using Graphviz.
+
+using Catlab.CategoricalAlgebra.FinSets
+
+A = FinSet(4)
+B = FinSet(3)
+f = FinFunction([1,2,2,3], A, B)
+
+# By default the mapping is shown by edges between the domain and codomain
+# subgraphs. One can turn this off with `draw_edge=false` if desired. By
+# using `elem_colors=true`, the mapping will be denoted with colors instead of
+# or in addition to edges. If using colors one can additionally use 
+# `edge_colors=true` to color the edges between subgraphs.
+
+to_graphviz(f)
+
+# For example:
+
+to_graphviz(f, elem_colors=true, edge_colors=true)
+
+# Elements in the sets can be labeled by setting `elem_labels=true`. Additionally
+# there are keyword args `invis_edge_dom` and `invis_edge_codom` which accept
+# boolean values. If set to `true` then invisible edges are drawn between elements
+# in the subgraph for which the argument was selected. This can help align the
+# subgraphs when trying to achieve a desired "look" for the graphic, especially
+# when combined with the graph attribute [`rankdir`](https://graphviz.org/docs/attrs/rankdir/).
+
+to_graphviz(
+    f, elem_colors=true, edge_colors=true,
+    invis_edge_dom=true, invis_edge_codom=true,
+    graph_attrs=Dict(:rankdir => "TB")
+)

--- a/src/graphics/GraphvizGraphs.jl
+++ b/src/graphics/GraphvizGraphs.jl
@@ -512,8 +512,6 @@ function to_graphviz(f::FinFunction;
   # map: A->B
   if draw_edge
     map_stmts = map(A) do e
-      # Graphviz.Edge(["\"dom_$(e)\"", "\"cod_$(f(e))\""], 
-      #               Graphviz.Attributes(:constraint => "false", :style => "dotted"))
       Graphviz.Edge(["\"dom_$(e)\"", "\"cod_$(f(e))\""],
                     merge!(edge_color(mcolors, f(e)),
                           Dict(:constraint => "false", :style => "dotted")))

--- a/test/graphics/GraphvizGraphs.jl
+++ b/test/graphics/GraphvizGraphs.jl
@@ -6,6 +6,7 @@ using Catlab.Theories, Catlab.Graphs, Catlab.Graphics.GraphvizGraphs
 import Catlab.Graphics: Graphviz
 using Catlab.CategoricalAlgebra.Subobjects
 using Catlab.CategoricalAlgebra.CSets
+using Catlab.CategoricalAlgebra.FinSets
 
 const stmts = Graphviz.filter_statements
 
@@ -177,5 +178,28 @@ f = ACSetTransformation(A, B; V = [1,2,2], E = [1,1])
 gv = to_graphviz(f, draw_codom=true)
 @test gv.directed
 @test length(stmts(gv, Graphviz.Subgraph)) == 2
+
+# homomorphisms between FinSet(s)
+#################################
+
+A = FinSet(4)
+B = FinSet(4)
+f = FinFunction([1,2,2,3], A, B)
+
+gv = to_graphviz(f)
+@test length(stmts(gv, Graphviz.Subgraph)) == 2
+@test length(stmts(gv, Graphviz.Edge)) == 4
+@test gv.directed
+
+A = FinSet(1)
+B = FinSet(2)
+f = FinFunction([2], A, B)
+
+gv = to_graphviz(f)
+@test length(stmts(gv, Graphviz.Subgraph)) == 2
+@test length(stmts(gv, Graphviz.Edge)) == 1
+
+# gv = to_graphviz(f, graph_attrs = Dict(:rankdir => "TB"))
+# stmts(gv, Graphviz.AttributeValue, :rankdir)
 
 end

--- a/test/graphics/GraphvizGraphs.jl
+++ b/test/graphics/GraphvizGraphs.jl
@@ -199,7 +199,22 @@ gv = to_graphviz(f)
 @test length(stmts(gv, Graphviz.Subgraph)) == 2
 @test length(stmts(gv, Graphviz.Edge)) == 1
 
-# gv = to_graphviz(f, graph_attrs = Dict(:rankdir => "TB"))
-# stmts(gv, Graphviz.AttributeValue, :rankdir)
+gv = to_graphviz(f, graph_attrs = Dict(:rankdir => "TB"))
+@test length(gv.graph_attrs) == 1
+@test gv.graph_attrs[:rankdir] == "TB"
+
+gv = to_graphviz(f, invis_edge_dom=true, invis_edge_codom=true)
+@test stmts(gv, Graphviz.Subgraph)[2].stmts[1] isa Graphviz.Node
+@test stmts(gv, Graphviz.Subgraph)[2].stmts[2] isa Graphviz.Node
+@test stmts(gv, Graphviz.Subgraph)[2].stmts[3] isa Graphviz.Edge
+@test length(stmts(gv, Graphviz.Subgraph)[1].stmts) == 1
+
+gv = to_graphviz(f, draw_edge=false)
+@test length(stmts(gv, Graphviz.Edge)) == 0 
+
+gv = to_graphviz(f, edge_colors=true, elem_colors=true)
+@test haskey(stmts(gv, Graphviz.Edge)[1].attrs, :color)
+@test haskey(stmts(gv, Graphviz.Subgraph)[2].stmts[1].attrs, :color)
+@test haskey(stmts(gv, Graphviz.Subgraph)[2].stmts[2].attrs, :color)
 
 end


### PR DESCRIPTION
Simple PR which makes it easier to visualize `FinFunction` using Graphviz, based on the earlier PR #655. I added some documentation to graphics/graphviz_graphs.jl regarding use of it, which you might feel should go somewhere else, but I didn't know anywhere more suitable.

~~The unit tests are too minimal, but I had trouble finding out how to get at the statements within `Subgraph` objects. @epatters if you have any suggestions as to how to go about this, I'd be very happy to include more substantive tests!~~

[EDIT]: non-trivial tests implemented https://github.com/AlgebraicJulia/Catlab.jl/pull/725/commits/d19361127155e9af7bdfaa950df7447ec2e8b2ae