### PR TITLE
Replace `@generated` code in homomorphism search with CompTime

### DIFF
--- a/src/acsets/Schemas.jl
+++ b/src/acsets/Schemas.jl
@@ -4,6 +4,8 @@ export Schema, TypeLevelSchema, BasicSchema, TypeLevelBasicSchema, typelevel,
   objects, attrtypes, attrtype_instantiation, homs, attrs, arrows, dom, codom,
   ob, hom, attrtype, attr, dom_nums, codom_nums, adom_nums, acodom_nums
 
+using StructEquality
+
 # Schemas
 #########
 
@@ -106,7 +108,7 @@ abstract type TypeLevelBasicSchema{Name, obs, homs, attrtypes, attrs} <: TypeLev
 
 const TypeLevelBasicCSetSchema{Name, obs, homs} = TypeLevelBasicSchema{Name, obs, homs, Tuple{}, Tuple{}}
 
-struct BasicSchema{Name} <: Schema{Name}
+@struct_hash_equal struct BasicSchema{Name} <: Schema{Name}
   obs::Vector{Name}
   homs::Vector{Tuple{Name,Name,Name}}
   attrtypes::Vector{Name}

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -669,8 +669,6 @@ in_hom(S, c) = [dom(S,f) => f for f in hom(S) if codom(S,f) == c]
 out_hom(S, c) = [f => codom(S,f) for f in hom(S) if dom(S,f) == c]
 
 
-# Dynamic morphism search
-##########################
 """ Internal state for backtracking search for ACSet homomorphisms.
 """
 struct BacktrackingState{
@@ -745,9 +743,9 @@ function backtracking_search(f, state::BacktrackingState, depth::Int;
     else
       return f(ACSetTransformation(state.assignment, state.dom, state.codom))
     end
-    elseif mrv == 0
-      # An element has no allowable assignment, so we must backtrack.
-      return false
+  elseif mrv == 0
+    # An element has no allowable assignment, so we must backtrack.
+    return false
   end
   c, x = mrv_elem
 

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -831,12 +831,12 @@ end
 
 """ Unassign the element (c,x) in the current assignment.
 """
-unassign_elem!(state::DynamicBacktrackingState{<:StructACSet{S}}, depth, c, x) where S = 
+unassign_elem!(state::BacktrackingState{<:StructACSet{S}}, depth, c, x) where S = 
   _unassign_elem!(Val{S}, state, depth,Val{c},x)
-unassign_elem!(state::DynamicBacktrackingState{DynamicACSet}, depth, c, x) = 
+unassign_elem!(state::BacktrackingState{DynamicACSet}, depth, c, x) = 
   runtime(_unassign_elem!,acset_schema(state.dom), state, depth,c,x)
 
-@ct_enable function _unassign_elem!(@ct(S), state::DynamicBacktrackingState, depth, @ct(c), x) 
+@ct_enable function _unassign_elem!(@ct(S), state::BacktrackingState, depth, @ct(c), x) 
   state.assignment[@ct c][x] == 0 && return
   assign_depth = state.assignment_depth[@ct c][x]
   @assert assign_depth <= depth

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -73,6 +73,17 @@ g = ACSetTransformation(Y,X; V=[1,2], E=[1])
 @test is_natural(g)
 @test compose(g,f) |> force == g
 
+G, H = [DynamicACSet("Grph",SchGraph) for _ in 1:2];
+add_parts!(G, :V, 2); 
+add_parts!(H,:V,2);
+add_part!(G, :E; src=1, tgt=2)
+add_parts!(H, :E,2; src=[1,2], tgt=[1,2])
+hs = homomorphisms(G,H)
+@test length(hs) == 2
+@test all(is_natural,hs)
+
+@test is_natural(id(G))
+
 # C-set morphisms
 #################
 
@@ -486,12 +497,12 @@ h = cycle_graph(LabeledGraph{Symbol}, 4, V=(label=[:a,:b,:d,:c],))
 #-------
 comps(x) = sort([k=>collect(v) for (k,v) in pairs(components(x))])
 # same set of morphisms
-K₇ = complete_graph(SymmetricGraph, 7)
-hs = homomorphisms(K₇,K₇)
-rand_hs = homomorphisms(K₇,K₇; random=true)
+K₆ = complete_graph(SymmetricGraph, 6)
+hs = homomorphisms(K₆,K₆)
+rand_hs = homomorphisms(K₆,K₆; random=true)
 @test sort(hs,by=comps) == sort(rand_hs,by=comps) # equal up to order
 @test hs != rand_hs # not equal given order
-@test homomorphism(K₇,K₇) != homomorphism(K₇,K₇;random=true)
+@test homomorphism(K₆,K₆) != homomorphism(K₆,K₆;random=true)
 
 # Sub-C-sets
 ############


### PR DESCRIPTION
This PR replaces the @generated functions with CompTime functions in `assign_elem!` and `unassign_elem!`. No noticeable performance regressions were observed (though this hasn't been rigorously tested). 