### PR TITLE
delete_subobj! bugfix

### DIFF
--- a/src/acsets/DenseACSets.jl
+++ b/src/acsets/DenseACSets.jl
@@ -518,10 +518,15 @@ function delete_subobj!(X::ACSet, delparts)
   dels = delete_subobj(X, delparts)
   return NamedTuple(map(ob(acset_schema(X))) do o
     ps = collect(parts(X,o))
+    for r in dels[o]
+      idx  = findfirst(==(r), ps)
+      idx2 = pop!(ps) 
+      if idx <= length(ps) 
+        ps[idx] = idx2
+      end
+    end 
     rem_parts!(X, o, dels[o])
-    return o => map(parts(X,o)) do i 
-      return i ∈ dels[o] ? pop!(ps) : i
-    end
+    return o => ps
   end)
 end
 

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -628,6 +628,12 @@ subG, subobjs = subobject_graph(G) |> collect
 @test length(incident(subG, 13, :src)) == 13 # ⊥ is initial
 @test length(incident(subG, 1, :src)) == 1 # ⊤ is terminal
 
+# Graph and ReflexiveGraph should have same subobject structure
+subG = subobject_graph(path_graph(Graph, 2)) |> first
+subRG, sos = subobject_graph(path_graph(ReflexiveGraph, 2))
+@test all(is_natural, hom.(sos))
+@test is_isomorphic(subG, subRG)
+
 # Partial overlaps 
 G = path_graph(Graph, 2)
 os = partial_overlaps(G,G)


### PR DESCRIPTION
delete_subobj! deletes part of an ACSet while returning the data needed to construct a morphism from the new into the old ACSet. This requires simulating how the indices change, and through more thorough testing I found an unnatural morphism being produced from the old code. 

This new version works for the new examples, and it appears to be more correct.