### PR TITLE
Improve finite functor error messages

### DIFF
--- a/src/categorical_algebra/FinCats.jl
+++ b/src/categorical_algebra/FinCats.jl
@@ -13,7 +13,7 @@ module FinCats
 export FinCat, FinCatGraph, Path, ob_generator, hom_generator,
   ob_generator_name, hom_generator_name, ob_generators, hom_generators,
   equations, is_discrete, is_free, graph, edges, src, tgt, presentation,
-  FinFunctor, FinDomFunctor, get_nonfunctorialities, is_functorial, collect_ob, collect_hom, force,
+  FinFunctor, FinDomFunctor, functoriality_failures, is_functorial, collect_ob, collect_hom, force,
   FinTransformation, components, is_natural, is_initial
 
 using StructEquality
@@ -406,7 +406,7 @@ checks are currently implemented, so this only functions for identity functors.
 
 See also: [`is_natural`](@ref).
 """
-function get_nonfunctorialities(F::FinDomFunctor; check_equations::Bool=false)
+function functoriality_failures(F::FinDomFunctor; check_equations::Bool=false)
   C, D = dom(F),codom(F)
   bad_dom = Iterators.filter(hom_generators(C)) do f 
     g = hom_map(F, f)
@@ -428,8 +428,8 @@ function get_nonfunctorialities(F::FinDomFunctor; check_equations::Bool=false)
 end
 
 function is_functorial(F::FinDomFunctor; check_equations::Bool=false)
-  failures = get_nonfunctorialities(F; check_equations=check_equations)
-  all(isempty,failures) || false
+  failures = functoriality_failures(F; check_equations=check_equations)
+  all(isempty,failures)
 end
 
 function Base.map(F::Functor{<:FinCat,<:TypeCat}, f_ob, f_hom)

--- a/src/programs/DiagrammaticPrograms.jl
+++ b/src/programs/DiagrammaticPrograms.jl
@@ -263,7 +263,7 @@ function parse_functor(C::FinCat, D::FinCat,check_equations::Bool, ast::AST.Mapp
   ob_map, hom_map = make_ob_hom_maps(C, ast)
   F = FinFunctor(mapvals(x -> parse_ob(D, x), ob_map),
                  mapvals(f -> parse_hom(D, f), hom_map), C, D)
-  failures = get_nonfunctorialities(F,check_equations=check_equations)
+  failures = functoriality_failures(F,check_equations=check_equations)
   if !all(isempty,failures)
     if !check_equations
       doms, cods = failures
@@ -275,14 +275,6 @@ function parse_functor(C::FinCat, D::FinCat,check_equations::Bool, ast::AST.Mapp
       Image of codomain differs from codomain of image: $cods
       """)
     end
-    #below doesn't actually work yet
-    doms, cods, eqns = failures
-    error("""
-      Parsed functor is not functorial. 
-      Domain errors: $doms 
-      Codomain errors: $cods
-      Equation errors: $eqns
-      """)
   end
   F
 end
@@ -1192,7 +1184,7 @@ Return the right-hand side of the assignment in an expression of the form
 function get_keyword_arg_val(expr::Expr)
   @match expr begin
     Expr(:(=),var,x) => x
-    Expr(_...) => error("""
+    _ => error("""
                         Unexpected argument $expr.
                         Acceptable inputs are of the form
                         `:(var=val)`.

--- a/test/categorical_algebra/FinCats.jl
+++ b/test/categorical_algebra/FinCats.jl
@@ -50,7 +50,7 @@ G = FinFunctor((V=[2,1], E=[[1],[2]]),C,C)
 @test codom(F) == D
 @test is_functorial(F)
 @test !is_functorial(G)
-@test map(collect,get_nonfunctorialities(G)) == ([1,2],[1,2])
+@test map(collect,functoriality_failures(G)) == ([1,2],[1,2])
 @test Ob(F) == FinFunction([1,4], FinSet(4))
 @test startswith(sprint(show, F), "FinFunctor($([1,4]),")
 @test ob_map(F, 2) == 4

--- a/test/categorical_algebra/FinCats.jl
+++ b/test/categorical_algebra/FinCats.jl
@@ -45,12 +45,14 @@ D_op = op(D)
 # Functors between free categories.
 C = FinCat(parallel_arrows(Graph, 2))
 F = FinFunctor((V=[1,4], E=[[1,3], [2,4]]), C, D)
+G = FinFunctor((V=[2,1], E=[[1],[2]]),C,C)
 @test dom(F) == C
 @test codom(F) == D
 @test is_functorial(F)
+@test !is_functorial(G)
+@test map(collect,get_nonfunctorialities(G)) == ([1,2],[1,2])
 @test Ob(F) == FinFunction([1,4], FinSet(4))
 @test startswith(sprint(show, F), "FinFunctor($([1,4]),")
-
 @test ob_map(F, 2) == 4
 @test hom_map(F, 1) == Path(h, [1,3])
 @test collect_ob(F) == [1,4]

--- a/test/programs/DiagrammaticPrograms.jl
+++ b/test/programs/DiagrammaticPrograms.jl
@@ -548,4 +548,9 @@ F_src_vv, F_src_ev, F_src_ve = components(diagram_map(F_src))
 @test collect_ob(F_src_ev) == [(1, SchReflexiveGraph[:src]),
                                (2, id(SchReflexiveGraph[:V]))]
 
+#Little parsing functions
+import Catlab.Programs.DiagrammaticPrograms.get_keyword_arg_val as get_keyword_arg_val
+@test get_keyword_arg_val(:(x=3)) == 3
+@test_throws ErrorException get_keyword_arg_val(:("not an assignment!"+3))
+@test Catlab.Programs.DiagrammaticPrograms.destructure_unary_call(:(f(g(x)))) == (:(f∘g),:x)
 end

--- a/test/programs/DiagrammaticPrograms.jl
+++ b/test/programs/DiagrammaticPrograms.jl
@@ -4,6 +4,7 @@ using Test
 using Catlab, Catlab.Graphs, Catlab.CategoricalAlgebra
 using Catlab.Programs.DiagrammaticPrograms
 using Catlab.Programs.DiagrammaticPrograms: NamedGraph
+using Catlab.Programs.DiagrammaticPrograms: get_keyword_arg_val, destructure_unary_call
 using Catlab.WiringDiagrams.CPortGraphs
 
 @present SchSet(FreeSchema) begin
@@ -549,8 +550,7 @@ F_src_vv, F_src_ev, F_src_ve = components(diagram_map(F_src))
                                (2, id(SchReflexiveGraph[:V]))]
 
 #Little parsing functions
-import Catlab.Programs.DiagrammaticPrograms.get_keyword_arg_val as get_keyword_arg_val
 @test get_keyword_arg_val(:(x=3)) == 3
 @test_throws ErrorException get_keyword_arg_val(:("not an assignment!"+3))
-@test Catlab.Programs.DiagrammaticPrograms.destructure_unary_call(:(f(g(x)))) == (:(f∘g),:x)
+@test destructure_unary_call(:(f(g(x)))) == (:(f∘g),:x)
 end


### PR DESCRIPTION
Fixes #598 by having `@finfunctor` tell the user which morphisms are mapped inconsistently with the object map. There is code ready to update `@finfunctor` to check preservation of equations between morphisms in the domain category, too, once we have some ability to check equality of homs.