### PR TITLE
Check that function data is compatible with codomains

### DIFF
--- a/src/categorical_algebra/Sets.jl
+++ b/src/categorical_algebra/Sets.jl
@@ -38,6 +38,7 @@ struct TypeSet{T} <: SetOb{T} end
 TypeSet(T::Type) = TypeSet{T}()
 
 Base.show(io::IO, ::TypeSet{T}) where T = print(io, "TypeSet($T)")
+Base.in(elem,::TypeSet{T}) where T = isa(elem,T)
 
 """ Abstract type for morphism in the category **Set**.
 

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -51,10 +51,13 @@ F = FinDomFunctor([FinSet(1), FinSet(3), FinSet(1)],
 f = FinFunction([1,3,4], 5)
 g = FinFunction([1,1,2,2,3], 3)
 h = FinFunction([3,1,2], 3)
+k = FinFunction([1,3,4],3,5)
 @test f isa FinFunction{Int,Int}
 @test (dom(f), codom(f)) == (FinSet(3), FinSet(5))
 @test force(f) === f
 @test codom(FinFunction([1,3,4])) == FinSet(4)
+@test k == f 
+
 
 X = FinSet(Set([:w,:x,:y,:z]))
 k = FinFunction(Dict(:a => :x, :b => :y, :c => :z), X)
@@ -87,7 +90,9 @@ rot3(x) = (x % 3) + 1
 @test preimage(id(FinSet(3)), 2) == [2]
 
 f = FinFunction([1,2,1,3], 5, index=true)
+l = FinFunction([1,2,1,3],4,5,index=true)
 @test is_indexed(f)
+@test f == l
 @test force(f) === f
 @test (dom(f), codom(f)) == (FinSet(4), FinSet(5))
 @test f(1) == 1
@@ -144,8 +149,10 @@ k = FinDomFunction(5:10)
 @test isempty(preimage(k, 4))
 
 k = FinDomFunction([:a,:b,:a,:c], index=true)
+l = FinDomFunction([:a,:b,:a,:c],TypeSet(Symbol),index=true)
 @test is_indexed(k)
 @test (dom(k), codom(k)) == (FinSet(4), TypeSet(Symbol))
+@test k == l
 @test k(1) == :a
 @test preimage(k, :a) == [1,3]
 @test preimage(k, :c) == [4]
@@ -155,6 +162,24 @@ k = FinDomFunction([:a,:b,:a,:c], index=true)
 
 f = FinFunction([1,3,2], 4)
 @test compose(f,k) == FinDomFunction([:a,:a,:b])
+
+#codomain checks
+
+three = FinSet(3)
+four = FinSet(4)
+badfunc = [1,5,2]
+strfunc = ["one","two","three"]
+strings = TypeSet(String)
+
+f = FinFunction(badfunc,three,four,known_correct=true)
+g = FinDomFunction(strfunc,strings,known_correct=false) #known_correct does nothing
+h = FinDomFunction(strfunc,strings,index=true,known_correct=true) #known_correct does nothing
+
+@test_throws ErrorException h = FinFunction(badfunc,three,four,index=true)
+@test_throws ErrorException l = FinFunction(badfunc,three,four)
+@test_throws ErrorException m = FinFunction(badfunc,three,four,index=true)
+@test_throws BoundsError n = FinFunction(badfunc,three,four,index=true,known_correct=true) 
+
 
 # Limits
 ########

--- a/test/categorical_algebra/Sets.jl
+++ b/test/categorical_algebra/Sets.jl
@@ -6,6 +6,11 @@ using Catlab.Theories, Catlab.CategoricalAlgebra
 # Sets from Julia types
 #######################
 
+# Elementhood for TypeSets
+strings = TypeSet(String)
+@test "hi" ∈ strings
+@test 7 ∉ strings
+
 # Callables.
 f = SetFunction(x -> 2x, TypeSet(Int), TypeSet(Int))
 g = SetFunction(x -> 3x, TypeSet(Int), TypeSet(Int))


### PR DESCRIPTION
Added checks that functions with explicitly given codomains actually have range in the codomain.

required adding in to typesets.

Also a little fiddling with which function constructors allow how many args; generally you should now never make it past FinFunction or FinDomFunction into the helper constructors without a codomain.

Fixes #751 .