### PR TITLE
Cascading delete in acsets

### DIFF
--- a/src/acsets/ACSetInterface.jl
+++ b/src/acsets/ACSetInterface.jl
@@ -254,7 +254,9 @@ function rem_part! end
 
 Cf. [`rem_part!`](@ref), which is not recursive.
 """
-function cascading_rem_part! end
+function cascading_rem_part!(acset::ACSet, type, part)
+  cascading_rem_parts!(acset, type, [part])
+end
 
 """ Remove parts from a C-set.
 
@@ -270,6 +272,8 @@ See also: [`rem_part!`](@ref).
 end
 
 """ Remove parts and all parts incident to them, recursively.
+
+The parts may be supplied in any order and may include duplicates.
 
 Cf. [`rem_parts!`](@ref), which is not recursive.
 """

--- a/src/acsets/ACSetInterface.jl
+++ b/src/acsets/ACSetInterface.jl
@@ -1,7 +1,8 @@
 module ACSetInterface
 export ACSet, acset_schema, acset_name, dom_parts, subpart_type,
   nparts, parts, has_part, has_subpart, subpart, incident,
-  add_part!, add_parts!, set_subpart!, set_subparts!, rem_part!, rem_parts!, clear_subpart!,
+  add_part!, add_parts!, set_subpart!, set_subparts!, rem_part!, rem_parts!, 
+  rem_part_rec!, rem_parts_rec!, clear_subpart!,
   copy_parts!, copy_parts_only!, disjoint_union, tables, pretty_tables, @acset
 
 using StaticArrays: StaticArray
@@ -249,22 +250,24 @@ See also: [`rem_parts!`](@ref).
 """
 function rem_part! end
 
+"""Recursive removal of a part. See [`rem_part!`](@ref)."""
+function rem_part_rec! end
+
 """ Remove parts from a C-set.
 
 The parts must be supplied in sorted order, without duplicates.
 
 See also: [`rem_part!`](@ref).
 """
-@inline function rem_parts!(acs::ACSet, type, parts; recurse=false)
+@inline function rem_parts!(acs::ACSet, type, parts)
   issorted(parts) || error("Parts to be removed must be in sorted order")
-  if recurse
-    delete_subobj!(acs, Dict([type=>parts]))
-  else 
-    for part in Iterators.reverse(parts)
-      rem_part!(acs, type, part)
-    end
+  for part in Iterators.reverse(parts)
+    rem_part!(acs, type, part)
   end
 end
+
+"""Recursive removal of parts. See [`rem_parts!`](@ref)."""
+function rem_parts_rec! end 
 
 """ Copy parts from a C-set to a C′-set.
 

--- a/src/acsets/ACSetInterface.jl
+++ b/src/acsets/ACSetInterface.jl
@@ -1,8 +1,8 @@
 module ACSetInterface
 export ACSet, acset_schema, acset_name, dom_parts, subpart_type,
   nparts, parts, has_part, has_subpart, subpart, incident,
-  add_part!, add_parts!, set_subpart!, set_subparts!, rem_part!, rem_parts!, 
-  rem_part_rec!, rem_parts_rec!, clear_subpart!,
+  add_part!, add_parts!, set_subpart!, set_subparts!, clear_subpart!,
+  rem_part!, rem_parts!, cascading_rem_part!, cascading_rem_parts!,
   copy_parts!, copy_parts_only!, disjoint_union, tables, pretty_tables, @acset
 
 using StaticArrays: StaticArray
@@ -250,8 +250,11 @@ See also: [`rem_parts!`](@ref).
 """
 function rem_part! end
 
-"""Recursive removal of a part. See [`rem_part!`](@ref)."""
-function rem_part_rec! end
+""" Remove part and all parts incident to it, recursively.
+
+Cf. [`rem_part!`](@ref), which is not recursive.
+"""
+function cascading_rem_part! end
 
 """ Remove parts from a C-set.
 
@@ -266,8 +269,11 @@ See also: [`rem_part!`](@ref).
   end
 end
 
-"""Recursive removal of parts. See [`rem_parts!`](@ref)."""
-function rem_parts_rec! end 
+""" Remove parts and all parts incident to them, recursively.
+
+Cf. [`rem_parts!`](@ref), which is not recursive.
+"""
+function cascading_rem_parts! end
 
 """ Copy parts from a C-set to a C′-set.
 

--- a/src/acsets/ACSetInterface.jl
+++ b/src/acsets/ACSetInterface.jl
@@ -255,10 +255,14 @@ The parts must be supplied in sorted order, without duplicates.
 
 See also: [`rem_part!`](@ref).
 """
