### PR TITLE
Breaking change to data migration API

### DIFF
--- a/docs/literate/sketches/cat_elements.jl
+++ b/docs/literate/sketches/cat_elements.jl
@@ -7,7 +7,7 @@ using Colors
 function graph(el::Elements)
   F = FinFunctor(Dict(:V => :El, :E => :Arr), Dict(:src => :src, :tgt => :tgt),
                  SchGraph, SchElements)
-  ΔF = DeltaMigration(F, Elements{Symbol}, Graph)
+  ΔF = DataMigrationFunctor(F, Elements{Symbol}, Graph)
   return ΔF(el)
 end
 

--- a/src/categorical_algebra/DataMigrations.jl
+++ b/src/categorical_algebra/DataMigrations.jl
@@ -1,8 +1,8 @@
 """ Functorial data migration for attributed C-sets.
 """
 module DataMigrations
-export DataMigration, SigmaMigration, DeltaMigration, migrate, migrate!,
-  representable, yoneda, colimit_representables
+export DataMigration, TotalDataMigration, SigmaMigration, DeltaMigration, SigmaMigrationFunctor, 
+  DeltaMigrationFunctor, DataMigrationFunctor, functor, migrate, migrate!,  representable, yoneda, colimit_representables
 
 using ACSets
 using ACSets.DenseACSets: constructor, datatypes
@@ -41,70 +41,73 @@ a "duc query" (disjoint union of conjunctive queries).
 """
 const GlucQuery{C<:FinCat} = Diagram{id,<:TypeCat{<:Diagram{op,C}}}
 
-""" Functor defining a pullback or delta data migration.
+""" A data migration is guaranteed to contain a functor between
+schemas that can be used to migrate data between acsets
+on those schemas. This functor ``F`` may be partial, in which case
+it contains extra data describing how to use it to execute a migration. The
+migration may be a pullback data migration ([`DeltaMigration`](@ref)), specified by a
+functor ``D → C`` between the schemas, or a conjunctive, gluing,
+duc, or gluc (contravariant) data migration. Alternatively, ``F`` may
+be a schema functor specifying a ``Σ`` migration in the covariant direction.
 """
-const DeltaSchemaMigration{D<:FinCat,C<:FinCat} = FinFunctor{D,C}
+abstract type AbstractDataMigration{F<:FinDomFunctor} end
+functor(M::AbstractDataMigration) = M.functor
+abstract type AbstractContravariantMigration{F<:FinDomFunctor} <: AbstractDataMigration{F} end
+abstract type AbstractCovariantMigration{F<:FinDomFunctor} <: AbstractDataMigration{F} end
 
-""" Functor defining a contravariant data migration using conjunctive queries.
+"""
+A contravariant data migration whose functor ``F`` may not be fully defined. Instead,
+the migration ``F⋅X`` for an acset ``X`` can only be constructed once we have access
+to ``X``'s attribute types. The dictionary of parameters contains anonymous 
+functions acting on ``X``'s attributes using Julia functions defined on 
+these attribute types.
+"""
+#The same, except for the supertype and the variance parameter T, as a QueryDiagram in older code.
+#(Instead, `C` itself is probably a category of queries, which thus contain the information of T further down.)
+struct DataMigration{F<:FinDomFunctor,Params<:AbstractDict} <: AbstractContravariantMigration{F}
+  functor::F
+  params::Params
+end
+#This is possibly a bit ugly/ought to be an abstract type? But it allows for some pseudo multiple inheritance
+const TotalDataMigration{F<:FinDomFunctor} = DataMigration{F,Dict{Any,Union{}}}
+TotalDataMigration(functor)=DataMigration(functor,Dict{Any,Union{}}())
+""" Schema-level functor defining a pullback or delta data migration.
+"""
+const DeltaSchemaMigration{D<:FinCat,C<:FinCat} = AbstractContravariantMigration{<:FinFunctor{D,C}}
+#Note TotalDeltaMigration <: DeltaSchemaMigration as well as TotalDataMigration. 
+#This only exists for the acset to acset migrate! method which is performance-optimized for 
+#the easy Delta case
+const TotalDeltaMigration{D<:FinCat,C<:FinCat} = TotalDataMigration{<:FinFunctor{D,C}}
+
+""" Schema-level functor defining a contravariant data migration using conjunctive queries.
 """
 const ConjSchemaMigration{D<:FinCat,C<:FinCat} =
-  FinDomFunctor{D,<:TypeCat{<:ConjQuery{C}}}
+  AbstractContravariantMigration{<:FinDomFunctor{D,<:TypeCat{<:ConjQuery{C}}}}
 
-""" Functor defining a contravariant data migration using gluing queries.
+""" Schema-level functor defining a contravariant data migration using gluing queries.
 """
 const GlueSchemaMigration{D<:FinCat,C<:FinCat} =
-  FinDomFunctor{D,<:TypeCat{<:GlueQuery{C}}}
+  AbstractContravariantMigration{<:FinDomFunctor{D,<:TypeCat{<:GlueQuery{C}}}}
 
-""" Functor defining a contravariant data migration using gluc queries.
+""" Schema-level functor defining a contravariant data migration using gluc queries.
 """
 const GlucSchemaMigration{D<:FinCat,C<:FinCat} =
-  FinDomFunctor{D,<:TypeCat{<:GlucQuery{C}}}
+  AbstractContravariantMigration{<:FinDomFunctor{D,<:TypeCat{<:GlucQuery{C}}}}
 
-""" Abstract type for a data migration functor.
+""" Sigma or left pushforward functorial data migration between acsets.
+
+  Given a functor ``F: C → D``, the sigma data migration ``Σ_F`` is a functor from
+  ``C``-sets to ``D``-sets that is left adjoint to the delta migration functor
+  ``Δ_F`` ([`DeltaMigration`](@ref)). Explicitly, the ``D``-set ``Σ_F(X)`` is
+  given on objects ``d ∈ D`` by the formula ``Σ_F(x)(d) = \\mathrm{colim}_{F ↓ d}
+  X ∘ π``, where ``π: (F ↓ d) → C`` is the projection.
+  
+  See (Spivak, 2014, *Category Theory for the Sciences*) for details.
 """
-abstract type MigrationFunctor{Dom<:ACSet,Codom<:ACSet} <:
-  Functor{TypeCat{Dom,ACSetTransformation},TypeCat{Codom,ACSetTransformation}} end
-
-ob_map(F::MigrationFunctor{Dom,Codom}, X) where {Dom,Codom} =
-  ob_map(F, Codom, X)
-
-(F::MigrationFunctor)(X::ACSet) = ob_map(F, X)
-(F::MigrationFunctor)(α::ACSetTransformation) = hom_map(F, α)
-
-""" Data migration functor given contravariantly.
-
-This type encompasses data migration functors from ``C``-sets to ``D``-sets
-given contravariantly by a functor out of the schema ``D``. The simplest such
-functor is a pullback data migration ([`DeltaMigration`](@ref)), specified by a
-functor ``D → C`` between the schemas. Other important cases include conjunctive
-and duc data migrations.
-"""
-struct DataMigration{Dom,Codom,F<:FinDomFunctor} <: MigrationFunctor{Dom,Codom}
+const SigmaSchemaMigration{F<:FinFunctor} = AbstractCovariantMigration{F}
+struct SigmaMigration{F<:FinFunctor} <: SigmaSchemaMigration{F}
   functor::F
 end
