### PR TITLE
New macro `@acset_transformation`

### DIFF
--- a/src/acsets/ACSetInterface.jl
+++ b/src/acsets/ACSetInterface.jl
@@ -4,7 +4,7 @@ export ACSet, acset_schema, acset_name, dom_parts, subpart_type,
   add_part!, add_parts!, set_subpart!, set_subparts!, clear_subpart!,
   rem_part!, rem_parts!, cascading_rem_part!, cascading_rem_parts!,
   copy_parts!, copy_parts_only!, disjoint_union, tables, pretty_tables,
-  @acset, @acset_transformation
+  @acset, @acset_transformation, @acset_transformations
 
 using StaticArrays: StaticArray
 using ..Schemas: types

--- a/src/acsets/ACSetInterface.jl
+++ b/src/acsets/ACSetInterface.jl
@@ -3,7 +3,8 @@ export ACSet, acset_schema, acset_name, dom_parts, subpart_type,
   nparts, parts, has_part, has_subpart, subpart, incident,
   add_part!, add_parts!, set_subpart!, set_subparts!, clear_subpart!,
   rem_part!, rem_parts!, cascading_rem_part!, cascading_rem_parts!,
-  copy_parts!, copy_parts_only!, disjoint_union, tables, pretty_tables, @acset
+  copy_parts!, copy_parts_only!, disjoint_union, tables, pretty_tables,
+  @acset, @acset_transformation
 
 using StaticArrays: StaticArray
 using ..Schemas: types

--- a/src/acsets/DenseACSets.jl
+++ b/src/acsets/DenseACSets.jl
@@ -828,7 +828,10 @@ function process_initial(expr)
     Expr(:(=),x,y) => parse_kwargs(expr)
     _ => error("Expected begin...end block or kwarg, received $body")
   end
