### PR TITLE
Reformat Tuple node labels in Graphviz graphs

### DIFF
--- a/src/graphics/GraphvizGraphs.jl
+++ b/src/graphics/GraphvizGraphs.jl
@@ -165,7 +165,6 @@ function to_graphviz_property_graph(g::AbstractGraph;
   )
 end
 
-# node_label(g, name::Symbol, v::Int) = Dict(:label => string(g[v, name]))
 node_label(g, name::Symbol, v::Int) = Dict(:label => node_label_to_string(g[v, name]))
 node_label(g, labels::Bool, v::Int) = Dict(:label => labels ? string(v) : "")
 

--- a/src/graphics/GraphvizGraphs.jl
+++ b/src/graphics/GraphvizGraphs.jl
@@ -165,15 +165,15 @@ function to_graphviz_property_graph(g::AbstractGraph;
   )
 end
 
-node_label(g, name::Symbol, v::Int) = Dict(:label => node_label_to_string(g[v, name]))
+node_label(g, name::Symbol, v::Int) = Dict(:label => label_to_string(g[v, name]))
 node_label(g, labels::Bool, v::Int) = Dict(:label => labels ? string(v) : "")
 
-node_label_to_string(vlabel::T) where {T} = string(vlabel)
-node_label_to_string(vlabel::Tuple) = join(string.(vlabel), ',')
-
-edge_label(g, name::Symbol, e::Int) = Dict(:label => string(g[e, name]))
+edge_label(g, name::Symbol, e::Int) = Dict(:label => label_to_string(g[e, name]))
 edge_label(g, labels::Bool, e::Int) =
   labels ? Dict(:label => string(e)) : Dict{Symbol,String}()
+
+label_to_string(vlabel::T) where {T} = string(vlabel)
+label_to_string(vlabel::Tuple) = join(string.(vlabel), ',')  
 
 function default_graph_attrs(prog::AbstractString)
   attrs = Dict{Symbol,String}()

--- a/src/graphics/GraphvizGraphs.jl
+++ b/src/graphics/GraphvizGraphs.jl
@@ -165,8 +165,12 @@ function to_graphviz_property_graph(g::AbstractGraph;
   )
 end
 
-node_label(g, name::Symbol, v::Int) = Dict(:label => string(g[v, name]))
+# node_label(g, name::Symbol, v::Int) = Dict(:label => string(g[v, name]))
+node_label(g, name::Symbol, v::Int) = Dict(:label => node_label_to_string(g[v, name]))
 node_label(g, labels::Bool, v::Int) = Dict(:label => labels ? string(v) : "")
+
+node_label_to_string(vlabel::T) where {T} = string(vlabel)
+node_label_to_string(vlabel::Tuple) = join(string.(vlabel), ',')
 
 edge_label(g, name::Symbol, e::Int) = Dict(:label => string(g[e, name]))
 edge_label(g, labels::Bool, e::Int) =

--- a/test/graphics/GraphvizGraphs.jl
+++ b/test/graphics/GraphvizGraphs.jl
@@ -102,6 +102,26 @@ g = path_graph(WeightedGraph{Float64}, 3, E=(weight=[0.5, 1.5],))
 gv = to_graphviz(g, edge_labels=:weight)
 @test stmts(gv, Graphviz.Edge, :label) == ["0.5", "1.5"]
 
+@present SchEdgeLabeledGraph <: SchLabeledGraph begin
+    Edge_Label::AttrType
+    edge_label::Attr(E,Edge_Label)
+end
+
+@acset_type EdgeLabeledGraph(SchEdgeLabeledGraph, index=[:src,:tgt]) <: AbstractLabeledGraph
+
+g = @acset EdgeLabeledGraph{Tuple, Tuple} begin
+    V = 2
+    label = [("a", "1"), ("b", "2")]
+end
+
+gv = to_graphviz(g, node_labels=:label)
+@test stmts(gv, Graphviz.Node, :label) == ["a,1", "b,2"]
+
+add_edges!(g, [1], [2], edge_label = [("a", "1")])
+
+gv = to_graphviz(g, edge_labels=:edge_label, node_labels=:label)
+@test stmts(gv, Graphviz.Edge, :label) == ["a,1"]
+
 # Symmetric graphs
 ##################
 

--- a/test/graphics/GraphvizGraphs.jl
+++ b/test/graphics/GraphvizGraphs.jl
@@ -86,6 +86,18 @@ g = path_graph(LabeledGraph{Symbol}, 3, V=(label=[:x, :y, :z],))
 gv = to_graphviz(g, node_labels=:label)
 @test stmts(gv, Graphviz.Node, :label) == ["x", "y", "z"]
 
+g = path_graph(LabeledGraph{Tuple}, 3, V=(label=[("1",), ("2",), ("3",)],))
+gv = to_graphviz(g, node_labels=:label)
+@test stmts(gv, Graphviz.Node, :label) == ["1", "2", "3"]
+
+g = path_graph(LabeledGraph{Tuple}, 3, V=(label=[("1", "a"), ("2", "b"), ("3", "c")],))
+gv = to_graphviz(g, node_labels=:label)
+@test stmts(gv, Graphviz.Node, :label) == ["1,a", "2,b", "3,c"]
+
+g = path_graph(LabeledGraph{Tuple}, 3, V=(label=[("1", :a), ("2", :b), ("3", :c)],))
+gv = to_graphviz(g, node_labels=:label)
+@test stmts(gv, Graphviz.Node, :label) == ["1,a", "2,b", "3,c"]
+
 g = path_graph(WeightedGraph{Float64}, 3, E=(weight=[0.5, 1.5],))
 gv = to_graphviz(g, edge_labels=:weight)
 @test stmts(gv, Graphviz.Edge, :label) == ["0.5", "1.5"]


### PR DESCRIPTION
This is a very small PR that just lets `to_graphviz` work with `node_labels` using labels that are Tuples. The reason this is useful is that some operations can change the types of labels on the resulting object. For example, taking the product of a `LabeledGraph{Symbol}` and `LabeledGraph{String}` results in a new label of type `Tuple{Symbol, String}`. This just makes the internal functions in the GraphvizGraphs module break those tuples down into a string for plotting, it's mostly useful for pedagogy.