### PR TITLE
Reexport all top-level modules

### DIFF
--- a/benchmark/Graphs.jl
+++ b/benchmark/Graphs.jl
@@ -7,7 +7,7 @@ import Graphs as SimpleGraphs
 import MetaGraphs
 const LG, MG = SimpleGraphs, MetaGraphs
 
-using Catlab, Catlab.CategoricalAlgebra, Catlab.Graphs
+using Catlab.GATs, Catlab.CategoricalAlgebra, Catlab.Graphs
 using Catlab.WiringDiagrams: query
 using Catlab.Programs: @relation
 

--- a/docs/literate/categorical_algebra/diagrams.jl
+++ b/docs/literate/categorical_algebra/diagrams.jl
@@ -8,7 +8,7 @@
 # X:Ob(J) labeled with its type F(X) and each edge is a morphism in J labeled
 # with its image under F.
 
-using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra
+using Catlab.GATs, Catlab.Theories, Catlab.CategoricalAlgebra
 using Catlab.Graphs, Catlab.Graphics, Catlab.Programs
 
 draw(d::Diagram) = to_graphviz(d, prog="neato", node_labels=true, edge_labels=true)

--- a/docs/literate/graphs/graphs.jl
+++ b/docs/literate/graphs/graphs.jl
@@ -1,4 +1,4 @@
-using Catlab, Catlab.Theories
+using Catlab.GATs, Catlab.Theories
 using Catlab.CategoricalAlgebra
 using Catlab.Graphs
 using Catlab.Graphics

--- a/docs/literate/graphs/graphs_label.jl
+++ b/docs/literate/graphs/graphs_label.jl
@@ -1,7 +1,7 @@
 # # Labeled Graphs
 # This example demonstrates how to define new C-Sets from existing C-Sets via the example of adding labels to a graph. We treat labels as members of an arbitrary FinSet of labels rather than a data attribute for pedagogical reasons. When you think of graphs where the labels are numbers, colors, or values of some kind, you would want to make them attributes. The motivation for this example is to be the simplest extension to the theory of graphs that you could possibly make. 
 
-using Catlab, Catlab.Theories
+using Catlab.GATs, Catlab.Theories
 using Catlab.CategoricalAlgebra
 using Catlab.Graphs
 using Catlab.Graphics

--- a/docs/literate/sketches/cat_elements.jl
+++ b/docs/literate/sketches/cat_elements.jl
@@ -1,6 +1,6 @@
 # # The Category of Elements
 # A very useful construction in applied category theory is the Category of Elements, which is also called the Grothendieck construction. This is a very general technique in category theory, but we will look at how you can use it to explain why graphs are so useful in computer science. We have already seen that C-Sets are a model of relational databases that can be used to store data as a collection of interlocking tables. Relational databases are the bread and butter of the computing industry. Every company on earth uses software that is backed by a relational database. Most data that is not stored in a relational DB is often stored in some kind of graph data structure. This sketch will show how these approaches are interchangeable via the category of elements, which associates to every database instance a graph and a graph homomorphism into the schema of the graph.
-using Catlab, Catlab.CategoricalAlgebra, Catlab.Graphs, Catlab.Graphics
+using Catlab.GATs, Catlab.CategoricalAlgebra, Catlab.Graphs, Catlab.Graphics
 using Colors
 
 # Let's tell Catlab how to draw categories of elements.

--- a/docs/literate/sketches/meets.jl
+++ b/docs/literate/sketches/meets.jl
@@ -9,7 +9,7 @@
 using Core: GeneratedFunctionStub
 using Test
 
-using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra
+using Catlab.GATs, Catlab.Theories, Catlab.CategoricalAlgebra
 using Catlab.Graphics
 
 import Catlab.Theories: compose

--- a/docs/literate/sketches/partitions.jl
+++ b/docs/literate/sketches/partitions.jl
@@ -10,7 +10,7 @@
 using Core: GeneratedFunctionStub
 using Test
 
-using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra
+using Catlab.GATs, Catlab.Theories, Catlab.CategoricalAlgebra
 import Catlab.Theories: compose
 using DataStructures
 using PrettyTables

--- a/docs/literate/sketches/preorders.jl
+++ b/docs/literate/sketches/preorders.jl
@@ -114,7 +114,7 @@ end
 # expressions are represented at expression trees
 ex = compose(P, [:f, :g])
 # the head of an expression is the root of the expression tree
-Catlab.head(ex)
+GATs.head(ex)
 # the julia type of the expression
 typeof(ex)
 # the GAT type of the expression

--- a/docs/literate/sketches/preorders.jl
+++ b/docs/literate/sketches/preorders.jl
@@ -12,7 +12,7 @@
 using Core: GeneratedFunctionStub
 using Test
 
