### PR TITLE
Use AlgebraicJuliaBot to tag releases

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -27,7 +27,4 @@ jobs:
     steps:
       - uses: JuliaRegistries/TagBot@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          # Edit the following line to reflect the actual name of the GitHub Secret containing your private key
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
-          # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}
+          token: ${{ secrets.RELEASE_TOKEN }}


### PR DESCRIPTION
When a github action tags a release it doesn't trigger other github actions it doesn't look like, hopefully this resolves it. Mainly getting documentation to build when a tag is created by TagBot rather than being manually created.