### PR TITLE
Add debug flag to `is_natural`

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -421,19 +421,19 @@ Xₕ ↓  ✓  ↓ Yₕ
   Xₙ --> Yₙ
      αₙ 
 
-If debug is true, return a list of violations, with elements such as: 
-  (h, index i in Xₐ, Yₕ(αₘ(i)), αₙ(Xₕ(i)))
+If `return_failures` is true, return a list of violations, with elements such as: 
+  (h, index i in Xₘ, Yₕ(αₘ(i)), αₙ(Xₕ(i)))
 
 This is type-unstable, so it should not be used in performance-sensitive code.
 """
-function is_natural(α::ACSetTransformation{S}; debug::Bool=false) where {S}
+function is_natural(α::ACSetTransformation{S}; return_failures::Bool=false) where {S}
   X, Y = dom(α), codom(α)
   unnatural = []
   for (f, c, d) in arrows(S)
     Xf, Yf, α_c, α_d = subpart(X,f), subpart(Y,f), α[c], α[d]
     for i in eachindex(Xf)
       if Yf[α_c(i)] != α_d(Xf[i])
-        if debug 
+        if return_failures 
           push!(unnatural, (f, i, Yf[α_c(i)], α_d(Xf[i])))
         else
           return false 
@@ -441,7 +441,7 @@ function is_natural(α::ACSetTransformation{S}; debug::Bool=false) where {S}
       end
     end
   end
-  return debug ? unnatural : true
+  return return_failures ? unnatural : true
 end
 
 function is_monic(α::TightACSetTransformation{S}) where {S}

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -412,13 +412,36 @@ end
 map_components(f, α::LooseACSetTransformation) =
   LooseACSetTransformation(map(f, components(α)), α.type_components, dom(α), codom(α))
 
-function is_natural(α::ACSetTransformation{S}) where {S}
+"""
+Check naturality condition for a purported ACSetTransformation, α: X→Y. 
+For each hom in the schema, e.g. h: m → n, the following square must commute:
+     αₘ
+  Xₘ --> Yₘ
+Xₕ ↓  ✓  ↓ Yₕ
+  Xₙ --> Yₙ
+     αₙ 
+
+If debug is true, return a list of violations, with elements such as: 
+  (h, index i in Xₐ, Yₕ(αₘ(i)), αₙ(Xₕ(i)))
+
+This is type-unstable, so it should not be used in performance-sensitive code.
+"""
+function is_natural(α::ACSetTransformation{S}; debug::Bool=false) where {S}
   X, Y = dom(α), codom(α)
+  unnatural = []
   for (f, c, d) in arrows(S)
     Xf, Yf, α_c, α_d = subpart(X,f), subpart(Y,f), α[c], α[d]
-    all(i -> Yf[α_c(i)] == α_d(Xf[i]), eachindex(Xf)) || return false
+    for i in eachindex(Xf)
+      if Yf[α_c(i)] != α_d(Xf[i])
+        if debug 
+          push!(unnatural, (f, i, Yf[α_c(i)], α_d(Xf[i])))
+        else
+          return false 
+        end 
+      end
+    end
   end
-  return true
+  return debug ? unnatural : true
 end
 
 function is_monic(α::TightACSetTransformation{S}) where {S}

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -73,6 +73,9 @@ g, h = path_graph(Graph, 4), cycle_graph(Graph, 2)
 @test !is_natural(β)
 β = CSetTransformation((V=[2,1], E=[2,1]), h, h)
 @test is_natural(β)
+β = CSetTransformation((V=[2,1], E=[2,2]), h, h)
+@test is_natural(β;debug=true) == [(:src,2,2,1),(:tgt,2,1,2)]
+
 
 # Category of C-sets.
 @test dom(α) === g
@@ -253,6 +256,8 @@ h = path_graph(WeightedGraph{Float64}, 4, E=(weight=[1.,2.,3.],))
 @test !is_natural(β) # Preserves weight but not graph homomorphism
 β = ACSetTransformation((V=[1,2], E=[1]), g, h)
 @test !is_natural(β) # Graph homomorphism but does not preserve weight
+β = ACSetTransformation((V=[1,3], E=[1]), g, h)
+@test is_natural(β; debug=true) == [(:tgt,1,2,3), (:weight,1,1.,2.)]
 
 # Loose morphisms.
 α = ACSetTransformation(g, h, V=[1,2], E=[1], Weight=x->x/2)

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -74,7 +74,7 @@ g, h = path_graph(Graph, 4), cycle_graph(Graph, 2)
 β = CSetTransformation((V=[2,1], E=[2,1]), h, h)
 @test is_natural(β)
 β = CSetTransformation((V=[2,1], E=[2,2]), h, h)
-@test is_natural(β;debug=true) == [(:src,2,2,1),(:tgt,2,1,2)]
+@test is_natural(β;return_failures=true) == [(:src,2,2,1),(:tgt,2,1,2)]
 
 
 # Category of C-sets.
@@ -257,7 +257,7 @@ h = path_graph(WeightedGraph{Float64}, 4, E=(weight=[1.,2.,3.],))
 β = ACSetTransformation((V=[1,2], E=[1]), g, h)
 @test !is_natural(β) # Graph homomorphism but does not preserve weight
 β = ACSetTransformation((V=[1,3], E=[1]), g, h)
-@test is_natural(β; debug=true) == [(:tgt,1,2,3), (:weight,1,1.,2.)]
+@test is_natural(β; return_failures=true) == [(:tgt,1,2,3), (:weight,1,1.,2.)]
 
 # Loose morphisms.
 α = ACSetTransformation(g, h, V=[1,2], E=[1], Weight=x->x/2)


### PR DESCRIPTION
It can be very helpful when debugging to see why an ACSet transformation is unnatural. When the keyword `debug` is set to true, a list of violations is is returned. (This is type unstable, but `is_natural` shouldn't be used in a hot loop, anyways).