-using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra
+using Catlab.GATs, Catlab.Theories, Catlab.CategoricalAlgebra
 import Catlab.Theories: compose
 
 #=

--- a/docs/literate/sketches/smc.jl
+++ b/docs/literate/sketches/smc.jl
@@ -3,7 +3,7 @@
 #md # [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/sketches/smc.ipynb)
 #
 # This vignette supports section 4.4.3 of Seven Sketches in Compositionality, which introduces the definition of symmetric monoidal categories (SMCs). SMCs are a core concept in applied category theory and are a workhorse of Catlab's utility in computing applications. We will discuss the definition as a GAT, see examples of working with formulas, and conversions to wiring diagrams (sometimes called string diagrams). SMCs are useful for modeling mathematical structures like programs or processes where the objects represent data or things and the morphisms represent processes that happen to those things. 
-using Catlab, Catlab.Theories
+using Catlab.GATs, Catlab.Theories
 using Catlab.CategoricalAlgebra
 using Catlab.WiringDiagrams
 using Catlab.Programs

--- a/docs/literate/wiring_diagrams/wd_cset.jl
+++ b/docs/literate/wiring_diagrams/wd_cset.jl
@@ -1,6 +1,6 @@
 # # Wiring Diagrams as Attributed C-Sets
 # Catlab supports many different flavors of diagrammatic syntax. These support the different combinatorial data structures that we use for representing categorical constructions. We will discuss DirectedWiringDiagrams, UndirectedWiringDiagrams, and CPortGraphs in this document.
-using Catlab, Catlab.Theories
+using Catlab.GATs, Catlab.Theories
 using Catlab.CategoricalAlgebra
 using Catlab.WiringDiagrams
 using Catlab.Programs

--- a/docs/literate/wiring_diagrams/wiring_diagram_basics.jl
+++ b/docs/literate/wiring_diagrams/wiring_diagram_basics.jl
@@ -2,7 +2,7 @@
 #
 #md # [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/wiring_diagrams/wiring_diagram_basics.ipynb)
 # 
-# Using Catlab, you can create, manipulate, serialize, and visualize *wiring
+# using Catlab.GATs, you can create, manipulate, serialize, and visualize *wiring
 # diagrams*, also known as [string
 # diagrams](https://ncatlab.org/nlab/show/string+diagram). The flexible data
 # structure for wiring diagrams allows arbitrary data to be attached to boxes,

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,10 +5,7 @@ const literate_dir = joinpath(@__DIR__, "literate")
 const generated_dir = joinpath(@__DIR__, "src", "generated")
 
 @info "Loading Catlab.jl"