-@inline function rem_parts!(acs::ACSet, type, parts)
+@inline function rem_parts!(acs::ACSet, type, parts; recurse=false)
   issorted(parts) || error("Parts to be removed must be in sorted order")
-  for part in Iterators.reverse(parts)
-    rem_part!(acs, type, part)
+  if recurse
+    delete_subobj!(acs, Dict([type=>parts]))
+  else 
+    for part in Iterators.reverse(parts)
+      rem_part!(acs, type, part)
+    end
   end
 end
 

--- a/src/acsets/DenseACSets.jl
+++ b/src/acsets/DenseACSets.jl
@@ -433,9 +433,6 @@ end
 ACSetInterface.rem_part!(acs::DynamicACSet, type::Symbol, part::Int) =
   runtime(_rem_part!, acs, acs.schema, type, part)
 
-ACSetInterface.cascading_rem_part!(acs::ACSet, type::Symbol, part::Int) =
-  delete_subobj!(acs, Dict([type=>[part]]))
-
 @ct_enable function _rem_part!(acs::SimpleACSet, @ct(S), @ct(ob), part)
   @ct s = Schema(S)
   @ct in_homs = homs(s; to=ob, just_names=true)
@@ -484,14 +481,14 @@ function delete_subobj(X::ACSet, delparts)
   return Dict([k => sort(collect(v)) for (k,v) in pairs(delparts)])
 end
 
-function delete_subobj!(X::ACSet, sub)
-  for (type,parts) in delete_subobj(X, sub)
+function delete_subobj!(X::ACSet, delparts)
+  for (type, parts) in delete_subobj(X, delparts)
     rem_parts!(X, type, parts)
   end 
 end
 
 ACSetInterface.cascading_rem_parts!(acs::ACSet, type, parts) =
-  delete_subobj!(acs, Dict([type=>sort(parts)]))
+  delete_subobj!(acs, Dict(type=>parts))
 
 # Copy Parts
 ############

--- a/src/acsets/DenseACSets.jl
+++ b/src/acsets/DenseACSets.jl
@@ -427,11 +427,14 @@ end
 @inline ACSetInterface.clear_subpart!(acs::SimpleACSet, part::Int, f::Symbol) =
   delete!(acs.subparts[f], part)
 
-@inline ACSetInterface.rem_part!(acs::StructACSet{S}, type::Symbol, part::Int; recurse=false) where {S} =
-  recurse ? delete_subobj!(acs, Dict([type=>[part]])) : _rem_part!(acs, Val{S}, Val{type}, part)
+@inline ACSetInterface.rem_part!(acs::StructACSet{S}, type::Symbol, part::Int) where {S} =
+  _rem_part!(acs, Val{S}, Val{type}, part)
+  
+ACSetInterface.rem_part!(acs::DynamicACSet, type::Symbol, part::Int) =
+  runtime(_rem_part!, acs, acs.schema, type, part)
 
-ACSetInterface.rem_part!(acs::DynamicACSet, type::Symbol, part::Int; recurse=false) =
-  recurse ? delete_subobj!(acs, Dict([type=>[part]])) : runtime(_rem_part!, acs, acs.schema, type, part)
+ACSetInterface.rem_part_rec!(acs::ACSet, type::Symbol, part::Int) = 
+  delete_subobj!(acs, Dict([type=>[part]]))
 
 @ct_enable function _rem_part!(acs::SimpleACSet, @ct(S), @ct(ob), part)
   @ct s = Schema(S)
@@ -486,6 +489,10 @@ function delete_subobj!(X::ACSet, sub)
     rem_parts!(X, type, parts)
   end 
 end
+
+ACSetInterface.rem_parts_rec!(acs::ACSet, type, parts) = 
+  delete_subobj!(acs, Dict([type=>sort(parts)]))
+
 
 # Copy Parts
 ############

--- a/src/acsets/DenseACSets.jl
+++ b/src/acsets/DenseACSets.jl
@@ -429,11 +429,11 @@ end
 
 @inline ACSetInterface.rem_part!(acs::StructACSet{S}, type::Symbol, part::Int) where {S} =
   _rem_part!(acs, Val{S}, Val{type}, part)
-  
+
 ACSetInterface.rem_part!(acs::DynamicACSet, type::Symbol, part::Int) =
   runtime(_rem_part!, acs, acs.schema, type, part)
 
-ACSetInterface.rem_part_rec!(acs::ACSet, type::Symbol, part::Int) = 
+ACSetInterface.cascading_rem_part!(acs::ACSet, type::Symbol, part::Int) =
   delete_subobj!(acs, Dict([type=>[part]]))
 
 @ct_enable function _rem_part!(acs::SimpleACSet, @ct(S), @ct(ob), part)
