### PR TITLE
Serialize acset schemas as JSON via `Schema` rather than `Presentation`

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -1847,7 +1847,7 @@ Given a presentation of an ACSet schema, such as `SchWeightedGraph` or
 
 Inverse to [`parse_json_acset_schema`](@ref).
 """
-function generate_json_acset_schema(pres::Presentation)
+function generate_json_acset_schema(schema::Schema)
   if !isnothing(Pkg.project().version) 
     catlab_pkg_ver = replace(string(Pkg.project().version), "v" => "") 
   else
@@ -1856,24 +1856,22 @@ function generate_json_acset_schema(pres::Presentation)
   OrderedDict(
     "version" => Dict("ACSetSchema" => "0.0.1",
                       "Catlab" => catlab_pkg_ver),
-    "Ob" => map(generators(pres, :Ob)) do x
-      Dict("name" => string(first(x)))
+    "Ob" => map(objects(schema)) do x
+      Dict("name" => string(x))
     end,
-    "Hom" => map(generators(pres, :Hom)) do f
-      Dict("name" => string(first(f)),
-           "dom" => string(first(dom(f))),
-           "codom" => string(first(codom(f))))
+    "Hom" => map(homs(schema)) do (f, x, y)
+      Dict("name" => string(f), "dom" => string(x), "codom" => string(y))
     end,
-    "AttrType" => map(generators(pres, :AttrType)) do x
-      Dict("name" => string(first(x)))
+    "AttrType" => map(attrtypes(schema)) do x
+      Dict("name" => string(x))
     end,
-    "Attr" => map(generators(pres, :Attr)) do f
-      Dict("name" => string(first(f)),
-           "dom" => string(first(dom(f))),
-           "codom" => string(first(codom(f))))
+    "Attr" => map(attrs(schema)) do (f, x, y)
+      Dict("name" => string(f), "dom" => string(x), "codom" => string(y))
     end,
   )
 end
+generate_json_acset_schema(pres::Presentation) =
+  generate_json_acset_schema(Schema(pres))
 
 """ Parse JSON-able object or JSON string representing an ACSet schema.
 
@@ -1927,9 +1925,9 @@ end
 Similar to [`generate_json_acset_schema`](@ref) except writes to a file.
 Inverse to [`read_json_acset_schema`](@ref).
 """
-function write_json_acset_schema(pres::Presentation, fname::AbstractString)
+function write_json_acset_schema(schema, fname::AbstractString)
   open(fname, "w") do f
-    write(f, JSON.json(generate_json_acset_schema(pres)))
+    write(f, JSON.json(generate_json_acset_schema(schema))
   end
 end
 


### PR DESCRIPTION
Preparation for migration to ACSets.jl (#771), where presentations will not be available.