-using Catlab.GATs,
-  # Must explicitly load all submodules for which docs are needed.
-  Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.Graphs,
-  Catlab.WiringDiagrams, Catlab.Graphics, Catlab.Programs
+using Catlab
 
 const no_literate = "--no-literate" in ARGS
 if !no_literate

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -81,7 +81,7 @@ makedocs(
       ],
     ],
     "Modules" => Any[
-      "apis/core.md",
+      "apis/gats.md",
       "apis/theories.md",
       "apis/categorical_algebra.md",
       "apis/graphs.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,7 +5,7 @@ const literate_dir = joinpath(@__DIR__, "literate")
 const generated_dir = joinpath(@__DIR__, "src", "generated")
 
 @info "Loading Catlab.jl"
-using Catlab,
+using Catlab.GATs,
   # Must explicitly load all submodules for which docs are needed.
   Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.Graphs,
   Catlab.WiringDiagrams, Catlab.Graphics, Catlab.Programs

--- a/docs/src/apis/categorical_algebra.md
+++ b/docs/src/apis/categorical_algebra.md
@@ -63,7 +63,7 @@ We can also add equations to this presentation, but we currently do nothing with
 We will now give an example of how this all works in practice.
 
 ```@example
-using Catlab, Catlab.CategoricalAlgebra
+using Catlab.GATs, Catlab.CategoricalAlgebra
 
 # Write down the schema for a weighted graph
 @present SchWeightedGraph(FreeSchema) begin

--- a/docs/src/apis/gats.md
+++ b/docs/src/apis/gats.md
@@ -48,7 +48,7 @@ using the [`@theory`](@ref) macro.
 For example, the theory of categories could be defined by:
 
 ```@setup category
-using Catlab
+using Catlab.GATs
 import Catlab.Theories: Ob, Hom, ObExpr, HomExpr, dom, codom, compose, ⋅, id
 ```
 
@@ -234,7 +234,7 @@ the cartesian monoidal category, we could define a signature `CartesianCategory`
 by inheriting from the builtin theory `SymmetricMonoidalCategory`.
 
 ```@setup cartesian-monoidal-category
-using Catlab
+using Catlab.GATs
 import Catlab.Theories: Ob, Hom, ObExpr, HomExpr, ThSymmetricMonoidalCategory,
   dom, codom, compose, id, otimes, munit, braid
 ```

--- a/docs/src/apis/gats.md
+++ b/docs/src/apis/gats.md
@@ -281,10 +281,10 @@ pair(f, g)
 
 ```@autodocs
 Modules = [
-  GAT,
-  Syntax,
-  Rewrite,
-  Present,
+  GATs.TheoriesInstances,
+  GATs.SyntaxSystems,
+  GATs.Rewriting,
+  GATs.Presentations,
 ]
 Private = false
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -148,7 +148,7 @@ debug messages.
 
 ```@contents
 Pages = [
-     "apis/core.md",
+     "apis/gats.md",
      "apis/theories.md",
      "apis/wiring_diagrams.md",
      "apis/graphics.md",

--- a/experiments/CompAlgebra/docs/algebraic_nets.jl
+++ b/experiments/CompAlgebra/docs/algebraic_nets.jl
@@ -3,7 +3,7 @@
 #md # [![](https://img.shields.io/badge/show-nbviewer-579ACA.svg)](@__NBVIEWER_ROOT_URL__/generated/experimental/algebraic_nets.ipynb)
 #
 
-using Catlab, Catlab.Theories, Catlab.Graphics
+using Catlab.GATs, Catlab.Theories, Catlab.Graphics
 using Catlab.Experimental.AlgebraicNets
 using Catlab.Experimental.MathFormulas
 

--- a/experiments/CompAlgebra/test/AlgebraicNets.jl
+++ b/experiments/CompAlgebra/test/AlgebraicNets.jl
@@ -3,7 +3,7 @@ module TestAlgebraicNets
 import Pkg
 using Test
 
-using Catlab
+using Catlab.GATs
 using CompAlgebra.AlgebraicNets
 
 R = Ob(AlgebraicNet, :R)

--- a/experiments/Markov/src/StochExpr.jl
+++ b/experiments/Markov/src/StochExpr.jl
@@ -1,7 +1,6 @@
-using Catlab
-using Catlab.Theories
-
 export crand
+
+using Catlab.GATs, Catlab.Theories
 
 
 # How do you give semantics to a stochastic map? You call it.

--- a/experiments/Markov/test/StochMapsExpr.jl
+++ b/experiments/Markov/test/StochMapsExpr.jl
@@ -1,7 +1,7 @@
-using Markov
-using Catlab
-using Catlab.Theories
 using Test
+
+using Catlab.GATs, Catlab.Theories
+using Markov
 
 X = Ob(FreeCartesianCategory, :Float64)
 u = Hom(x->x*rand(), X, X)

--- a/src/Catlab.jl
+++ b/src/Catlab.jl
@@ -4,15 +4,19 @@ using Reexport
 
 include("gats/GATs.jl")
 include("theories/Theories.jl")
-
 include("categorical_algebra/ACSetsGATsInterop.jl")
 include("graphs/Graphs.jl")
 include("categorical_algebra/CategoricalAlgebra.jl")
-
 include("wiring_diagrams/WiringDiagrams.jl")
 include("graphics/Graphics.jl")
 include("programs/Programs.jl")
 
 @reexport using .GATs
+@reexport using .Theories
+@reexport using .Graphs
+@reexport using .CategoricalAlgebra
+@reexport using .WiringDiagrams
+@reexport using .Graphics
+@reexport using .Programs
 
 end

--- a/src/Catlab.jl
+++ b/src/Catlab.jl
@@ -6,7 +6,6 @@ include("gats/GATs.jl")
 include("theories/Theories.jl")
 
 include("categorical_algebra/ACSetsGATsInterop.jl")
-include("categorical_algebra/Permutations.jl")
 include("graphs/Graphs.jl")
 include("categorical_algebra/CategoricalAlgebra.jl")
 

--- a/src/categorical_algebra/CategoricalAlgebra.jl
+++ b/src/categorical_algebra/CategoricalAlgebra.jl
@@ -9,6 +9,7 @@ include("Limits.jl")
 include("Subobjects.jl")
 include("Sets.jl")
 include("FinSets.jl")
+include("Permutations.jl")
 include("Matrices.jl")
 include("FinRelations.jl")
 include("CSets.jl")
@@ -29,6 +30,7 @@ include("Slices.jl")
 
 @reexport using .Sets
 @reexport using .FinSets
+@reexport using .Permutations
 @reexport using .CSets
 @reexport using .CatElements
 

--- a/src/wiring_diagrams/Expressions.jl
+++ b/src/wiring_diagrams/Expressions.jl
@@ -12,7 +12,7 @@ go the other way around.
 module WiringDiagramExpressions
 export to_ob_expr, to_hom_expr, to_wiring_diagram, to_undirected_wiring_diagram
 
-using ...GATs, ...Theories, ...Permutations, ...CategoricalAlgebra
+using ...GATs, ...Theories, ...CategoricalAlgebra
 using ...GATs.SyntaxSystems: syntax_module
 using ...Graphs, ..DirectedWiringDiagrams, ..UndirectedWiringDiagrams,
   ..MonoidalDirectedWiringDiagrams, ..MonoidalUndirectedWiringDiagrams

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -2,7 +2,7 @@ module TestCSets
 using Test
 using Random: seed!
 
-using Catlab, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
+using Catlab.GATs, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
 
 seed!(100)
 

--- a/test/categorical_algebra/CatElements.jl
+++ b/test/categorical_algebra/CatElements.jl
@@ -1,6 +1,6 @@
 module TestCatElements
 using Test
-using Catlab, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
+using Catlab.GATs, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
 
 arr = @acset Graph begin
   V = 2

--- a/test/categorical_algebra/Categories.jl
+++ b/test/categorical_algebra/Categories.jl
@@ -1,7 +1,7 @@
 module TestCategories
 using Test
 
-using Catlab, Catlab.Theories
+using Catlab.GATs, Catlab.Theories
 using Catlab.CategoricalAlgebra.Sets, Catlab.CategoricalAlgebra.Categories
 
 # Instances

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -1,7 +1,7 @@
 module TestDataMigrations
 using Test
 
-using Catlab, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
+using Catlab.GATs, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
 using Catlab.Programs.DiagrammaticPrograms
 
 @present SchSet(FreeSchema) begin

--- a/test/categorical_algebra/FinCats.jl
+++ b/test/categorical_algebra/FinCats.jl
@@ -1,7 +1,7 @@
 module TestFinCats
 using Test
 
-using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.Graphs
+using Catlab.GATs, Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.Graphs
 
 # Categories on graphs
 ######################

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -1,7 +1,7 @@
 module TestFinSets
 using Test
 
-using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra
+using Catlab.GATs, Catlab.Theories, Catlab.CategoricalAlgebra
 using Catlab.CategoricalAlgebra.FinSets: VarSet
 
 sshow(args...) = sprint(show, args...)

--- a/test/categorical_algebra/Permutations.jl
+++ b/test/categorical_algebra/Permutations.jl
@@ -1,7 +1,7 @@
 module TestPermutations
 
 using Test
-using Catlab.Theories, Catlab.Permutations
+using Catlab.Theories, Catlab.CategoricalAlgebra.Permutations
 
 # Decomposition
 ###############

--- a/test/categorical_algebra/StructuredCospans.jl
+++ b/test/categorical_algebra/StructuredCospans.jl
@@ -1,7 +1,7 @@
 module TestStructuredCospans
 using Test
 
-using Catlab, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
+using Catlab.GATs, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
 
 # Structured cospans of C-sets
 ##############################

--- a/test/graphics/GraphvizCategories.jl
+++ b/test/graphics/GraphvizCategories.jl
@@ -1,7 +1,7 @@
 module TestGraphvizCategories
 using Test
 
-using Catlab, Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.Graphs
+using Catlab.GATs, Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.Graphs
 using Catlab.Graphics.GraphvizCategories
 using Catlab.Graphics: Graphviz
 

--- a/test/programs/DiagrammaticPrograms.jl
+++ b/test/programs/DiagrammaticPrograms.jl
@@ -1,7 +1,7 @@
 module TestDiagrammaticPrograms
 using Test
 
-using Catlab, Catlab.Graphs, Catlab.CategoricalAlgebra
+using Catlab.GATs, Catlab.Graphs, Catlab.CategoricalAlgebra
 using Catlab.Programs.DiagrammaticPrograms
 using Catlab.Programs.DiagrammaticPrograms: NamedGraph
 using Catlab.Programs.DiagrammaticPrograms: get_keyword_arg_val, destructure_unary_call

--- a/test/programs/GenerateJuliaPrograms.jl
+++ b/test/programs/GenerateJuliaPrograms.jl
@@ -2,7 +2,7 @@ module TestGenerateJuliaPrograms
 
 using Test
 
-using Catlab, Catlab.Theories
+using Catlab.GATs, Catlab.Theories
 using Catlab.Programs.GenerateJuliaPrograms
 
 ℝ = Ob(FreeCartesianCategory, :ℝ)

--- a/test/programs/ParseJuliaPrograms.jl
+++ b/test/programs/ParseJuliaPrograms.jl
@@ -2,7 +2,7 @@ module TestParseJuliaPrograms
 
 using Test
 
-using Catlab, Catlab.Theories, Catlab.WiringDiagrams
+using Catlab.GATs, Catlab.Theories, Catlab.WiringDiagrams
 using Catlab.Programs
 using Catlab.Programs.ParseJuliaPrograms: normalize_arguments
 


### PR DESCRIPTION
In other words, running "using Catlab" now gives you everything. A long requested change!

Depends on the changes in #800.