-  isa(initial,Vector) ? Expr(:kw,:initial,Expr(:tuple,initial...)) : initial
+  isa(initial,Vector) ? length(initial) > 0 ? 
+      Expr(:kw,:initial,Expr(:tuple,initial...)) : 
+      Expr(:kw,:initial,Expr(:tuple,Expr(:parameters,))) :
+    initial
 end
 function parse_kwargs(expr)
   @match expr begin

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -831,13 +831,16 @@ function backtracking_search(f, X::ACSet, Y::ACSet;
   end
   iso_failures = Iterators.filter(c->nparts(X,c)!=nparts(Y,c),iso)
   mono_failures = Iterators.filter(c->nparts(X,c)>nparts(Y,c),monic)  
-   (isempty(iso_failures) && isempty(mono_failures)) ||
-    (!error_failures && return f(false)) ||
-    error("""
-    Cardinalities inconsistent with request for...
-      iso at object(s) $isoFailures
-      mono at object(s) $monoFailures
-    """)
+  if (!isempty(iso_failures) || !isempty(mono_failures))
+    if !error_failures 
+      return false 
+    else error("""
+      Cardinalities inconsistent with request for...
+        iso at object(s) $iso_failures
+        mono at object(s) $mono_failures
+      """)
+    end
+  end
 
   # Injections between finite sets of the same size are bijections, so reduce to that case.
   monic = unique([iso..., monic...])

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -543,7 +543,7 @@ though at this time the domain and codomain must be fully specified ACSets.
 """
 function is_natural(α::ACSetTransformation) 
   isa(α,LooseACSetTransformation) ? 
-    is_natural(dom(α),codom(α),α.components,α.type_components) :
+    is_natural(dom(α),codom(α),α.components,type_components(α)) :
     is_natural(dom(α),codom(α),α.components)
 end
 function is_natural(dom,codom,comps...)
@@ -564,8 +564,9 @@ function naturality_failures(X,Y,comps)
 end
 function naturality_failures(X,Y,comps,type_comps)
   S = acset_schema(X)
-  comps = Dict(a=> isa(comps[a],SetFunction) ? comps[a] : FinFunction(comps[a]) for a in keys(comps))
-  type_comps = Dict(a=>isa(type_comps[a],SetFunction) ? type_comps[a] : SetFunction(type_comps[a],TypeSet(X,a),TypeSet(Y,a)) for a in keys(type_comps))
+  comps = Dict(a=> isa(comps[a],Union{SetFunction,VarFunction,LooseVarFunction}) ? comps[a] : FinDomFunction(comps[a])  for a in keys(comps))
+  type_comps = Dict(a=>isa(type_comps[a],Union{SetFunction,VarFunction,LooseVarFunction}) ? type_comps[a] : 
+                        SetFunction(type_comps[a],TypeSet(X,a),TypeSet(Y,a)) for a in keys(type_comps))
   α = merge(comps,type_comps)
   arrs = [(f,c,d) for (f,c,d) in arrows(S) if haskey(α,c) && haskey(α,d)]
   ps = Iterators.map(arrs) do (f,c,d)
@@ -695,8 +696,9 @@ default, a backtracking search algorithm is used ([`BacktrackingSearch`](@ref)).
 
 See also: [`homomorphisms`](@ref), [`isomorphism`](@ref).
 """
-homomorphism(X::ACSet, Y::ACSet; alg=BacktrackingSearch(), kw...) =
-  homomorphism(X, Y, alg; kw. ..)
+homomorphism(X::ACSet, Y::ACSet; alg=BacktrackingSearch(), kw...) = begin 
+  homomorphism(X, Y, alg; kw...)
+end
 
 function homomorphism(X::ACSet, Y::ACSet, alg::BacktrackingSearch; kw...)
   result = nothing

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -542,7 +542,7 @@ You're allowed to run this on a named tuple partly specifying an ACSetTransforma
 though at this time the domain and codomain must be fully specified ACSets.
 """
 function is_natural(α::LooseACSetTransformation) 
-    is_natural(dom(α),codom(α),α.components,type_components(α))
+  is_natural(dom(α),codom(α),α.components,type_components(α))
 end
 function is_natural(α::ACSetTransformation)
   is_natural(dom(α),codom(α),α.components)
@@ -700,9 +700,8 @@ any immediate inconsistencies in specified initial data.
 
 See also: [`homomorphisms`](@ref), [`isomorphism`](@ref).
 """
-homomorphism(X::ACSet, Y::ACSet; alg=BacktrackingSearch(), kw...) = begin 
+homomorphism(X::ACSet, Y::ACSet; alg=BacktrackingSearch(), kw...) =
   homomorphism(X, Y, alg; kw...)
-end
 
 function homomorphism(X::ACSet, Y::ACSet, alg::BacktrackingSearch; kw...)
   result = nothing

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -6,7 +6,7 @@ export ACSetTransformation, CSetTransformation,StructACSetTransformation,
   TightACSetTransformation, LooseACSetTransformation, SubACSet, SubCSet,
   ACSetHomomorphismAlgorithm, BacktrackingSearch, HomomorphismQuery,
   components, type_components, force, get_unnaturalities, show_unnaturalities, is_natural, homomorphism, homomorphisms,
-  homomorphism_error_failures, homomorphisms_error_failures, is_homomorphic, isomorphism, isomorphisms, is_isomorphic,
+  homomorphism_error_failures, is_homomorphic, isomorphism, isomorphisms, is_isomorphic,
   generate_json_acset, parse_json_acset, read_json_acset, write_json_acset,
   generate_json_acset_schema, parse_json_acset_schema,
   read_json_acset_schema, write_json_acset_schema, acset_schema_json_schema
@@ -737,6 +737,11 @@ function homomorphism_error_failures(X,Y;kw...)
   if isa(result,Dict)
     error(show_unnaturalities(result))
   end
+  if result == false
+    error("""
+          No homomorphism exists extending given data.
+          """)
+  end
   if result == false return nothing end
   return result
 end
@@ -869,6 +874,12 @@ function backtracking_search(f, X::ACSet, Y::ACSet;
   monoFailures = Iterators.filter(c->nparts(X,c)>nparts(Y,c),monic)  
   isempty(isoFailures) && isempty(monoFailures)||
       return f((isoFailures,monoFailures))
+
+  # Injections between finite sets of the same size are bijections, so reduce to that case.
+  monic = unique([iso..., monic...])
+
+  uns = get_unnaturalities(X,Y,initial,type_components)
+  all(isempty,[uns[a] for a in keys(uns)]) || return f(uns)
 
   # Injections between finite sets of the same size are bijections, so reduce to that case.
   monic = unique([iso..., monic...])

--- a/src/categorical_algebra/FinCats.jl
+++ b/src/categorical_algebra/FinCats.jl
@@ -330,7 +330,6 @@ ob(C::FinCatPresentation{ThSchema}, x::GATExpr) =
     error("Expression $x is not an object or attribute type")
 
 hom(C::FinCatPresentation, f) = hom_generator(C, f)
-hom(C::FinCatPresentation,f::Nothing) = nothing
 hom(C::FinCatPresentation, fs::AbstractVector) =
   mapreduce(f -> hom(C, f), compose, fs)
 hom(C::FinCatPresentation, f::GATExpr) =
@@ -386,7 +385,6 @@ decompose(C::OppositeCat, f::GATExpr{:compose}) = reverse(decompose(C.cat, f))
 function hom_map(F::FinDomFunctor, f::GATExpr{:id})
   id(codom(F), ob_map(F, dom(f)))
 end
-hom_map(F::FinDomFunctor, n::GATExpr{:nothing}) = n
 
 (F::FinDomFunctor)(expr::ObExpr) = ob_map(F, expr)
 (F::FinDomFunctor)(expr::HomExpr) = hom_map(F, expr)
@@ -437,7 +435,6 @@ function is_functorial(F::FinDomFunctor; check_equations::Bool=false)
   all(isempty,failures)
 end
 
-
 function Base.map(F::Functor{<:FinCat,<:TypeCat}, f_ob, f_hom)
   C = dom(F)
   FinDomFunctor(map(x -> f_ob(ob_map(F, x)), ob_generators(C)),
@@ -474,7 +471,7 @@ FinDomFunctorMap(ob_map::Union{AbstractVector{Ob},AbstractDict{<:Any,Ob}},
                  dom::FinCat) where {Ob,Hom} =
   FinDomFunctorMap(ob_map, hom_map, dom, TypeCat(Ob, Hom))
 
-function FinDomFunctor(ob_map::Union{AbstractVector{Ob},AbstractDict{<:Any,Ob}}, 
+function FinDomFunctor(ob_map::Union{AbstractVector{Ob},AbstractDict{<:Any,Ob}},
                        hom_map::Union{AbstractVector{Hom},AbstractDict{<:Any,Hom}},
                        dom::FinCat, codom::Union{Cat,Nothing}=nothing) where {Ob,Hom}
   length(ob_map) == length(ob_generators(dom)) ||

--- a/src/categorical_algebra/FinCats.jl
+++ b/src/categorical_algebra/FinCats.jl
@@ -65,7 +65,6 @@ Because object generators usually coincide with objects, the default method for
 function ob_generator end
 
 ob(C::FinCat, x) = ob_generator(C, x)
-hom(C::FinCat,x::Nothing) = x
 
 """ Coerce or look up morphism generator in a finitely presented category.
 
@@ -219,7 +218,6 @@ compose(C::FinCatPathGraph, fs...) =
   reduce(vcat, coerce_path(graph(C), f) for f in fs)
 
 hom(C::FinCatPathGraph, f) = coerce_path(graph(C), f)
-hom(C::FinCatPathGraph, f::Nothing) = nothing
 
 coerce_path(g::HasGraph, path::Path) = path
 coerce_path(g::HasGraph, x) = Path(g, x)
@@ -239,6 +237,7 @@ end
 FinCatGraph(g::HasGraph) = FreeCatGraph(g)
 
 is_free(::FreeCatGraph) = true
+equations(::FreeCatGraph) = []
 
 function Base.show(io::IO, C::FreeCatGraph)
   print(io, "FinCat(")
@@ -262,6 +261,7 @@ See (Spivak, 2014, *Category theory for the sciences*, §4.5).
 end
 
 equations(C::FinCatGraphEq) = C.equations
+equations(C::OppositeCat) = map(x->reverse(x.first)=>reverse(x.second),equations(C.cat))
 
 function FinCatGraph(g::HasGraph, eqs::AbstractVector)
   eqs = map(eqs) do eq

--- a/src/categorical_algebra/Sets.jl
+++ b/src/categorical_algebra/Sets.jl
@@ -52,6 +52,7 @@ abstract type SetFunction{Dom <: SetOb, Codom <: SetOb} end
 
 SetFunction(f::Function, args...) = SetFunctionCallable(f, args...)
 SetFunction(::typeof(identity), args...) = IdentityFunction(args...)
+SetFunction(f::SetFunction) = f
 
 show_type_constructor(io::IO, ::Type{<:SetFunction}) = print(io, "SetFunction")
 

--- a/test/acsets/CSetDataStructures.jl
+++ b/test/acsets/CSetDataStructures.jl
@@ -398,7 +398,7 @@ for lset_maker in lset_makers
   @test_throws Exception set_subpart!(lset, 1, :label, :bar)
 end
 
-# @acset macro
+# @acset and @acset_transformation macros
 #-------------
 
 @present SchDecGraph(FreeSchema) begin
@@ -448,6 +448,13 @@ pg = @acset DecGraph{Tuple{Int,Int}} begin
 end
 @test pg[:dec] == [(1,2), (2,3), (3,4)]
 
+h = @acset DecGraph{String} begin
+  V = 4
+  E = 4
+  src = [1,2,3,4]
+  tgt = [2,3,4,1]
+  dec = ["b","c","d","a"]
+end
 # Test mapping
 #-------------
 

--- a/test/acsets/CSetDataStructures.jl
+++ b/test/acsets/CSetDataStructures.jl
@@ -2,6 +2,7 @@ module TestCSetDataStructures
 using Test
 
 using Catlab.CSetDataStructures
+using Catlab.CategoricalAlgebra.CSets
 using Tables
 
 # Discrete dynamical systems
@@ -398,7 +399,7 @@ for lset_maker in lset_makers
   @test_throws Exception set_subpart!(lset, 1, :label, :bar)
 end
 
-# @acset and @acset_transformation macros
+# @acset and @acset_transformation(s) macros
 #-------------
 
 @present SchDecGraph(FreeSchema) begin
@@ -448,6 +449,9 @@ pg = @acset DecGraph{Tuple{Int,Int}} begin
 end
 @test pg[:dec] == [(1,2), (2,3), (3,4)]
 
+# Acset transformation macros 
+#-----------------
+
 h = @acset DecGraph{String} begin
   V = 4
   E = 4
@@ -455,6 +459,33 @@ h = @acset DecGraph{String} begin
   tgt = [2,3,4,1]
   dec = ["b","c","d","a"]
 end
+
+k = @acset DecGraph{String} begin
+  V = 2
+  E = 2
+  src = [1,1]
+  tgt = [2,2]
+  dec = ["a","a"]
+end
+l = @acset DecGraph{String} begin
+  V = 2
+  E = 2
+  src = [1,2]
+  tgt = [1,2]
+  dec = ["a","a"]
+end
+α = @acset_transformation g h
+@acset_transformation g h monic=true
+β = @acset_transformation g h begin 
+  V = [4,1,2,3]
+  E = [4,1,2,3]
+end
+@test α[:V](1) == α[:E](1) == 4
+@test α == β
+@test length(@acset_transformations g h) == length(@acset_transformations g h begin end) == 1
+@test_throws ErrorException @acset_transformation k l begin V = [1,2] ; E = [1,2] end
+@test_throws ErrorException @acset_transformation k l begin V = [1,2] end
+
 # Test mapping
 #-------------
 

--- a/test/acsets/CSetDataStructures.jl
+++ b/test/acsets/CSetDataStructures.jl
@@ -1,7 +1,7 @@
 module TestCSetDataStructures
 using Test
 
-using Catlab.CSetDataStructures
+using Catlab.CSetDataStructures, Catlab.Graphs
 using Catlab.CategoricalAlgebra.CSets
 using Tables
 
@@ -475,16 +475,25 @@ l = @acset DecGraph{String} begin
   dec = ["a","a"]
 end
 α = @acset_transformation g h
-@acset_transformation g h monic=true
 β = @acset_transformation g h begin 
   V = [4,1,2,3]
   E = [4,1,2,3]
-end
+end monic=true
+γ = @acset_transformation g h begin end monic=[:V]
 @test α[:V](1) == α[:E](1) == 4
-@test α == β
-@test length(@acset_transformations g h) == length(@acset_transformations g h begin end) == 1
+@test α == β == γ
+
+x = @acset Graph begin
+  V = 2
+  E = 2
+  src = [1,1]
+  tgt = [2,2]
+end
+@test length(@acset_transformations x x) == length(@acset_transformations x x monic=[:V]) == 4
+@test length(@acset_transformations x x monic = true) == 
+      length(@acset_transformations x x begin V=[1,2] end monic = [:E]) == 
+      length(@acset_transformations x x begin V = Dict(1=>1) end monic = [:E]) == 2
 @test_throws ErrorException @acset_transformation k l begin V = [1,2] ; E = [1,2] end
-@test_throws ErrorException @acset_transformation k l begin V = [1,2] end
 
 # Test mapping
 #-------------

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -151,7 +151,7 @@ h_ = homomorphism(G, I)
 @test is_epic(g_)
 @test !is_monic(h_)
 @test !is_epic(h_)
-@test_throws ErrorException homomorphism_error_failures(H,G,monic=true)
+@test_throws ErrorException homomorphism(H,G,monic=true,error_failures=true)
 
 # Limits
 #-------
@@ -479,11 +479,8 @@ set_subpart!(s3, :f, [20,10])
 
 #Backtracking with monic and iso failure objects
 g1, g2 = path_graph(Graph, 3), path_graph(Graph, 2)
-@test collect(Catlab.CategoricalAlgebra.CSets.backtracking_search(identity,g1,g2;monic=true)[2]) == [:V,:E]
 rem_part!(g1,:E,2)
-@test collect(Catlab.CategoricalAlgebra.CSets.backtracking_search(identity,g1,g2;monic=true)[2]) == [:V]
-@test collect(Catlab.CategoricalAlgebra.CSets.backtracking_search(identity,g1,g2;iso=true)[1]) == [:V]
-@test_throws ErrorException homomorphism_error_failures(g1,g2;monic=true)
+@test_throws ErrorException homomorphism(g1,g2;monic=true,error_failures=true)
 
 
 # Symmetric graphs

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -115,15 +115,17 @@ g, h = path_graph(Graph, 4), cycle_graph(Graph, 2)
 @test components(α′′) == components(α)
 
 # Naturality.
+d = get_unnaturalities(α)
+@test [collect(d[a]) for a in keys(d)] == [[],[]]
 @test is_natural(α)
 β = CSetTransformation((V=[1,2,1,2], E=[1,1,1]), g, h)
+d = get_unnaturalities(β)
+@test [collect(d[a]) for a in keys(d)] == [[(2,1,2)],[(2,2,1)]]
+@test startswith(show_unnaturalities(β),"Failures")
 @test !is_natural(β)
 β = CSetTransformation((V=[2,1], E=[2,1]), h, h)
 @test is_natural(β)
 β = CSetTransformation((V=[2,1], E=[2,2]), h, h)
-uns = get_unnaturalities(β)
-@test Dict([f => collect(uns[f]) for (f,c,d) in arrows(acset_schema(dom(β)))]) == 
-      Dict([:src=>[(2,2,1)],:tgt=>[(2,1,2)]])
 
 
 # Category of C-sets.
@@ -149,7 +151,7 @@ h_ = homomorphism(G, I)
 @test is_epic(g_)
 @test !is_monic(h_)
 @test !is_epic(h_)
-
+@test_throws ErrorException homomorphism_error_failures(H,G,monic=true)
 
 # Limits
 #-------

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -120,7 +120,7 @@ d = get_unnaturalities(α)
 @test is_natural(α)
 β = CSetTransformation((V=[1,2,1,2], E=[1,1,1]), g, h)
 d = get_unnaturalities(β)
-@test [collect(d[a]) for a in keys(d)] == [[(2,1,2)],[(2,2,1)]]
+@test sort([collect(v) for v in values(d)]) == [[(2,1,2)],[(2,2,1)]]
 @test startswith(show_unnaturalities(β),"Failures")
 @test !is_natural(β)
 β = CSetTransformation((V=[2,1], E=[2,1]), h, h)

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -115,11 +115,11 @@ g, h = path_graph(Graph, 4), cycle_graph(Graph, 2)
 @test components(α′′) == components(α)
 
 # Naturality.
-d = get_unnaturalities(α)
+d = naturality_failures(α)
 @test [collect(d[a]) for a in keys(d)] == [[],[]]
 @test is_natural(α)
 β = CSetTransformation((V=[1,2,1,2], E=[1,1,1]), g, h)
-d = get_unnaturalities(β)
+d = naturality_failures(β)
 @test sort([collect(v) for v in values(d)]) == [[(2,1,2)],[(2,2,1)]]
 @test startswith(show_unnaturalities(β),"Failures")
 @test !is_natural(β)
@@ -308,7 +308,7 @@ h = path_graph(WeightedGraph{Float64}, 4, E=(weight=[1.,2.,3.],))
 β = ACSetTransformation((V=[1,2], E=[1]), g, h)
 @test !is_natural(β) # Graph homomorphism but does not preserve weight
 β = ACSetTransformation((V=[1,3], E=[1]), g, h)
-uns = get_unnaturalities(β)
+uns = naturality_failures(β)
 @test collect(uns[:src]) == [] && collect(uns[:tgt]) == [(1,2,3)] &&
   collect(uns[:weight]) == [(1,1.0,2.0)]
 

--- a/test/categorical_algebra/FinCats.jl
+++ b/test/categorical_algebra/FinCats.jl
@@ -117,8 +117,6 @@ s = sprint(show, Δ¹)
 @test startswith(s, "FinCat($(Graph)")
 @test contains(s, "Path")
 
-
-
 # Symbolic categories
 #####################
 

--- a/test/categorical_algebra/FinCats.jl
+++ b/test/categorical_algebra/FinCats.jl
@@ -18,6 +18,7 @@ C = FinCat(g)
 @test ob_generators(C) == 1:2
 @test hom_generators(C) == 1:3
 @test startswith(sprint(show, C), "FinCat($(Graph)")
+@test equations(C) == []
 
 C_op = op(C)
 @test C_op isa FinCat
@@ -26,6 +27,7 @@ C_op = op(C)
 @test ob_generators(C_op) == 1:2
 @test hom_generators(C_op) == 1:3
 @test op(C_op) == C
+@test equations(C) == []
 
 h = Graph(4)
 add_edges!(h, [1,1,2,3], [2,3,4,4])
@@ -106,12 +108,16 @@ F = FinDomFunctor([FinSet(4), FinSet(2)], [FinFunction([1,1,2,2])], C)
 add_edges!(Δ¹_graph, [1,1,2], [2,2,1])
 Δ¹ = FinCat(Δ¹_graph, [ [1,3] => empty(Path, Δ¹_graph, 1),
                         [2,3] => empty(Path, Δ¹_graph, 1) ])
+Δ¹_op = op(Δ¹)
 @test graph(Δ¹) == Δ¹_graph
 @test length(equations(Δ¹)) == 2
+@test length(equations(Δ¹_op)) == 2
 @test !is_free(Δ¹)
 s = sprint(show, Δ¹)
 @test startswith(s, "FinCat($(Graph)")
 @test contains(s, "Path")
+
+
 
 # Symbolic categories
 #####################

--- a/test/categorical_algebra/Sets.jl
+++ b/test/categorical_algebra/Sets.jl
@@ -59,6 +59,7 @@ plus_one_to_even = SetFunction(x -> x+1, evens, odds)
 @test_throws ErrorException plus_one_to_odd(2) == 3
 @test plus_one_to_even(2) == 3
 @test_throws ErrorException plus_one_to_even(3) == 4
+@test SetFunction(plus_one_to_odd) == plus_one_to_odd
 
 plus_two_to_odd = compose(plus_one_to_odd, plus_one_to_even)
 @test plus_two_to_odd(3) == 5


### PR DESCRIPTION
Closes #623 by defining macros @acset_transformation(s) that provide guardrails and syntax for construction of AcsetTransformations. Also refactors `is_natural` to be type-stable. 