### PR TITLE
Colimits of dynamic acsets

### DIFF
--- a/src/acsets/DenseACSets.jl
+++ b/src/acsets/DenseACSets.jl
@@ -295,6 +295,11 @@ Base.copy(acs::DynamicACSet) =
     deepcopy(acs.subparts)
   )
 
+indices(acs::DynamicACSet) = 
+  [k for (k,v) in collect(acs.subparts) if v.pc isa StoredPreimageCache]
+unique_indices(acs::DynamicACSet) = 
+  [k for (k,v) in collect(acs.subparts) if v.pc isa InjectiveCache]
+
 Base.copy(acs::T) where {T <: StructACSet} = T(copy(acs.parts), map(copy, acs.subparts))
 
 Base.:(==)(acs1::T, acs2::T) where {T <: SimpleACSet} =

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -980,7 +980,7 @@ end
 
 
 function colimit(::Type{<:Tuple{DynamicACSet,TightACSetTransformation}}, diagram) 
-  X = first(cocone_objects(d))
+  X = first(cocone_objects(diagram))
   S = acset_schema(X)
   ACS = ()->DynamicACSet(X.name,S)
   colimits = map(colimit, unpack_diagram(diagram))

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -1020,7 +1020,7 @@ function colimit(para::ParallelMorphisms{<:FinSet{Int}})
   Colimit(para, SMulticospan{1}(quotient_projection(sets)))
 end
 
-function universal(coeq::Coequalizer{<:FinSet{Int}}, cocone::SMulticospan{1})
+function universal(coeq::Coequalizer{<:FinSet{Int}}, cocone::Multicospan)
   pass_to_quotient(proj(coeq), only(cocone))
 end
 

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -80,9 +80,20 @@ add_part!(G, :E; src=1, tgt=2)
 add_parts!(H, :E,2; src=[1,2], tgt=[1,2])
 hs = homomorphisms(G,H)
 @test length(hs) == 2
-@test all(is_natural,hs)
+@test all(is_natural, hs)
 
 @test is_natural(id(G))
+
+G, H, expected = [DynamicACSet("Grph",SchGraph) for _ in 1:3];
+add_parts!(G, :V, 2); 
+add_parts!(H, :V, 2);
+add_parts!(expected, :V, 3);
+add_part!(G, :E; src=1, tgt=2)
+add_parts!(H, :E,2; src=[1,2], tgt=[1,2])
+add_parts!(expected, :E, 3; src=[1,2,3], tgt=[1,2,3])
+h1,h2 = homomorphisms(G,H)
+clim = colimit(Span(h1,h2));
+@test apex(clim) == expected
 
 # C-set morphisms
 #################

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -84,13 +84,14 @@ hs = homomorphisms(G,H)
 
 @test is_natural(id(G))
 
-G, H, expected = [DynamicACSet("Grph",SchGraph) for _ in 1:3];
+G, H, expected =[DynamicACSet("WG", SchWeightedGraph; type_assignment=Dict(:Weight=>Float64)) 
+                 for _ in 1:3]
 add_parts!(G, :V, 2); 
 add_parts!(H, :V, 2);
 add_parts!(expected, :V, 3);
-add_part!(G, :E; src=1, tgt=2)
-add_parts!(H, :E,2; src=[1,2], tgt=[1,2])
-add_parts!(expected, :E, 3; src=[1,2,3], tgt=[1,2,3])
+add_part!(G, :E; src=1, tgt=2, weight=1.0)
+add_parts!(H, :E,2; src=[1,2], tgt=[1,2], weight=1.0)
+add_parts!(expected, :E, 3; src=[1,2,3], tgt=[1,2,3], weight=1.0)
 h1,h2 = homomorphisms(G,H)
 clim = colimit(Span(h1,h2));
 @test apex(clim) == expected


### PR DESCRIPTION
This PR makes minimal changes in order to get working pushouts for dynamic acsets. `@ct_enable` is applied to `pack_colimit`,`colimit_attrs!`, and the top-level `colimit` call for a `DynamicACSet` first looks for an object in the diagram and then gets type information from that. For example:

```
diagram_ob(m::Multispan{DynamicACSet}) = apex(m)
diagram_ob(m::Multicospan{DynamicACSet}) = apex(m)
# etc., add as needed
```
Right now only these diagrams are covered, but to support general colimits, every type that can serve as a diagram should be covered.