-
-DataMigration(functor::F, ::Type{Dom}, ::Type{Codom}) where {F,Dom,Codom} =
-  DataMigration{Dom,Codom,F}(functor)
-DataMigration(functor::F, ::Type{Codom}) where {F,Codom} =
-  DataMigration{ACSet,Codom,F}(functor)
-
-ob_map(F::DataMigration, T::Type, X) = migrate(T, X, F.functor)
-
-""" Delta or pullback functorial data migration between acsets.
-
-Given a functor ``F: D → C``, the delta migration functor ``Δ_F`` from
-``C``-sets to ``D``-sets is defined contravariantly by ``Δ_F(X) := X ∘ F``.
-
-See (Spivak, 2014, *Category Theory for the Sciences*) for details.
-"""
-const DeltaMigration{Dom,Codom} = DataMigration{Dom,Codom,<:DeltaSchemaMigration}
-
-DeltaMigration(args...) = DataMigration(args...)::DeltaMigration
-
-const ConjMigration{Dom,Codom} = DataMigration{Dom,Codom,<:ConjSchemaMigration}
-const GlueMigration{Dom,Codom} = DataMigration{Dom,Codom,<:GlueSchemaMigration}
-const GlucMigration{Dom,Codom} = DataMigration{Dom,Codom,<:GlucSchemaMigration}
-
 # Contravariant migration
 #########################
 
@@ -112,11 +115,11 @@ const GlucMigration{Dom,Codom} = DataMigration{Dom,Codom,<:GlucSchemaMigration}
 
 The mutating variant of this function is [`migrate!`](@ref).
 """
-function migrate(::Type{T}, X::ACSet, F::FinDomFunctor; kw...) where T <: ACSet
-  T(migrate(X, F; kw...))
+function migrate(::Type{T}, X::ACSet, M::AbstractDataMigration; kw...) where T <: ACSet
+  T(migrate(X, M; kw...))
 end
-function migrate(X::ACSet, F::FinDomFunctor; kw...)
-  migrate(FinDomFunctor(X), F; kw...)
+function migrate(X::ACSet, M::AbstractDataMigration; kw...)
+  migrate(FinDomFunctor(X), M; kw...)
 end
 
 """ Contravariantly migrate data from the acset `Y` to the acset `X`.
@@ -124,19 +127,24 @@ end
 This is the mutating variant of [`migrate!`](@ref). When the functor on schemas
 is the identity, this operation is equivalent to [`copy_parts!`](@ref).
 """
-function migrate!(X::ACSet, Y::ACSet, F::FinDomFunctor; kw...)
-  copy_parts!(X, migrate(Y, F; kw...))
+function migrate!(X::ACSet, Y::ACSet, M::AbstractDataMigration; kw...)
+  copy_parts!(X, migrate(Y, M; kw...))
 end
+
 
 # Delta migration
 #----------------
+migrate(Y::ACSet,M::DeltaSchemaMigration) = migrate(FinDomFunctor(Y),M)
+migrate(Y::FinDomFunctor,M::DeltaSchemaMigration) = compose(M,Y)
+#TODO: write compose
 
-migrate(::Type{T}, X::ACSet, F::DeltaSchemaMigration) where T <: ACSet =
-  migrate!(T(), X, F)
+migrate(::Type{T}, X::ACSet, M::TotalDeltaMigration) where T <: ACSet =
+  migrate!(T(), X, M)
 migrate(::Type{T}, X::ACSet, FOb, FHom) where T <: ACSet =
   migrate!(T(), X, FOb, FHom)
 
-function migrate!(X::StructACSet{S}, Y::ACSet, F::DeltaSchemaMigration) where S
+function migrate!(X::StructACSet{S}, Y::ACSet, M::TotalDeltaMigration) where S
+  F = functor(M)
   partsX = Dict(c => add_parts!(X, c, nparts(Y, nameof(ob_map(F,c))))
                 for c in ob(S))
   for (f,c,d) in homs(S)
@@ -149,25 +157,16 @@ function migrate!(X::StructACSet{S}, Y::ACSet, F::DeltaSchemaMigration) where S
 end
 
 function migrate!(X::ACSet, Y::ACSet, FOb, FHom)
-  F = FinFunctor(FOb, FHom, FinCat(Presentation(X)), FinCat(Presentation(Y)))
-  migrate!(X, Y, F)
-end
-
-function (::Type{T})(X::ACSet, F::FinFunctor) where T <: ACSet
-  Base.depwarn("Data migration constructor is deprecated, use `migrate` instead", :ACSet)
-  migrate(T, X, F)
-end
-
-function (::Type{T})(X::ACSet, FOb::AbstractDict, FHom::AbstractDict) where T <: ACSet
-  Base.depwarn("Data migration constructor is deprecated, use `migrate` instead", :ACSet)
-  migrate(T, X, FOb, FHom)
+  M = TotalDataMigration(FinFunctor(FOb, FHom, FinCat(Presentation(X)), FinCat(Presentation(Y))))
+  migrate!(X, Y, M)
 end
 
 # Conjunctive migration
 #----------------------
-
-function migrate(X::FinDomFunctor, F::ConjSchemaMigration;
+#todo: generalize compose for non-total migrations
+function migrate(X::FinDomFunctor, M::ConjSchemaMigration;
                  return_limits::Bool=false, tabular::Bool=false)
+  F = functor(M)
   tgt_schema = dom(F)
   limits = make_map(ob_generators(tgt_schema)) do c
     Fc = ob_map(F, c)
@@ -180,6 +179,7 @@ function migrate(X::FinDomFunctor, F::ConjSchemaMigration;
     else
       (SetOb, FinDomFunction{Int})
     end
+    #
     # XXX: Disable domain check because acsets don't store schema equations.
     lim = limit(force(compose(Fc, X, strict=false), diagram_types...),
                 alg=SpecializeLimit(fallback=ToBipartiteLimit()))
@@ -202,7 +202,8 @@ end
 # Gluing migration
 #-----------------
 
-function migrate(X::FinDomFunctor, F::GlueSchemaMigration)
+function migrate(X::FinDomFunctor, M::GlueSchemaMigration)
+  F = functor(M)
   tgt_schema = dom(F)
   colimits = make_map(ob_generators(tgt_schema)) do c
     Fc = ob_map(F, c)
@@ -221,7 +222,8 @@ end
 # Gluc migration
 #---------------
 
-function migrate(X::FinDomFunctor, F::GlucSchemaMigration)
+function migrate(X::FinDomFunctor, M::GlucSchemaMigration)
+  F = functor(M)
   tgt_schema = dom(F)
   colimits_of_limits = make_map(ob_generators(tgt_schema)) do c
     Fc = ob_map(F, c)
@@ -242,37 +244,67 @@ function migrate(X::FinDomFunctor, F::GlucSchemaMigration)
   FinDomFunctor(mapvals(ob∘first, colimits_of_limits), funcs, tgt_schema)
 end
 
+""" Abstract type for a data migration functor.
+
+This allows the user to have an actual model of the theory of 
+functors, once one knows the exact concrete types Dom and Codom
+of the relevant acsets. 
+"""
+abstract type MigrationFunctor{Dom<:ACSet,Codom<:ACSet} <:
+  Functor{TypeCat{Dom,ACSetTransformation},TypeCat{Codom,ACSetTransformation}} end
+
+ob_map(F::MigrationFunctor{Dom,Codom}, X) where {Dom,Codom} =
+  ob_map(F, Codom, X)
+
+(F::MigrationFunctor)(X::ACSet) = ob_map(F, X)
+(F::MigrationFunctor)(α::ACSetTransformation) = hom_map(F, α)
+"""
+Data migration functor given contravariantly. Stores a contravariant migration.
+"""
+struct DataMigrationFunctor{Dom,Codom,M<:AbstractContravariantMigration} <: MigrationFunctor{Dom,Codom}
+  migration::M
+end
+migration(F::DataMigrationFunctor) = F.migration
+functor(F::DataMigrationFunctor) = functor(migration(F))
+
+DataMigrationFunctor(functor::F, ::Type{Dom}, ::Type{Codom}) where {F,Dom,Codom} =
+  DataMigrationFunctor{Dom,Codom,TotalDataMigration{F}}(TotalDataMigration(functor))
+DataMigrationFunctor(functor::F, ::Type{Codom}) where {F,Codom} =
+  DataMigrationFunctor{ACSet,Codom,TotalDataMigration{F}}(TotalDataMigration(functor))
+
+ob_map(F::DataMigrationFunctor, T::Type, X) = migrate(T, X, migration(F))
+
+const DeltaMigrationFunctor{Dom,Codom} = DataMigrationFunctor{Dom,Codom,<:DeltaSchemaMigration}
+const ConjMigrationFunctor{Dom,Codom} = DataMigrationFunctor{Dom,Codom,<:ConjSchemaMigration}
+const GlueMigrationFunctor{Dom,Codom} = DataMigrationFunctor{Dom,Codom,<:GlueSchemaMigration}
+const GlucMigrationFunctor{Dom,Codom} = DataMigrationFunctor{Dom,Codom,<:GlucSchemaMigration}
+
 # Sigma migration
 #################
-
-""" Sigma or left pushforward functorial data migration between acsets.
-
-Given a functor ``F: C → D``, the sigma data migration ``Σ_F`` is a functor from
-``C``-sets to ``D``-sets that is left adjoint to the delta migration functor
-``Δ_F`` ([`DeltaMigration`](@ref)). Explicitly, the ``D``-set ``Σ_F(X)`` is
-given on objects ``d ∈ D`` by the formula ``Σ_F(x)(d) = \\mathrm{colim}_{F ↓ d}
-X ∘ π``, where ``π: (F ↓ d) → C`` is the projection.
-
-See (Spivak, 2014, *Category Theory for the Sciences*) for details.
-"""
-struct SigmaMigration{Dom,Codom} <: MigrationFunctor{Dom,Codom}
-  F::FinFunctor 
+struct SigmaMigrationFunctor{Dom,Codom,M<:SigmaSchemaMigration} <: MigrationFunctor{Dom,Codom}
+  migration::M
   dom_constructor
   codom_constructor
-  SigmaMigration(f,d::ACSet,c::ACSet) = new{typeof(d),typeof(c)}(f,constructor(d),constructor(c))
+  SigmaMigrationFunctor(f::F,d::ACSet,c::ACSet) where F<:FinFunctor = 
+    new{typeof(d),typeof(c),SigmaMigration{F}}(SigmaMigration(f),constructor(d),constructor(c))
 end 
-SigmaMigration(f,::Type{T},c::ACSet) where T<:StructACSet = SigmaMigration(f,T(),constructor(c))
-SigmaMigration(f,d::ACSet,::Type{T}) where T<:StructACSet = SigmaMigration(f,d,T())
-SigmaMigration(f,d::Type{T′},::Type{T}) where {T<:StructACSet, T′<:StructACSet} = SigmaMigration(f,d,T())
+migration(F::SigmaMigrationFunctor) = F.migration
+functor(F::SigmaMigrationFunctor) = functor(migration(F))
 
+SigmaMigrationFunctor(f,::Type{T},c::ACSet) where T<:StructACSet = SigmaMigrationFunctor(f,T(),constructor(c))
+SigmaMigrationFunctor(f,d::ACSet,::Type{T}) where T<:StructACSet = SigmaMigrationFunctor(f,d,T())
+SigmaMigrationFunctor(f,d::Type{T′},::Type{T}) where {T<:StructACSet, T′<:StructACSet} = SigmaMigrationFunctor(f,d,T())
 """
 Create a C-Set for the collage of the functor. Initialize data in the domain 
 portion of the collage, then run the chase.
 """
-function (F::SigmaMigration)(d::ACSet; n=100)
-  D,CD = F.dom_constructor(), F.codom_constructor()
+#This should be deprecated in terms of a new migrate function if anybody works on sigma migrations sometime.
+#Also, we probably don't want to construct the collage every time we migrate using M, at least it should
+#be possible to cache.
+function (M::SigmaMigrationFunctor)(d::ACSet; n=100)
+  D,CD = M.dom_constructor(), M.codom_constructor()
   S = acset_schema(d)
-  col, col_pres = collage(F.F)
+  col, col_pres = collage(functor(M))
   i1,i2 = legs(col)
   # Initialize collage C-Set with data from `d`
   atypes = Dict{Symbol,Type}()
@@ -329,7 +361,7 @@ function representable(T, C::Presentation{ThSchema}, ob::Symbol)
   add_generator!(C₀, C[ob])
   X = AnonACSet(C₀); add_part!(X, ob)
   F = FinFunctor(Dict(ob => ob), Dict(), C₀, C)
-  ΣF = SigmaMigration(F, X, T)
+  ΣF = SigmaMigrationFunctor(F, X, T)
   return ΣF(X)
 end
 
@@ -384,10 +416,11 @@ take colimits of representables to construct a `op(J)`-shaped diagram of C-sets.
 Since every C-set is a colimit of representables, this is a generic way of
 constructing diagrams of C-sets.
 """