@@ -490,9 +490,8 @@ function delete_subobj!(X::ACSet, sub)
   end 
 end
 
-ACSetInterface.rem_parts_rec!(acs::ACSet, type, parts) = 
+ACSetInterface.cascading_rem_parts!(acs::ACSet, type, parts) =
   delete_subobj!(acs, Dict([type=>sort(parts)]))
-
 
 # Copy Parts
 ############

--- a/test/acsets/ACSets.jl
+++ b/test/acsets/ACSets.jl
@@ -1,10 +1,25 @@
 module TestACSets
+using Test
 
-include("IndexUtils.jl")
-include("LVectors.jl")
-include("Mappings.jl")
-include("Columns.jl")
-include("Schemas.jl")
-include("CSetDataStructures.jl")
+@testset "Utilities" begin
+  include("IndexUtils.jl")
+  include("LVectors.jl")
+end
+
+@testset "Mappings" begin
+  include("Mappings.jl")
+end
+
+@testset "Columns" begin
+  include("Columns.jl")
+end
+
+@testset "Schemas" begin
+  include("Schemas.jl")
+end
+
+@testset "DataStructures" begin
+  include("CSetDataStructures.jl")
+end
 
 end # module

--- a/test/acsets/CSetDataStructures.jl
+++ b/test/acsets/CSetDataStructures.jl
@@ -82,8 +82,15 @@ for dds_maker in dds_makers
   # recursive deletion
   dds = dds_maker()
   add_parts!(dds, :X, 3, Φ=[2,3,3])
-  rem_part!(dds, :X, 2; recurse=true)
+  rem_part_rec!(dds, :X, 2)
   @test nparts(dds, :X) == 1
+
+  dds = dds_maker()
+  add_parts!(dds, :X, 3, Φ=[2,3,3])
+  rem_parts_rec!(dds, :X, [1,2])
+  @test nparts(dds, :X) == 1
+
+  
 
   # Pretty printing.
   dds = dds_maker()

--- a/test/acsets/CSetDataStructures.jl
+++ b/test/acsets/CSetDataStructures.jl
@@ -79,6 +79,12 @@ for dds_maker in dds_makers
   @test incident(dds, 1, :Φ) == [1,2]
   @test incident(dds, 2, :Φ) == []
 
+  # recursive deletion
+  dds = dds_maker()
+  add_parts!(dds, :X, 3, Φ=[2,3,3])
+  rem_part!(dds, :X, 2; recurse=true)
+  @test nparts(dds, :X) == 1
+
   # Pretty printing.
   dds = dds_maker()
   add_parts!(dds, :X, 3, Φ=[2,3,3])

--- a/test/acsets/CSetDataStructures.jl
+++ b/test/acsets/CSetDataStructures.jl
@@ -79,18 +79,16 @@ for dds_maker in dds_makers
   @test incident(dds, 1, :Φ) == [1,2]
   @test incident(dds, 2, :Φ) == []
 
-  # recursive deletion
+  # Recursive deletion.
   dds = dds_maker()
   add_parts!(dds, :X, 3, Φ=[2,3,3])
-  rem_part_rec!(dds, :X, 2)
+  cascading_rem_part!(dds, :X, 2)
   @test nparts(dds, :X) == 1
 
   dds = dds_maker()
   add_parts!(dds, :X, 3, Φ=[2,3,3])
-  rem_parts_rec!(dds, :X, [1,2])
+  cascading_rem_parts!(dds, :X, [1,2])
   @test nparts(dds, :X) == 1
-
-  
 
   # Pretty printing.
   dds = dds_maker()
@@ -126,7 +124,7 @@ for dds_maker in dds_makers
   @test !isempty(sprint(show, MIME"text/plain"(), empty_dds))
   @test !isempty(sprint(show, MIME"text/html"(), empty_dds))
 
-  # # Error handling when adding parts.
+  # Error handling when adding parts.
   dds = dds_maker()
   add_parts!(dds, :X, 3, Φ=[1,1,1])
   @test_throws AssertionError add_part!(dds, :X, Φ=5)
@@ -147,9 +145,6 @@ for dds_maker in dds_makers
   add_parts!(dds, :X, 3, Φ=[2,3,2])
   @test hash(dds) != hash(dds2)
 end
-
-
-
 
 # Dendrograms
 #############


### PR DESCRIPTION
Removing a part with `recurse=true` removes all incident parts recursively

This can be redone much nicer after ACSets support 'mark as deleted'. Because deleting a single part changes the ids of other parts, a full pass must be made to find everything that must be deleted and then the deletion follows afterwards.