-function colimit_representables(F::DeltaSchemaMigration, y)
-  compose(op(F), y)
+function colimit_representables(M::DeltaSchemaMigration, y)
+  compose(op(functor(M)), y)
 end
-function colimit_representables(F::ConjSchemaMigration, y)
+function colimit_representables(M::ConjSchemaMigration, y)
+  F = functor(M)
   C = dom(F)
   ACS = constructor(ob_map(y,first(ob_generators(dom(y)))))
   colimits = make_map(ob_generators(C)) do c
@@ -433,3 +466,4 @@ function FreeDiagrams.FreeDiagram(pres::Presentation{ThSchema, Symbol})
 end
 
 end
+

--- a/src/programs/DiagrammaticPrograms.jl
+++ b/src/programs/DiagrammaticPrograms.jl
@@ -6,13 +6,13 @@ provided by other submodules.
 """
 module DiagrammaticPrograms
 export @graph, @fincat, @finfunctor, @diagram, @free_diagram,
-  @migrate, @migration
+  @migrate, @migration, @acset_colim
 
 using Base.Iterators: repeated
 using MLStyle: @match
 
 using ...GAT, ...Present, ...Graphs, ...CategoricalAlgebra
-using ...Theories: munit, FreeSchema.Attr
+using ...Theories: munit
 using ...CategoricalAlgebra.FinCats: mapvals, make_map
 using ...CategoricalAlgebra.DataMigrations: ConjQuery, GlueQuery, GlucQuery
 import ...CategoricalAlgebra.FinCats: FinCat, vertex_name, vertex_named,
@@ -30,29 +30,15 @@ abstract type ObExpr end
 abstract type HomExpr end
 abstract type AssignExpr end
 
-@data ObExpr begin
-  ObGenerator(name)
-  OnlyOb()
-  Apply(ob::ObExpr, hom::HomExpr)
-  Coapply(hom::HomExpr, ob::ObExpr)
-end
-
-@data HomExpr begin
-  HomGenerator(name)
-  Compose(homs::Vector{<:HomExpr})
-  Id(ob::ObExpr)
-  Mapping(assignments::Vector{<:AssignExpr})
-end
-
 @data DiagramExpr begin
-  ObOver(name::Symbol, over::Union{ObExpr,Nothing}) #probably shouldn't be nothing
-  HomOver(name::Symbol, src::Symbol, tgt::Symbol, over::HomExpr)
-  AttrOver(name::Symbol, src::Symbol,tgt::Symbol,aux_func_def::Expr)
+  ObOver(name::Symbol, over::Union{ObExpr,Nothing})
+  HomOver(name::Union{Symbol,Nothing}, src::Symbol, tgt::Symbol, over::HomExpr)
+  AssignLiteral(name::Symbol, value)
 end
 
 @data CatExpr <: DiagramExpr begin
   Ob(name::Symbol)
-  Hom(name::Symbol, src::Symbol, tgt::Symbol)
+  Hom(name::Union{Symbol,Nothing}, src::Symbol, tgt::Symbol)
   HomEq(lhs::HomExpr, rhs::HomExpr)
 end
 
@@ -61,6 +47,12 @@ end
   Diagram(statements::Vector{<:DiagramExpr})
 end
 
+@data ObExpr begin
+  ObGenerator(name)
+  OnlyOb()
+  Apply(ob::ObExpr, hom::HomExpr)
+  Coapply(hom::HomExpr, ob::ObExpr)
+end
 @data LimitExpr <: ObExpr begin
   Limit(statements::Vector{<:DiagramExpr})
   Product(statements::Vector{ObOver})
@@ -70,6 +62,13 @@ end
   Colimit(statements::Vector{<:DiagramExpr})
   Coproduct(statements::Vector{ObOver})
   Initial()
+end
+
+@data HomExpr begin
+  HomGenerator(name)
+  Compose(homs::Vector{<:HomExpr})
+  Id(ob::ObExpr)
+  Mapping(assignments::Vector{<:AssignExpr})
 end
 
 @data AssignExpr begin
@@ -150,7 +149,7 @@ macro graph(graph_type, body)
 end
 macro graph(body)
   ast = AST.Cat(parse_diagram_ast(body))
-  :(parse_graph(NamedGraph{Symbol,Symbol}, $ast))
+  :(parse_graph(NamedGraph{Symbol,Union{Symbol,Nothing}}, $ast))
 end
 
 function parse_graph(::Type{G}, ast::AST.Cat) where
@@ -198,6 +197,7 @@ dimension is:
 end
 ```
 
+
 The objects and morphisms must be uniquely named.
 """
 macro fincat(body)
@@ -242,26 +242,47 @@ the schema for circular port graphs by ignoring the ports:
   tgt => tgt ⨟ box
 end
 ```
+
+A constructor exists that purports to allow the user to check that a proposed
+functor satisfies relations in the domain, but this functionality doesn't
+yet exist (and the problem is undecidable in general.) Thus the only check
+is that the source and target of the image of an arrow are the image of its
+source and target.
 """
-macro finfunctor(dom_cat, codom_cat, body)
+macro finfunctor(dom_cat, codom_cat, check_equations, body)
+  check_equations = get_keyword_arg_val(check_equations) 
   # Cannot parse Julia expr during expansion because domain category is needed.
+  :(parse_functor($(esc(dom_cat)), $(esc(codom_cat)), $(Meta.quot(body)),
+                  check_equations=$check_equations))
+end
+
+macro finfunctor(dom_cat, codom_cat, body)
   :(parse_functor($(esc(dom_cat)), $(esc(codom_cat)), $(Meta.quot(body))))
 end
 
-function parse_functor(C::FinCat, D::FinCat, ast::AST.Mapping)
+function parse_functor(C::FinCat, D::FinCat, ast::AST.Mapping;
+                       check_equations::Bool=false)
   ob_map, hom_map = make_ob_hom_maps(C, ast)
   F = FinFunctor(mapvals(x -> parse_ob(D, x), ob_map),
                  mapvals(f -> parse_hom(D, f), hom_map), C, D)
-  is_functorial(F, check_equations=false) ||
-    error("Parsed functor is not functorial: $ast")
-  return F
+  failures = functoriality_failures(F, check_equations=check_equations)
+  if !all(isempty,failures)
+    doms, cods = failures[1], failures[2]
+    doms = map(x -> hom_generator_name(C,x),doms)
+    cods = map(x -> hom_generator_name(C,x),cods)
+    error("Parsed functor is not functorial. " *
+          "Images of domain differing from domain of image: $doms " *
+          "Images of codomain differing from codomain of image: $cods")
+  end
+  F
 end
-parse_functor(C::FinCat, D::FinCat, body::Expr) =
-  parse_functor(C, D, parse_mapping_ast(body, C))
-parse_functor(C::Presentation, D::Presentation, args...) =
-  parse_functor(FinCat(C), FinCat(D), args...)
 
-function make_ob_hom_maps(C::FinCat, ast::AST.Mapping; allow_missing::Bool=false,
+parse_functor(C::FinCat, D::FinCat, body::Expr; kw...) =
+  parse_functor(C, D, parse_mapping_ast(body, C); kw...)
+parse_functor(C::Presentation, D::Presentation, args...; kw...) =
+  parse_functor(FinCat(C), FinCat(D), args...; kw...)
+
+function make_ob_hom_maps(C::FinCat, ast; allow_missing::Bool=false,
                           missing_ob::Bool=false, missing_hom::Bool=false)
   allow_missing && (missing_ob = missing_hom = true)
   ob_assign = Dict(a.lhs.name => a.rhs
@@ -351,11 +372,7 @@ Diagrams.shape(d::DiagramData) = d.shape
 
 function Diagrams.Diagram(d::DiagramData{T}, codom) where T
   F = FinDomFunctor(d.ob_map, d.hom_map, d.shape, codom)
-  SimpleDiagram{T}(F)
-end
-function DataMigrations.DataMigration(d::DiagramData, codom)
-  F = FinDomFunctor(d.ob_map, d.hom_map, d.shape, codom)
-  isempty(d.params) ? TotalDataMigration(F) : DataMigration(F, d.params)
+  isempty(d.params) ? SimpleDiagram{T}(F) : QueryDiagram{T}(F, d.params)
 end
 
 """ Present a diagram in a given category.
@@ -447,42 +464,31 @@ parse_diagram(pres::Presentation, ast::AST.Diagram) =
   parse_diagram(FinCat(pres), ast)
 
 function parse_diagram_data(C::FinCat, statements::Vector{<:AST.DiagramExpr};
-                            type=Any, ob_parser=nothing, hom_parser=nothing, 
-                            kw...)
+                            type=Any, ob_parser=nothing, hom_parser=nothing)
   isnothing(ob_parser) && (ob_parser = x -> parse_ob(C, x))
   isnothing(hom_parser) && (hom_parser = (f,x,y) -> parse_hom(C,f))
   g, eqs = DiagramGraph(), Pair[]
   F_ob, F_hom, params = [], [], Dict{Int,Any}()
-  attrs,homs = generators(presentation(C),:Attr),generators(presentation(C),:Hom)
-  mornames = map(first,[attrs;homs])
   for stmt in statements
     @match stmt begin
       AST.ObOver(x, X) => begin
         parse!(g, AST.Ob(x))
-        push!(F_ob, isnothing(X) ? nothing : ob_parser(X;kw...))
+        push!(F_ob, isnothing(X) ? nothing : ob_parser(X))
       end
       AST.HomOver(f, x, y, h) => begin
         e = parse!(g, AST.Hom(f, x, y))
         X, Y = F_ob[src(g,e)], F_ob[tgt(g,e)]
-        push!(F_hom, hom_parser(h, X, Y;kw...))
+        push!(F_hom, hom_parser(h, X, Y))
         if isnothing(Y)
-          # OOOH look down
           # Infer codomain in base category from parsed hom.
           F_ob[tgt(g,e)] = codom(C, F_hom[end])
         end
       end
-      #add the hom that's going to map to h, then save for later
-      AST.AttrOver(f,x,y,expr) => begin
-        e = parse!(g,AST.Hom(f,x,y))
-        push!(F_hom, FreeSchema.Attr{:nothing}([f],[]))
-        aux_func = make_func(expr,mornames)
-        params[e] = aux_func
+      AST.AssignLiteral(x, value) => begin
+        v = vertex_named(g, x)
+        haskey(params, v) && error("Literal already assigned to $x")
+        params[v] = value
       end
-      #AST.AssignLiteral(x, value) => begin
-      #  v = vertex_named(g, x)
-        #haskey(params, v) && error("Literal already assigned to $x")
-        #params[v] = value #only place where params gets touched, WRONG
-      #end
       AST.HomEq(lhs, rhs) =>
         push!(eqs, parse_path(g, lhs) => parse_path(g, rhs))
       _ => error("Cannot use statement $stmt in diagram definition")
@@ -494,8 +500,7 @@ end
 parse_diagram_data(C::FinCat, ast::AST.Diagram; kw...) =
   parse_diagram_data(C, ast.statements; kw...)
 
-#This used to allow homs "named" `nothing` but no longer does.
-const DiagramGraph = NamedGraph{Symbol,Symbol}
+const DiagramGraph = NamedGraph{Symbol,Union{Symbol,Nothing}}
 
 # Data migrations
 #################
@@ -590,6 +595,26 @@ macro migration(tgt_schema, src_schema, body)
   :(parse_migration($(esc(tgt_schema)), $(esc(src_schema)), $(Meta.quot(body))))
 end
 
+"""
+Uses the output of `yoneda`:
+
+@acset_colim yGraph begin 
+  (e1,e2)::E 
+  src(e1) == tgt(e2) 
+end
+"""
+macro acset_colim(yon, body)
+  body2 = quote
+    I => @join $body
+  end
+  ast = AST.Diagram(parse_diagram_ast(body2))
+  quote
+    p = Presentation(acset_schema(last(first($(esc(yon)).ob_map))))
+    tmp = parse_migration(p, $ast)
+    ob_map(colimit_representables(tmp, $(esc(yon))), :I)
+  end
+end
+
 """ Parse a contravariant data migration from a Julia expression.
 
 The process kicked off by this internal function is somewhat complicated due to
@@ -604,11 +629,10 @@ high-level steps of this process are:
 3. Convert all query and query morphisms to this common type, yielding `Diagram`
    and `DiagramHom` instances.
 """
-function parse_migration(src_schema::Presentation, ast::AST.Diagram;
-                        kw...)
+function parse_migration(src_schema::Presentation, ast::AST.Diagram)
   C = FinCat(src_schema)
-  d = parse_query_diagram(C, ast.statements;kw...)
-  make_query(C, d)
+  d = parse_query_diagram(C, ast.statements)
+  DataMigration(make_query(C, d))
 end
 function parse_migration(tgt_schema::Presentation, src_schema::Presentation,
                          ast::AST.Mapping)
@@ -619,48 +643,48 @@ function parse_migration(tgt_schema::Presentation, src_schema::Presentation,
     parse_query_hom(C, ismissing(expr) ? AST.Mapping(AST.AssignExpr[]) : expr,
                     F_ob[dom(D,f)], F_ob[codom(D,f)])
   end
-  make_query(C, DiagramData{Any}(F_ob, F_hom, D))
+  DataMigration(make_query(C, DiagramData{Any}(F_ob, F_hom, D)))
 end
 function parse_migration(tgt_schema::Presentation, src_schema::Presentation,
                          body::Expr)
-  #need to look into function below
   ast = parse_mapping_ast(body, FinCat(tgt_schema), preprocess=true)
   parse_migration(tgt_schema, src_schema, ast)
 end
-
+DataMigrations.DataMigration(h::SimpleDiagram) = DataMigration(diagram(h))
+DataMigrations.DataMigration(h::QueryDiagram) = DataMigration(diagram(h),h.params)
 # Query parsing
 #--------------
 
 """ Parse expression defining a query.
 """
-function parse_query(C::FinCat, expr::AST.ObExpr; kw...)
+function parse_query(C::FinCat, expr::AST.ObExpr)
   @match expr begin
     AST.ObGenerator(x) => ob_generator(C, x)
     AST.Limit(stmts) || AST.Product(stmts) =>
-      parse_query_diagram(C, stmts, type=op; kw...)
+      parse_query_diagram(C, stmts, type=op)
     AST.Colimit(stmts) || AST.Coproduct(stmts) =>
-      parse_query_diagram(C, stmts, type=id; kw...)
+      parse_query_diagram(C, stmts, type=id)
     AST.Terminal() => DiagramData{op}([], [], FinCat(DiagramGraph()))
     AST.Initial() => DiagramData{id}([], [], FinCat(DiagramGraph()))
   end
 end
 function parse_query_diagram(C::FinCat, stmts::Vector{<:AST.DiagramExpr}; kw...)
   parse_diagram_data(C, stmts;
-    ob_parser = X -> parse_query(C,X;kw...),
-    hom_parser = (f,X,Y) -> parse_query_hom(C,f,X,Y; kw...), kw...)
+    ob_parser = X -> parse_query(C,X),
+    hom_parser = (f,X,Y) -> parse_query_hom(C,f,X,Y), kw...)
 end
 
 """ Parse expression defining a morphism of queries.
 """
 function parse_query_hom(C::FinCat{Ob}, expr::AST.HomExpr,
-                         ::Ob, ::Union{Ob,Nothing}; kw...) where Ob
+                         ::Ob, ::Union{Ob,Nothing}) where Ob
   parse_hom(C, expr)
 end
 
 # Conjunctive fragment.
 
 function parse_query_hom(C::FinCat{Ob}, ast::AST.Mapping,
-                         d::Union{Ob,DiagramData{op}}, d′::DiagramData{op}; kw...) where Ob
+                         d::Union{Ob,DiagramData{op}}, d′::DiagramData{op}) where Ob
   ob_rhs, hom_rhs = make_ob_hom_maps(shape(d′), ast, allow_missing=d isa Ob)
   f_ob = mapvals(ob_rhs, keys=true) do j′, rhs
     parse_diagram_ob_rhs(C, rhs, ob_map(d′, j′), d)
@@ -720,23 +744,20 @@ parse_hom(C, ::Missing) = missing
 function make_query(C::FinCat{Ob}, data::DiagramData{T}) where {T, Ob}
   F_ob, F_hom, J = data.ob_map, data.hom_map, shape(data)
   F_ob = mapvals(x -> make_query(C, x), F_ob)
-  for a in map(typeof,values(F_ob)) println(a) end  
   query_type = mapreduce(typeof, promote_query_type, values(F_ob), init=Ob)
   @assert query_type != Any
   F_ob = mapvals(x -> convert_query(C, query_type, x), F_ob)
   F_hom = mapvals(F_hom, keys=true) do h, f
     make_query_hom(C, f, F_ob[dom(J,h)], F_ob[codom(J,h)])
   end
-  F_hom = typeof(F_hom) == Vector{FreeSchema.Attr{:nothing}} ? 
-    Any[a for a in F_hom] : F_hom
   if query_type <: Ob
-    DataMigration(DiagramData{T}(F_ob, F_hom, J, data.params), C)
+    Diagram(DiagramData{T}(F_ob, F_hom, J, data.params), C)
   else
     # XXX: Why is the element type of `F_ob` sometimes too loose?
     D = TypeCat(typeintersect(query_type, eltype(values(F_ob))),
                 eltype(values(F_hom)))
-    #@assert isempty(data.params)
-    DataMigration(DiagramData{T}(F_ob, F_hom, J,data.params), D)
+    @assert isempty(data.params)
+    Diagram(DiagramData{T}(F_ob, F_hom, J), D)
   end
 end
 
@@ -861,7 +882,7 @@ function parse_diagram_ast(body::Expr; free::Bool=false, preprocess::Bool=true)
       # X, Y, ...
       Expr(:tuple, Xs...) => map(AST.Ob, Xs)
       # X → Y
-      Expr(:call, :(→), X::Symbol, Y::Symbol) => [AST.Hom(gen_anonhom!(state), X, Y)]
+      Expr(:call, :(→), X::Symbol, Y::Symbol) => [AST.Hom(nothing, X, Y)]
       # f : X → Y
       Expr(:call, :(:), f::Symbol, Expr(:call, :(→), X::Symbol, Y::Symbol)) =>
         [AST.Hom(f, X, Y)]
@@ -879,62 +900,54 @@ function parse_diagram_ast(body::Expr; free::Bool=false, preprocess::Bool=true)
       Expr(:(::), Expr(:tuple, xs...), X) => let ob = parse_ob_ast(X)
         map(x -> push_ob_over!(state, AST.ObOver(x, ob)), xs)
       end
-      # h could be Julia if y is over an attr
-      # (f: x → y) :: ([weight(d),weight∘height(x)],7)
       # (f: x → y) => h
       # (f: x → y)::h
       Expr(:call, :(=>), Expr(:call, :(:), f::Symbol,
                               Expr(:call, :(→), x::Symbol, y::Symbol)), h) ||
       Expr(:(::), Expr(:call, :(:), f::Symbol,
       Expr(:call, :(→), x::Symbol, y::Symbol)), h) => begin
-        parse_hom_over(f,x,y,state.ob_over[x],state.ob_over[y],h)
-    end
-      
+        X, Y = state.ob_over[x], state.ob_over[y]
+        [AST.HomOver(f, x, y, parse_hom_ast(h, X, Y))]
+      end
       # (x → y) => h
       # (x → y)::h
       Expr(:call, :(=>), Expr(:call, :(→), x::Symbol, y::Symbol), h) ||
-      Expr(:(::), Expr(:call, :(→), x::Symbol, y::Symbol), h) => 
-        parse_hom_over(gen_anonhom!(state),x,y,state.ob_over[x],state.ob_over[y],h)
-      # make sure to handle literals!
+      Expr(:(::), Expr(:call, :(→), x::Symbol, y::Symbol), h) => begin
+        X, Y = state.ob_over[x], state.ob_over[y]
+        [AST.HomOver(nothing, x, y, parse_hom_ast(h, X, Y))]
+      end
       # x == "foo"
       # "foo" == x
-     # Expr(:call, :(==), x::Symbol, value::Literal) ||
-     # Expr(:call, :(==), value::Literal, x::Symbol) =>
-     #   [AST.AssignLiteral(x, get_literal(value))]
+      Expr(:call, :(==), x::Symbol, value::Literal) ||
+      Expr(:call, :(==), value::Literal, x::Symbol) =>
+        [AST.AssignLiteral(x, get_literal(value))]
       # h(x) == y
-      # y == h(x), this is for y an object of one of the diagrams.
+      # y == h(x)
       (Expr(:call, :(==), call::Expr, y::Symbol) ||
        Expr(:call, :(==), y::Symbol, call::Expr)) && if free end => begin
-         h, x = destructure_unary_call(call) 
-         X, Y, z = state.ob_over[x], state.ob_over[y], gen_anonhom!(state)
-         [AST.HomOver(z, x, y, parse_hom_ast(h, X, Y))]
+         h, x = destructure_unary_call(call)
+         X, Y = state.ob_over[x], state.ob_over[y]
+         [AST.HomOver(nothing, x, y, parse_hom_ast(h, X, Y))]
       end
       # h(x) == "foo"
       # "foo" == h(x)
-      # this is wrong on master, assigning the literal to y instead of z
-      # this should probably just be destroyed because it's hard to generalize
-      # to parsing eg weight(e) = (x -> ...) well actually, the only definable
-      # functions from an unlabelled finite set are constants, so maybe this is fine?
-      # but it shouldn't be just for literals...Anyway this is sugar.
-     # (Expr(:call, :(==), call::Expr, value::Literal) ||
-     #  Expr(:call, :(==), value::Literal, call::Expr)) && if free end => begin
-     #    (h, x), y, z = destructure_unary_call(call), gen_anonob!(state), gen_anonhom!(state)
-     #    X = state.ob_over[x]
-     #    [AST.ObOver(y, nothing),
-     #     AST.AssignLiteral(z, get_literal(value)),
-     #     AST.HomOver(z, x, y, parse_hom_ast(h, X))]
-     # end
+      (Expr(:call, :(==), call::Expr, value::Literal) ||
+       Expr(:call, :(==), value::Literal, call::Expr)) && if free end => begin
+         (h, x), y = destructure_unary_call(call), gen_anon!(state)
+         X = state.ob_over[x]
+         [AST.ObOver(y, nothing),
+          AST.AssignLiteral(y, get_literal(value)),
+          AST.HomOver(nothing, x, y, parse_hom_ast(h, X))]
+      end
       # h(x) == k(y)
-      # this is for anonymous objects, how to make it work for 
-      # weight(e_1)==weight(e_2)? Needs let.
       Expr(:call, :(==), lhs::Expr, rhs::Expr) && if free end => begin
         (h, x), (k, y) = destructure_unary_call(lhs), destructure_unary_call(rhs)
-        z, p, q = gen_anonob!(state), gen_anonhom!(state), gen_anonhom!(state)
+        z = gen_anon!(state)
         X, Y = state.ob_over[x], state.ob_over[y]
         # Assumes that codomain not needed to parse morphisms.
         [AST.ObOver(z, nothing),
-         AST.HomOver(p, x, z, parse_hom_ast(h, X)),
-         AST.HomOver(q, y, z, parse_hom_ast(k, Y))]
+         AST.HomOver(nothing, x, z, parse_hom_ast(h, X)),
+         AST.HomOver(nothing, y, z, parse_hom_ast(k, Y))]
       end
       # f == g
       Expr(:call, :(==), lhs, rhs) && if !free end =>
@@ -943,39 +956,13 @@ function parse_diagram_ast(body::Expr; free::Bool=false, preprocess::Bool=true)
       _ => error("Cannot parse statement in category/diagram definition: $expr")
     end
   end
-  return stmts
 end
-function parse_hom_over(name,x,y,X,Y,rhs)
-  @match rhs begin
-    Expr(:(->),_...) || Expr(:block,_...)=> begin #maybe add check that block ends with a lambda
-      [AST.AttrOver(name,x,y,rhs)]
-    end
-    _ => [AST.HomOver(name,x,y,parse_hom_ast(rhs,X,Y))]
-  end
-end
-"""
-Counts anonymous objects and homs to allow them unique internal refs.
-Tracks names of objects to avoid multiple objects with the same name.
-Doesn't track names for homs since it doesn't matter for eg free diagrams;
-macros like fincat will handle hom uniqueness for themselves.
 
-Note that ob_over[x] is the object of the base which x is over, perhaps
-confusingly.
-"""
-#=
 Base.@kwdef mutable struct DiagramASTState
-  nanon::Int=0 
+  nanon::Int = 0
   ob_over::Dict{Symbol,AST.ObExpr} = Dict{Symbol,AST.ObExpr}()
 end
 gen_anon!(state::DiagramASTState) = Symbol("##unnamed#$(state.nanon += 1)")
-=#
-Base.@kwdef mutable struct DiagramASTState
-  nanonob::Int=0 
-  nanonhom::Int=0
-  ob_over::Dict{Symbol,AST.ObExpr} = Dict{Symbol,AST.ObExpr}()
-end
-gen_anonob!(state::DiagramASTState) = Symbol("##unnamedob#$(state.nanonob += 1)")
-gen_anonhom!(state::DiagramASTState) = Symbol("##unnamedhom#$(state.nanonhom += 1)")
 
 function push_ob_over!(state::DiagramASTState, ob::AST.ObOver)
   isnothing(ob.name) && return ob
@@ -987,33 +974,33 @@ end
 
 """ Parse object expression from Julia expression to AST.
 """
-function parse_ob_ast(expr;kw...)::AST.ObExpr
+function parse_ob_ast(expr)::AST.ObExpr
   @match expr begin
-    Expr(:macrocall, _...) => parse_ob_macro_ast(expr;kw...)
+    Expr(:macrocall, _...) => parse_ob_macro_ast(expr)
     x::Symbol || Expr(:curly, _...) => AST.ObGenerator(expr)
     _ => error("Invalid object expression $expr")
   end
 end
 const compose_ops = (:(⋅), :(⨟), :(∘))
 
-function parse_ob_macro_ast(expr;kw...)::AST.ObExpr
+function parse_ob_macro_ast(expr)::AST.ObExpr
   @match expr begin
     Expr(:macrocall, form, ::LineNumberNode, args...) =>
-      parse_ob_macro_ast(Expr(:macrocall, form, args...);kw...)
+      parse_ob_macro_ast(Expr(:macrocall, form, args...))
     Expr(:macrocall, &(Symbol("@limit")), body) ||
     Expr(:macrocall, &(Symbol("@join")), body) =>
-      AST.Limit(parse_diagram_ast(body, free=true, preprocess=false;kw...))
+      AST.Limit(parse_diagram_ast(body, free=true, preprocess=false))
     Expr(:macrocall, &(Symbol("@product")), body) =>
-      AST.Product(parse_diagram_ast(body, free=true, preprocess=false;kw...))
+      AST.Product(parse_diagram_ast(body, free=true, preprocess=false))
     Expr(:macrocall, &(Symbol("@terminal"))) ||
     Expr(:macrocall, &(Symbol("@unit"))) =>
       AST.Terminal()
     Expr(:macrocall, &(Symbol("@colimit")), body) ||
     Expr(:macrocall, &(Symbol("@glue")), body) =>
-      AST.Colimit(parse_diagram_ast(body, free=true, preprocess=false;kw...))
+      AST.Colimit(parse_diagram_ast(body, free=true, preprocess=false))
     Expr(:macrocall, &(Symbol("@coproduct")), body) ||
     Expr(:macrocall, &(Symbol("@cases")), body) =>
-      AST.Coproduct(parse_diagram_ast(body, free=true, preprocess=false;kw...))
+      AST.Coproduct(parse_diagram_ast(body, free=true, preprocess=false))
     Expr(:macrocall, &(Symbol("@initial"))) ||
     Expr(:macrocall, &(Symbol("@empty"))) =>
       AST.Initial()
@@ -1064,7 +1051,6 @@ function parse_hom_ast(expr, dom::AST.ColimitExpr,
     AST.Coapply(parse_hom_ast(args..., cod), AST.OnlyOb())
   end
 end
-
 
 """ Parse object/morphism mapping from Julia expression to AST.
 """
@@ -1159,7 +1145,6 @@ end
 # Julia expression utilities
 ############################
 
-# Types that can be Julia literals.
 const Literal = Union{Number,Char,String,QuoteNode}
 
 get_literal(value::Literal) = value
@@ -1179,9 +1164,7 @@ function reparse_arrows(expr)
     _ => expr
   end
 end
-function make_func(body,vars)
-  eval(Expr(:(->),Expr(:tuple,vars...),body))
-end
+
 """ Left-most argument plus remainder of left-associated binary operations.
 """
 function leftmost_arg(expr, ops; all_ops=nothing)
@@ -1209,6 +1192,18 @@ function destructure_unary_call(expr::Expr)
       rest, x = destructure_unary_call(arg)
       (Expr(:call, :(∘), head, rest), x)
     end
+  end
+end
+
+"""
+Return the right-hand side of the assignment in an expression of the form
+`:(var=val)`.
+"""
+function get_keyword_arg_val(expr::Expr)
+  @match expr begin
+    Expr(:(=),var,x) => x
+    _ => error("Unexpected argument $expr."*
+               "Acceptable inputs are of the form `:(var=val)`.")
   end
 end
 

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -78,7 +78,7 @@ idF = FinFunctor(
   Dict(ϕ => ϕ, label => label), 
   SchLabeledDDS, SchLabeledDDS
 )
-@test ldds == migrate(LabeledDDS{Int}, ldds, TotalDataMigration(idF))
+@test ldds == migrate(LabeledDDS{Int}, ldds, DataMigration(idF))
 
 # Conjunctive migration
 #----------------------
@@ -88,7 +88,7 @@ V, E, src, tgt = generators(SchGraph)
 C = FinCat(SchGraph)
 F_V = FinDomFunctor([V], FinCat(1), C)
 F_E = FinDomFunctor(FreeDiagram(Cospan(tgt, src)), C)
-M = TotalDataMigration(FinDomFunctor(Dict(V => Diagram{op}(F_V),
+M = DataMigration(FinDomFunctor(Dict(V => Diagram{op}(F_V),
                        E => Diagram{op}(F_E)),
                   Dict(src => DiagramHom{op}([(1, src)], F_E, F_V),
                        tgt => DiagramHom{op}([(2, tgt)], F_E, F_V)), C))
@@ -112,18 +112,19 @@ M = @migration SchGraph SchGraph begin
   src => e₁ ⋅ src
   tgt => e₂ ⋅ tgt
 end
+F = func(M)
 H = migrate(g, M, tabular=true)
 @test length(H(V)) == 5
 @test length(H(E)) == 3
 @test H(src)((v=3, e₁=2, e₂=3)) == (V=2,)
 @test H(tgt)((v=3, e₁=2, e₂=3)) == (V=4,)
 
-h = migrate(Graph, g, F)
+h = migrate(Graph, g, M)
 @test (nv(h), ne(h)) == (5, 3)
 @test sort!(collect(zip(h[:src], h[:tgt]))) == [(1,3), (2,4), (3,5)]
 
 h = Graph(5)
-migrate!(h, g, F)
+migrate!(h, g, M)
 @test (nv(h), ne(h)) == (10, 3)
 @test sort!(collect(zip(h[:src], h[:tgt]))) == [(6,8), (7,9), (8,10)]
 
@@ -280,7 +281,6 @@ h′ = @acset Graph begin
   tgt = [1,2,3,4, 2,3,4, 3,4]
 end
 @test h == h′
-
 
 # Sigma migration
 #################

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -112,7 +112,7 @@ M = @migration SchGraph SchGraph begin
   src => e₁ ⋅ src
   tgt => e₂ ⋅ tgt
 end
-F = func(M)
+F = functor(M)
 H = migrate(g, M, tabular=true)
 @test length(H(V)) == 5
 @test length(H(E)) == 3

--- a/test/programs/DiagrammaticPrograms.jl
+++ b/test/programs/DiagrammaticPrograms.jl
@@ -237,7 +237,7 @@ M = @migration SchGraph SchGraph begin
   tgt => src
 end
 @test M isa DataMigrations.DeltaSchemaMigration
-@test func(M) == FinFunctor(Dict(:V => :V, :E => :E),
+@test functor(M) == FinFunctor(Dict(:V => :V, :E => :E),
                       Dict(:src => :tgt, :tgt => :src),
                       SchGraph, SchGraph)
 
@@ -250,7 +250,7 @@ M = @migration SchGraph begin
 end
 J = FinCat(parallel_arrows(NamedGraph{Symbol,Union{Symbol,Nothing}}, 2,
                            V=(vname=[:E,:V],), E=(ename=[:src,:tgt],)))
-@test func(M) == FinDomFunctor([:E,:V], [:tgt,:src], J, FinCat(SchGraph))
+@test functor(M) == FinDomFunctor([:E,:V], [:tgt,:src], J, FinCat(SchGraph))
 
 # Conjunctive migration
 #----------------------
@@ -268,7 +268,7 @@ M = @migration SchGraph SchGraph begin
   tgt => e₂ ⋅ tgt
 end
 @test M isa DataMigrations.ConjSchemaMigration
-F = func(M)
+F = functor(M)
 F_E = diagram(ob_map(F, :E))
 @test nameof.(collect_ob(F_E)) == [:V, :E, :E]
 @test nameof.(collect_hom(F_E)) == [:tgt, :src]
@@ -287,7 +287,7 @@ M′ = @migration SchGraph SchGraph begin
   src => src(e₁)
   tgt => tgt(e₂)
 end
-@test func(M′) == F
+@test functor(M′) == F
 
 # Graph with edges of weight 5.0.
 M = @migration SchGraph SchWeightedGraph begin
@@ -300,7 +300,7 @@ M = @migration SchGraph SchWeightedGraph begin
   tgt => e
 end
 @test M isa DataMigrations.ConjSchemaMigration
-F = func(M)
+F = functor(M)
 F_E = ob_map(F, :E)
 @test only(values(F_E.params)) == 5.0
 F_src = hom_map(F, :src)
@@ -315,7 +315,7 @@ M = @migration SchGraph SchSet begin
   tgt => begin end
 end
 @test M isa DataMigrations.ConjSchemaMigration
-@test isempty(shape(ob_map(func(M), :V)))
+@test isempty(shape(ob_map(functor(M), :V)))
 
 # Syntactic variant of above.
 M′ = @migration SchGraph SchSet begin
@@ -323,7 +323,7 @@ M′ = @migration SchGraph SchSet begin
   E => X
 end
 # something weird about == for datamigrations
-@test func(M′) == func(M) && M′.params == M.params
+@test functor(M′) == functor(M) && M′.params == M.params
 
 # Cartesian product of graph with itself.
 M = @migration SchGraph SchGraph begin
@@ -332,7 +332,7 @@ M = @migration SchGraph SchGraph begin
   src => (v₁ => e₁⋅src; v₂ => e₂⋅src)
   tgt => (v₁ => e₁⋅tgt; v₂ => e₂⋅tgt)
 end
-F = func(M)
+F = functor(M)
 F_V = diagram(ob_map(F, :V))
 @test collect_ob(F_V) == fill(SchGraph[:V], 2)
 F_src = hom_map(F, :src)
@@ -369,7 +369,7 @@ M = @migration SchReflexiveGraph SchGraph begin
     v => v₂; ℓ => ℓ₂; s => s₂; t => t₂
   end
 end
-F = func(M)
+F = functor(M)
 F_tgt = hom_map(F, :tgt)
 @test ob_map(F_tgt, :v) == (2, id(SchGraph[:V]))
 @test hom_map(F_tgt, :t) |> edges |> only == 4
@@ -398,7 +398,7 @@ M = @migration SchGraph begin
     v => tgt
   end
 end
-F = func(M)
+F = functor(M)
 F_src = hom_map(F, :src)
 @test collect_ob(F_src) == [(1, SchGraph[:src]), (1, id(SchGraph[:E]))]
 @test collect_hom(F_src) == [id(shape(codom(F_src)), 1)]
@@ -423,7 +423,7 @@ M = @migration SchGraph SchSet begin
   V => X
   E => @empty
 end
-F = func(M)
+F = functor(M)
 @test M isa DataMigrations.GlueSchemaMigration
 @test isempty(shape(ob_map(F, :E)))
 
@@ -441,7 +441,7 @@ M = @migration SchGraph SchGraph begin
   end
 end
 @test M isa DataMigrations.GlueSchemaMigration
-F = func(M)
+F = functor(M)
 F_V = diagram(ob_map(F, :V))
 @test collect_ob(F_V) == fill(SchGraph[:V], 2)
 F_src = hom_map(F, :src)
@@ -455,7 +455,7 @@ M = @migration SchReflexiveGraph SchGraph begin
   tgt => (e => tgt)
   refl => v
 end
-F = func(M)
+F = functor(M)
 F_tgt = hom_map(F, :tgt)
 @test collect_ob(F_tgt) == [(1, SchGraph[:tgt]), (1, id(SchGraph[:V]))]
 
@@ -469,7 +469,7 @@ M = @migration SchGraph begin
   end
   (component: V → Component) => v
 end
-F = func(M)
+F = functor(M)
 F_C = diagram(ob_map(F, :Component))
 @test nameof.(collect_ob(F_C)) == [:E, :V]
 @test nameof.(collect_hom(F_C)) == [:src, :tgt]
@@ -501,7 +501,7 @@ M = @migration SchLabeledGraph SchLabeledGraph begin
   Label => Label
   label => label
 end
-F = func(M)
+F = functor(M)
 @test ob_map(F, :V) isa DataMigrations.GlucQuery
 @test M isa DataMigrations.GlucSchemaMigration
 F_src = hom_map(F, :src)
@@ -535,7 +535,7 @@ M = @migration SchGraph SchBipartiteGraph begin
     e₂ => v₂ ∘ (e₁₂ ⋅ tgt₂)
   end
 end
-F = func(M)
+F = functor(M)
 @test ob_map(F, :V) isa DataMigrations.GlucQuery
 @test M isa DataMigrations.GlucSchemaMigration
 F_src = hom_map(F, :src)
@@ -564,7 +564,7 @@ M = @migration SchReflexiveGraph SchReflexiveGraph begin
   end
   refl => vv
 end
-F = func(M)
+F = functor(M)
 @test ob_map(F, :V) isa DataMigrations.GlucQuery
 @test M isa DataMigrations.GlucSchemaMigration
 F_src = hom_map(F, :src)


### PR DESCRIPTION
This PR separates `DataMigration`s from `DataMigrationFunctor`s. The former is currently just a functor from a schema to another schema or a category of diagrams in (diagrams in) a schema. For upcoming functionality, a `DataMigration` `M` contains a dictionary `params` intended to contain some Julia functions describing the attributes `migrate(X,M)` should have in terms of the attributes of `X`. The semantic reason for this change is that a data migration is not the same thing as a functor--the functor tells you how to migrate, but isn't identical to the migration. But it was forced, practically, by the need for those `params`. The existing `QueryDiagram`s handle the need for `param`s just fine when we're doing, well, queries, but not when we're doing mutations, as I'm working on elsewhere right now.

In more detail, we have a new tree of types rooted at `AbstractDataMigration`, which always has a `func` method getting the underlying functor, with children `AbstractContravariantMigration` and `AbstractCovariantMigration`. Depending on the codomain of the underlying functor, an `AbstractContravariantMigration` might be (identical to, not a supertype of) a `DeltaSchemaMigration`, a `ConjSchemaMigration`, etc. The only `struct` subtyping `AbstractContravariantMigration` thus far is `DataMigration`, which contains a functor and the aforementioned dictionary of parameters. If the dictionary type's values are in `Union{}`, you have a `TotalDataMigration`, which might in particular be a `TotalDeltaMigration`, and which can be constructed using just a functor.

There's also some stuff for `SigmaMigration`s and `DataMigrationFunctor`s, where there's not too much going on of interest.

The `@migration` macros now always return a `DataMigration`, and all methods of `migrate` now expect an `AbstractDataMigration` rather than a `Functor`. It would be easy and might be good quality of life to add back in methods accepting just the underlying functor for `TotalDataMigration`s, but that won't be a breaking change so I've ignored it for now.

The trickiest thing to decide on here was how to handle the relationship between `DataMigration`s and `QueryDiagram`s, which are *almost* isomorphic structs. The only objective difference is that `QueryDiagram`s include a parameter identifying which diagram category they live in. We were originally planning to eliminate `QueryDiagram`s entirely and make even the output of `DiagrammaticPrograms.make_query` be a `DataMigration`, but that would require making `DataMigration`s carry around a variance parameter and some fiddling with implementing `limit` etc for `DataMigration`s, so I've left `QueryDiagram`s alive. Another option would be to just add the variance parameter so that `DataMigration==QueryDiagram``, and probably avoid all the new named types, but that seems unaesthetic and a bit disorganized to me. Happy for thoughts on this issue, though.

A side note: this PR involved the first error message I've ever seen that overflowed my entire terminal! That is, I had to pipe it to a text file to be able to scroll all the way to the top. These unergonomic error messages are a pretty nontrivial time cost. I think we've discussed and agreed that only Julia can do much about this issue, just wanted to note it again.