### PR TITLE
Transformations between acsets involving only combinatorial data

### DIFF
--- a/benchmark/Graphs.jl
+++ b/benchmark/Graphs.jl
@@ -42,7 +42,7 @@ SYMGRAPHS = Dict(k => SymmetricGraph(g) for (k,g) in LG_SYMGRAPHS)
 #########
 
 # `bench_iter_edges` and `bench_has_edge` adapted from Graphs:
-# https://github.com/JuliaGraphs/Graphs.jl/blob/master/benchmark/core.jl
+# https://github.com/JuliaGraphs/Graphs.jl/blob/main/benchmark/core.jl
 
 function bench_iter_edges(g)
   count = 0

--- a/src/categorical_algebra/Chase.jl
+++ b/src/categorical_algebra/Chase.jl
@@ -28,9 +28,9 @@ import ..Categories: ob_map
 #####
 
 """Distill the component of a morphism that merges elements together"""
-egd(e::CSetTransformation) = factorize(image(e),e)
+egd(e::ACSetTransformation) = factorize(image(e),e)
 """Distill the component of a morphism that adds new elements"""
-tgd(e::CSetTransformation) = factorize(coimage(e), e)
+tgd(e::ACSetTransformation) = factorize(coimage(e), e)
 """Check if id up to isomorphism"""
 no_change(f) = all(c->is_monic(c) && is_epic(c), components(f))
 

--- a/src/categorical_algebra/HomSearch.jl
+++ b/src/categorical_algebra/HomSearch.jl
@@ -198,10 +198,10 @@ function backtracking_search(f, X::ACSet, Y::ACSet;
 
   # Fail early if no monic/isos exist on cardinality grounds.
   if iso isa Bool
-    iso = iso ? Ob : ()
+    iso = iso ? ObAttr : ()
   end
   if monic isa Bool
-    monic = monic ? Ob : ()
+    monic = monic ? ObAttr : ()
   end
   iso_failures = Iterators.filter(c->nparts(X,c)!=nparts(Y,c),iso)
   mono_failures = Iterators.filter(c->nparts(X,c)>nparts(Y,c),monic)  
@@ -655,7 +655,7 @@ function Base.iterate(Sub::OverlapIterator, state=nothing)
     # Get monic maps from Y into each of the objects. The first comes for free
     maps = Vector{ACSetTransformation}[[abs_subobj]]
     for X in Sub.others
-      fs = homomorphisms(Y, X; monic=true)
+      fs = homomorphisms(Y, X; monic=ob(acset_schema(Y)))
       real_fs = Set() # quotient fs via automorphisms of Y
       for f in fs 
         if all(rf->all(σ -> force(σ⋅f) != force(rf),  syms), real_fs)  

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -96,37 +96,37 @@ clim = colimit(Span(h1,h2));
 
 # Constructors and accessors.
 g, h = path_graph(Graph, 4), cycle_graph(Graph, 2)
-α = CSetTransformation((V=[1,2,1,2], E=[1,2,1]), g, h)
+α = ACSetTransformation((V=[1,2,1,2], E=[1,2,1]), g, h)
 @test components(α) == (V=α[:V], E=α[:E])
 @test α[:V] isa FinFunction{Int} && α[:E] isa FinFunction{Int}
 @test α[:V](3) == 1
 @test α[:E](2) == 2
 @test startswith(sprint(show, α), "ACSetTransformation((V = ")
 
-α′ = CSetTransformation(g, h, V=[1,2,1,2], E=[1,2,1])
+α′ = ACSetTransformation(g, h, V=[1,2,1,2], E=[1,2,1])
 @test components(α′) == components(α)
-α′′ = CSetTransformation(g, h, V=FinFunction([1,2,1,2]), E=FinFunction([1,2,1]))
+α′′ = ACSetTransformation(g, h, V=FinFunction([1,2,1,2]), E=FinFunction([1,2,1]))
 @test components(α′′) == components(α)
 
 # Naturality.
 d = naturality_failures(α)
 @test [collect(d[a]) for a in keys(d)] == [[],[]]
 @test is_natural(α)
-β = CSetTransformation((V=[1,2,1,2], E=[1,1,1]), g, h)
+β = ACSetTransformation((V=[1,2,1,2], E=[1,1,1]), g, h)
 d = naturality_failures(β)
 @test sort([collect(v) for v in values(d)]) == [[(2,1,2)],[(2,2,1)]]
 @test startswith(sprint(show_naturality_failures, β), "Failures")
 @test !is_natural(β)
-β = CSetTransformation((V=[2,1], E=[2,1]), h, h)
+β = ACSetTransformation((V=[2,1], E=[2,1]), h, h)
 @test is_natural(β)
-β = CSetTransformation((V=[2,1], E=[2,2]), h, h)
+β = ACSetTransformation((V=[2,1], E=[2,2]), h, h)
 
 # Category of C-sets.
 @test dom(α) === g
 @test codom(α) === h
 γ = compose(α,β)
-@test γ isa TightACSetTransformation
-@test γ == CSetTransformation((V=α[:V]⋅β[:V], E=α[:E]⋅β[:E]), g, h)
+@test γ isa ACSetTransformation
+@test γ == ACSetTransformation((V=α[:V]⋅β[:V], E=α[:E]⋅β[:E]), g, h)
 @test id(g) isa TightACSetTransformation
 @test force(compose(id(g), α)) == α
 @test force(compose(α, id(h))) == α
@@ -154,14 +154,14 @@ term = cycle_graph(Graph, 1)
 lim = terminal(Graph)
 @test ob(lim) == term
 @test force(delete(lim, g)) ==
-  CSetTransformation((V=fill(1,4), E=fill(1,3)), g, term)
+  ACSetTransformation((V=fill(1,4), E=fill(1,3)), g, term)
 
 # Products in Graph: unitality.
 lim = product(g, term)
 @test ob(lim) == g
 @test force(proj1(lim)) == force(id(g))
 @test force(proj2(lim)) ==
-  CSetTransformation((V=fill(1,4), E=fill(1,3)), g, term)
+  ACSetTransformation((V=fill(1,4), E=fill(1,3)), g, term)
 
 # Product in Graph: two directed intervals (Reyes et al 2004, p. 48).
 I = path_graph(Graph, 2)
@@ -181,8 +181,8 @@ lim = product(g, loop2)
 g2 = ob(lim)
 @test (nv(g2), ne(g2)) == (nv(g), 2*ne(g))
 @test (src(g2), tgt(g2)) == (repeat(src(g), 2), repeat(tgt(g), 2))
-α = CSetTransformation((V=[2,3], E=[2]), I, g)
-β = CSetTransformation((V=[1,1], E=[2]), I, loop2)
+α = ACSetTransformation((V=[2,3], E=[2]), I, g)
+β = ACSetTransformation((V=[1,1], E=[2]), I, loop2)
 γ = pair(lim, α, β)
 @test force(γ⋅proj1(lim)) == α
 @test force(γ⋅proj2(lim)) == β
@@ -190,8 +190,8 @@ g2 = ob(lim)
 # Equalizer in Graph from (Reyes et al 2004, p. 50).
 g, h = cycle_graph(Graph, 2), Graph(2)
 add_edges!(h, [1,2,2], [2,1,1])
-ϕ = CSetTransformation((V=[1,2], E=[1,2]), g, h)
-ψ = CSetTransformation((V=[1,2], E=[1,3]), g, h)
+ϕ = ACSetTransformation((V=[1,2], E=[1,2]), g, h)
+ψ = ACSetTransformation((V=[1,2], E=[1,3]), g, h)
 @test is_natural(ϕ) && is_natural(ψ)
 eq = equalizer(ϕ, ψ)
 @test ob(eq) == I
@@ -205,8 +205,8 @@ g0, g1, g2 = Graph(2), Graph(3), Graph(2)
 add_edges!(g0, [1,1,2], [1,2,2])
 add_edges!(g1, [1,2,3], [2,3,3])
 add_edges!(g2, [1,2,2], [1,2,2])
-ϕ = CSetTransformation((V=[1,2,2], E=[2,3,3]), g1, g0)
-ψ = CSetTransformation((V=[1,2], E=[1,3,3]), g2, g0)
+ϕ = ACSetTransformation((V=[1,2,2], E=[2,3,3]), g1, g0)
+ψ = ACSetTransformation((V=[1,2], E=[1,3,3]), g2, g0)
 @test is_natural(ϕ) && is_natural(ψ)
 lim = pullback(ϕ, ψ)
 @test nv(ob(lim)) == 3
@@ -229,7 +229,7 @@ lim′ = limit(FinDomFunctor(diagram))
 # Initial object in graph: the empty graph.
 colim = initial(Graph)
 @test ob(colim) == Graph()
-@test create(colim, g) == CSetTransformation((V=Int[], E=Int[]), Graph(), g)
+@test create(colim, g) == ACSetTransformation((V=Int[], E=Int[]), Graph(), g)
 
 # Coproducts in Graph: unitality.
 g = path_graph(Graph, 4)
@@ -237,7 +237,7 @@ colim = coproduct(g, Graph())
 @test ob(colim) == g
 @test force(coproj1(colim)) == force(id(g))
 @test force(coproj2(colim)) ==
-  CSetTransformation((V=Int[], E=Int[]), Graph(), g)
+  ACSetTransformation((V=Int[], E=Int[]), Graph(), g)
 
 # Coproduct in Graph.
 h = cycle_graph(Graph, 2)
@@ -246,7 +246,7 @@ coprod = ob(colim)
 @test nv(coprod) == 6
 @test src(coprod) == [1,2,3,5,6]
 @test tgt(coprod) == [2,3,4,6,5]
-α = CSetTransformation((V=[1,2,1,2], E=[1,2,1]), g, h)
+α = ACSetTransformation((V=[1,2,1,2], E=[1,2,1]), g, h)
 β = id(h)
 γ = copair(colim, α, β)
 @test force(coproj1(colim)⋅γ) == α
@@ -258,8 +258,8 @@ colim2 = coproduct(path_graph(Graph, 4), cycle_graph(Graph, 2))
 # Coequalizer in Graph: collapsing a segment to a loop.
 g = Graph(2)
 add_edge!(g, 1, 2)
-α = CSetTransformation((V=[1], E=Int[]), Graph(1), g)
-β = CSetTransformation((V=[2], E=Int[]), Graph(1), g)
+α = ACSetTransformation((V=[1], E=Int[]), Graph(1), g)
+β = ACSetTransformation((V=[2], E=Int[]), Graph(1), g)
 @test is_natural(α) && is_natural(β)
 coeq = coequalizer(α, β)
 @test ob(coeq) == ob(terminal(Graph))
@@ -267,8 +267,8 @@ coeq = coequalizer(α, β)
 @test force(proj(coeq)[:E]) == FinFunction([1])
 
 # Pushout in Graph from (Reyes et al 2004, p. 59).
-α = CSetTransformation((V=[2], E=Int[]), Graph(1), g)
-β = CSetTransformation((V=[1], E=Int[]), Graph(1), ob(terminal(Graph)))
+α = ACSetTransformation((V=[2], E=Int[]), Graph(1), g)
+β = ACSetTransformation((V=[1], E=Int[]), Graph(1), ob(terminal(Graph)))
 @test is_natural(α) && is_natural(β)
 colim = pushout(α, β)
 @test nv(ob(colim)) == 2
@@ -335,13 +335,20 @@ end
 @acset_type VELabeledGraph(SchVELabeledGraph,
                            index=[:src,:tgt]) <: AbstractGraph
 
-# Terminal labeled graph.
-@test ob(terminal(VELabeledGraph)) == cycle_graph(VELabeledGraph{Tuple{}}, 1; E=(;elabel=[()]), V=(;vlabel=[()]))
+# Terminal labeled graph (across all possible choices of Julia data types)
+@test ob(terminal(VELabeledGraph; loose=true)) == 
+  cycle_graph(VELabeledGraph{Tuple{}}, 1; E=(;elabel=[()]), V=(;vlabel=[()]))
+
+# Terminal in the subcategory where all attrs are variables
+T2 = ob(terminal(VELabeledGraph{Symbol}; cset=true))
+@test T2 == @acset VELabeledGraph{Symbol} begin 
+  V=1; E=1; Label=2; src=1; tgt=1; vlabel=[AttrVar(1)]; elabel=[AttrVar(2)]
+end
 
 # Product of labeled graphs.
 g = path_graph(VELabeledGraph{Symbol}, 2, V=(vlabel=[:a,:b],), E=(elabel=:f,))
 h = path_graph(VELabeledGraph{String}, 2, V=(vlabel=["x","y"],), E=(elabel="f",))
-π1, π2 = lim = product(g, h)
+π1, π2 = lim = product(g, h; loose=true)
 prod′ = ob(lim)
 @test prod′ isa VELabeledGraph{Tuple{Symbol,String}}
 @test Set(prod′[:vlabel]) == Set([(:a, "x"), (:a, "y"), (:b, "x"), (:b, "y")])
@@ -451,8 +458,8 @@ Y = path_graph(Graph, 3) ⊕ path_graph(Graph, 2) ⊕ path_graph(Graph, 2)
 add_vertex!(Y)
 add_edge!(Y, 2, 8)
 Z = cycle_graph(Graph, 1) ⊕ cycle_graph(Graph, 1)
-ιY, ιZ = colim = pushout(CSetTransformation(I, Y, V=[3]),
-                         CSetTransformation(I, Z, V=[1]))
+ιY, ιZ = colim = pushout(ACSetTransformation(I, Y, V=[3]),
+                         ACSetTransformation(I, Z, V=[1]))
 B_implies_C, B = Subobject(ιY), Subobject(ιZ)
 C = Subobject(ob(colim), V=2:5, E=2:3)
 @test (B ⟹ C) |> force == B_implies_C |> force
@@ -557,9 +564,8 @@ l32 = ACSetTransformation((Weight = t32,), w3, w2)
 l = l32 ⋅ l21 # {Int}->{Bool} x {Bool}->{Symbol} = {Int}->{Symbol}
 @test collect(l[:Weight]) == [:X,:B]
 
-
 # Homomorphism search
-#####################
+#--------------------
 
 A = @acset WG{Bool} begin V=1;E=2;Weight=1;src=1;tgt=1;
                           weight=[true, AttrVar(1)] end
@@ -594,6 +600,7 @@ Z = @acset A2{Symbol} begin X=1; D=1; f=[AttrVar(1)]; g=[AttrVar(1)] end
 
 # Colimits 
 #---------
+
 const WG = WeightedGraph
 
 A = @acset WG{Bool} begin V=1;E=2;Weight=2;src=1;tgt=1;weight=[AttrVar(1),true] end
@@ -645,8 +652,37 @@ h = abstract_attributes(X)
 rem_part!(X, :E, 2)
 @test nparts(dom(h), :E) == 2
 
+# Limits
+#-------
+
+A = @acset WG{Symbol} begin V=1;E=2;Weight=1;src=1;tgt=1;weight=[AttrVar(1),:X] end
+B = @acset WG{Symbol} begin V=1;E=2;Weight=1;src=1;tgt=1;weight=[:X, :Y] end
+C = B ⊕ @acset WG{Symbol} begin V=1 end
+AC = homomorphism(A,C)
+BC = CSetTransformation(B,C; V=[1],E=[1,2], Weight=[:X])
+@test all(is_natural,[AC,BC])
+p1, p2 = product(A,A; cset=true);
+X = @acset WG{Symbol} begin V=1;E=2;Weight=1;src=1;tgt=1;weight=[:X, :X] end
+@test nparts(apex(product(X,X;cset=true)),:Weight) == 1
+
+# Pullback in Graph from (Reyes et al 2004, p. 53), again
+g0, g1, g2 = WG{Symbol}.([2,3,2])
+add_edges!(g0, [1,1,2], [1,2,2]; weight=[:X,:Y,:Z])
+add_edges!(g1, [1,2,3], [2,3,3]; weight=[:Y,:Z,AttrVar(add_part!(g1,:Weight))])
+add_edges!(g2, [1,2,2], [1,2,2]; weight=[AttrVar(add_part!(g2,:Weight)), :Z,:Z])
+ϕ = only(homomorphisms(g1, g0)) |> CSetTransformation
+ψ = only(homomorphisms(g2, g0; initial=(V=[1,2],))) |> CSetTransformation
+@test is_natural(ϕ) && is_natural(ψ)
+lim = pullback(ϕ, ψ)
+@test nv(ob(lim)) == 3
+@test sort!(collect(zip(src(ob(lim)), tgt(ob(lim))))) ==
+  [(2,3), (2,3), (3,3), (3,3)]
+@test is_natural(proj1(lim)) && is_natural(proj2(lim))
+
+
 # Subobjects with variables 
 #--------------------------
+
 X = @acset SetAttr{Bool} begin X=2;D=1;f=[true, AttrVar(1)] end
 A = Subobject(X, X=[1])
 B = Subobject(X, X=[2], D=[1])
@@ -679,5 +715,47 @@ end
 @test dom(hom(subtract(A,B))) == @acset VES begin V=3; E=2; Label=2
   src=[1,2]; tgt=3; vlabel=[:a,:b,:c]; elabel=AttrVar.(1:2)
 end
+
+# Limits of CSetTransformations between ACSets
+#---------------------------------------------
+# Example: "Reflexive graphs" where reflexive edges have weight -1
+A = @acset WeightedGraph{Float64} begin V=2; E=3; 
+  src=[1, 2, 1]; tgt=[1, 2, 2]; weight=[-1, -1, 5] 
+end
+B = @acset WeightedGraph{Float64} begin V=3; E=5; 
+  src=[1, 2, 3, 1, 2]; tgt=[1, 2, 3, 2, 3]; weight=[-1, -1, -1, 2, 3] 
+end
+
+# 1. Stratification with LooseACSetTransformation
+C_nothing =  @acset WeightedGraph{Nothing} begin V=1; E=2; Weight=2
+  src=1; tgt=1; weight=[nothing,nothing]
+end
+AC_nothing = LooseACSetTransformation(
+    (V=[1, 1], E=[1, 1, 2],), (Weight=(_->nothing),), A, C_nothing)
+BC_nothing = LooseACSetTransformation(
+    (V=[1, 1, 1], E=[2, 2, 2, 1, 1],), (Weight=(_->nothing),), B, C_nothing)
+res = apex(pullback(AC_nothing, BC_nothing))
+@test nparts(res, :E) == 7
+@test eltype(res[:weight]) == Tuple{Float64, Float64}
+
+# 2. Stratification with CSetTransformations
+C = @acset WeightedGraph{Float64} begin V=1; E=2; Weight=2
+  src=1; tgt=1; weight=[3.1415, 2.71]
+end
+
+AC = CSetTransformation(A, C; V=[1, 1], E=[1, 1, 2])
+BC = CSetTransformation(B, C; V=[1, 1, 1], E=[2, 2, 2, 1, 1])
+ABC = pullback(AC,BC);
+expected = @acset WeightedGraph{Float64} begin V=6; E=7; Weight=3; 
+  src=[1,1,2,3,3,4,5]; tgt=[2,3,4,4,5,6,6]; weight=AttrVar.([1,2,2,1,3,3,1]) 
+end
+@test is_isomorphic(apex(ABC),expected)
+
+# 3. Apply commutative monoid to attrs
+ABC = pullback(AC,BC; attrfun=(weight=prod,))
+expected = @acset WeightedGraph{Float64} begin V=6; E=7;
+  src=[1,1,2,3,3,4,5]; tgt=[2,3,4,4,5,6,6]; weight=[-5,-2,-2,-5,-3,-3,-5]
+end
+@test is_isomorphic(apex(ABC),expected)
 
 end

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -163,11 +163,16 @@ lim = product(g, term)
 @test force(proj2(lim)) ==
   ACSetTransformation((V=fill(1,4), E=fill(1,3)), g, term)
 
+  
 # Product in Graph: two directed intervals (Reyes et al 2004, p. 48).
 I = path_graph(Graph, 2)
 prod′ = ob(product(I, I))
 @test (nv(prod′), ne(prod′)) == (4, 1)
 @test src(prod′) != tgt(prod′)
+
+I3 = ⊗([I,I,I])
+@test (nv(I3), ne(I3)) == (8, 1)
+@test ⊗(Graph[]) == apex(terminal(Graph))
 
 # Product in Graph: deleting edges by multiplying by an isolated vertex.
 g = path_graph(Graph, 4)
@@ -238,6 +243,10 @@ colim = coproduct(g, Graph())
 @test force(coproj1(colim)) == force(id(g))
 @test force(coproj2(colim)) ==
   ACSetTransformation((V=Int[], E=Int[]), Graph(), g)
+
+g3 = ⊕([g,g,g])
+@test (nv(g3), ne(g3)) == (12, 9)
+@test ⊕(Graph[]) == Graph()
 
 # Coproduct in Graph.
 h = cycle_graph(Graph, 2)

--- a/test/categorical_algebra/Chase.jl
+++ b/test/categorical_algebra/Chase.jl
@@ -26,7 +26,7 @@ end
 core = @acset Graph begin V=2; E=2; src=[1,2]; tgt=[2,1] end
 
 # This adds a self loop to #1 and merges #1/#3
-etgd = CSetTransformation(etgd_s,etgd_t; V=[1,2,1], E=[2,3])
+etgd = ACSetTransformation(etgd_s,etgd_t; V=[1,2,1], E=[2,3])
 
 @test is_isomorphic(codom(egd(etgd)), core) # EGD has no extra self-edge
 @test collect(egd(etgd)[:V]) == [1,2,1] # but it does merge vertices

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -1,0 +1,598 @@
+module TestDataMigrations
+using Test
+
+using Catlab.GATs, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
+using Catlab.Programs.DiagrammaticPrograms
+
+@present SchSet(FreeSchema) begin
+  X::Ob
+end
+@acset_type AcsetSet(SchSet)
+
+@present SchDDS <: SchSet begin
+  Φ::Hom(X,X)
+end
+@acset_type DDS(SchDDS, index=[:Φ])
+
+# Contravariant migration
+#########################
+
+# Pullback migration
+#-------------------
+
+h = Graph(3)
+add_parts!(h, :E, 3, src = [1,2,3], tgt = [2,3,1])
+
+# Identity data migration.
+@test h == migrate(Graph, h, Dict(:V => :V, :E => :E),
+                   Dict(:src => :src, :tgt => :tgt))
+
+# Migrate DDS → Graph.
+dds = DDS()
+add_parts!(dds, :X, 3, Φ=[2,3,1])
+X = SchDDS[:X]
+@test h == migrate(Graph, dds, Dict(:V => :X, :E => :X),
+                   Dict(:src => id(X), :tgt => :Φ))
+
+h2 = copy(h)
+migrate!(h2, dds, Dict(:V => :X, :E => :X),
+                  Dict(:src => id(X), :tgt => :Φ))
+@test h2 == ob(coproduct(h, h))
+
+# Migrate DDS → DDS by advancing four steps.
+@test dds == migrate(DDS, dds, Dict(:X => :X),
+                     Dict(:Φ => [:Φ, :Φ, :Φ, :Φ]))
+
+@present SchLabeledDDS <: SchDDS begin
+  Label::AttrType
+  label::Attr(X, Label)
+end
+@acset_type LabeledDDS(SchLabeledDDS, index=[:Φ, :label])
+
+S, ϕ, Label, label = generators(SchLabeledDDS)
+V, E, s, t, Weight, weight = generators(SchWeightedGraph)
+
+ldds = LabeledDDS{Int}()
+add_parts!(ldds, :X, 4, Φ=[2,3,4,1], label=[100, 101, 102, 103])
+
+wg = WeightedGraph{Int}(4)
+add_parts!(wg, :E, 4, src=[1,2,3,4], tgt=[2,3,4,1], weight=[101, 102, 103, 100])
+
+@test wg == migrate(WeightedGraph{Int}, ldds,
+  Dict(:V => :X, :E => :X, :Weight => :Label),
+  Dict(:src => id(S), :tgt => :Φ, :weight => [:Φ, :label]))
+
+@test Presentation(Graph(1)) == SchGraph
+@test Presentation(ldds) == SchLabeledDDS
+
+F = FinFunctor(
+  Dict(V => S, E => S, Weight => Label),
+  Dict(s => id(S), t => ϕ, weight => compose(ϕ, label)),
+  SchWeightedGraph, SchLabeledDDS
+)
+ΔF = DataMigrationFunctor(F, LabeledDDS{Int}, WeightedGraph{Int})
+@test wg == ΔF(ldds)
+
+idF = id(FinCat(SchLabeledDDS))
+@test ldds == migrate(LabeledDDS{Int}, ldds, DataMigration(idF))
+
+# Conjunctive migration
+#----------------------
+
+# Graph whose edges are paths of length 2.
+V, E, src, tgt = generators(SchGraph)
+C = FinCat(SchGraph)
+F_V = FinDomFunctor([V], FinCat(1), C)
+F_E = FinDomFunctor(FreeDiagram(Cospan(tgt, src)), C)
+M = DataMigration(FinDomFunctor(Dict(V => Diagram{op}(F_V),
+                       E => Diagram{op}(F_E)),
+                  Dict(src => DiagramHom{op}([(1, src)], F_E, F_V),
+                       tgt => DiagramHom{op}([(2, tgt)], F_E, F_V)), C))
+@test M isa DataMigrations.ConjSchemaMigration
+g = path_graph(Graph, 5)
+H = migrate(g, M, tabular=true)
+@test length(H(V)) == 5
+@test length(H(E)) == 3
+@test H(src)((x1=2, x2=3, x3=3)) == (x1=2,)
+@test H(tgt)((x1=2, x2=3, x3=3)) == (x1=4,)
+
+# Same migration, but defining using the `@migration` macro.
+M = @migration SchGraph SchGraph begin
+  V => V
+  E => @join begin
+    v::V
+    (e₁, e₂)::E
+    tgt(e₁) == v
+    src(e₂) == v
+  end
+  src => e₁ ⋅ src
+  tgt => e₂ ⋅ tgt
+end
+F = functor(M)
+H = migrate(g, M, tabular=true)
+@test length(H(V)) == 5
+@test length(H(E)) == 3
+@test H(src)((v=3, e₁=2, e₂=3)) == (V=2,)
+@test H(tgt)((v=3, e₁=2, e₂=3)) == (V=4,)
+
+h = migrate(Graph, g, M)
+@test (nv(h), ne(h)) == (5, 3)
+@test sort!(collect(zip(h[:src], h[:tgt]))) == [(1,3), (2,4), (3,5)]
+
+h = Graph(5)
+migrate!(h, g, M)
+@test (nv(h), ne(h)) == (10, 3)
+@test sort!(collect(zip(h[:src], h[:tgt]))) == [(6,8), (7,9), (8,10)]
+
+# Weighted graph whose edges are path of length 2 with equal weight.
+F = @migration SchWeightedGraph SchWeightedGraph begin
+  V => V
+  E => @join begin
+    v::V; (e₁, e₂)::E; w::Weight
+    tgt(e₁) == v
+    src(e₂) == v
+    weight(e₁) == w
+    weight(e₂) == w
+  end
+  Weight => Weight
+  src => e₁ ⋅ src
+  tgt => e₂ ⋅ tgt
+  weight => w
+end
+g = path_graph(WeightedGraph{Float64}, 6, E=(weight=[0.5,0.5,1.5,1.5,1.5],))
+h = migrate(WeightedGraph{Float64}, g, F)
+@test (nv(h), ne(h)) == (6, 3)
+@test sort!(collect(zip(h[:src], h[:tgt], h[:weight]))) ==
+  [(1,3,0.5), (3,5,1.5), (4,6,1.5)]
+
+# Graph whose vertices are paths of length 2 and edges are paths of length 3.
+g = path_graph(Graph, 6)
+h = @migrate Graph g begin
+  V => @join begin
+    v::V
+    (e₁, e₂)::E
+    (t: e₁ → v)::tgt
+    (s: e₂ → v)::src
+  end
+  E => @join begin
+    (v₁, v₂)::V
+    (e₁, e₂, e₃)::E
+    (t₁: e₁ → v₁)::tgt
+    (s₁: e₂ → v₁)::src
+    (t₂: e₂ → v₂)::tgt
+    (s₂: e₃ → v₂)::src
+  end
+  src => (v => v₁; e₁ => e₁; e₂ => e₂; t => t₁; s => s₁)
+  tgt => (v => v₂; e₁ => e₂; e₂ => e₃; t => t₂; s => s₂)
+end
+@test h == path_graph(Graph, 4)
+
+# Bouquet graph on a set.
+set = @acset AcsetSet begin X = 5 end
+g = @migrate Graph set begin
+  V => @unit
+  E => X
+end
+g′ = @acset Graph begin
+  V = 1
+  E = 5
+  src = [1,1,1,1,1]
+  tgt = [1,1,1,1,1]
+end
+@test g == g′
+
+# Gluing migration
+#-----------------
+
+# Free reflexive graph on a graph.
+g = cycle_graph(Graph, 5)
+h = @migrate ReflexiveGraph g begin
+  V => V
+  E => @cases (v::V; e::E)
+  src => (e => src)
+  tgt => (e => tgt)
+  refl => v
+end
+@test h == cycle_graph(ReflexiveGraph, 5)
+
+# Free symmetric graph on a graph.
+g = star_graph(Graph, 5)
+h = @migrate SymmetricGraph g begin
+  V => V
+  E => @cases (fwd::E; rev::E)
+  src => (fwd => src; rev => tgt)
+  tgt => (fwd => tgt; rev => src)
+  inv => (fwd => rev; rev => fwd)
+end
+@test h == star_graph(SymmetricGraph, 5)
+
+# Free symmetric weighted graph on a weighted graph.
+weights = range(0, 1, length=5)
+g = star_graph(WeightedGraph{Float64}, 6, E=(weight=weights,))
+h = @migrate SymmetricWeightedGraph g begin
+  V => V
+  E => @cases (fwd::E; rev::E)
+  Weight => Weight
+  src => (fwd => src; rev => tgt)
+  tgt => (fwd => tgt; rev => src)
+  inv => (fwd => rev; rev => fwd)
+  weight => (fwd => weight; rev => weight)
+end
+h′ = star_graph(SymmetricWeightedGraph{Float64}, 6)
+h′[:weight] = vcat(weights, weights)
+@test h == h′
+
+# Free symmetric reflexive graph on a reflexive graph.
+g = star_graph(ReflexiveGraph, 5)
+h = @migrate SymmetricReflexiveGraph g begin
+  V => V
+  E => @glue begin
+    (fwd, rev)::E
+    v::V
+    (refl_fwd: v → fwd)::refl
+    (refl_rev: v → rev)::refl
+  end
+  src => (fwd => src; rev => tgt)
+  tgt => (fwd => tgt; rev => src)
+  refl => v
+  inv => begin
+    fwd => rev; rev => fwd; v => v;
+    refl_fwd => refl_rev; refl_rev => refl_fwd
+  end
+end
+@test is_isomorphic(h, star_graph(SymmetricReflexiveGraph, 5))
+
+# Discrete graph on set.
+set = @acset AcsetSet begin X = 5 end
+g = @migrate Graph set begin
+  V => X
+  E => @empty
+end
+@test g == Graph(5)
+
+# Gluc migration
+#---------------
+
+# Graph with edges that are paths of length <= 2.
+g = path_graph(Graph, 4)
+h = @migrate Graph g begin
+  V => V
+  E => @cases begin
+    v => V
+    e => E
+    path => @join begin
+      v::V
+      (e₁, e₂)::E
+      tgt(e₁) == v
+      src(e₂) == v
+    end
+  end
+  src => (e => src; path => e₁⋅src)
+  tgt => (e => tgt; path => e₂⋅tgt)
+end
+h′ = @acset Graph begin
+  V = 4
+  E = 9
+  src = [1,2,3,4, 1,2,3, 1,2]
+  tgt = [1,2,3,4, 2,3,4, 3,4]
+end
+@test h == h′
+
+# Sigma migration
+#################
+
+V1B, V2B, EB = generators(SchUndirectedBipartiteGraph, :Ob)
+srcB, tgtB = generators(SchUndirectedBipartiteGraph, :Hom)
+
+VG, EG = generators(SchGraph, :Ob)
+srcG, tgtG = generators(SchGraph, :Hom)
+
+F = FinFunctor(
+  Dict(V1B => VG, V2B => VG, EB => EG),
+  Dict(srcB => srcG, tgtB => tgtG),
+  SchUndirectedBipartiteGraph, SchGraph
+)
+idF = id(FinCat(SchGraph))
+
+ΣF = SigmaMigrationFunctor(F, UndirectedBipartiteGraph, Graph)
+X = UndirectedBipartiteGraph()
+
+Y = ΣF(X)
+@test nparts(Y, :V) == 0
+@test nparts(Y, :E) == 0
+
+X = @acset UndirectedBipartiteGraph begin
+  V₁ = 4
+  V₂ = 3
+  E = 4
+  src = [1,2,2,3]
+  tgt = [1,1,2,3]
+end
+
+Yd = ΣF(X; return_unit=true)
+Y = Graph(codom(Yd))
+α = diagram_map(Yd)
+@test nparts(Y, :V) == 7
+@test nparts(Y, :E) == 4
+@test length(Y[:src] ∩ Y[:tgt]) == 0
+@test isempty(collect(α[:V₁]) ∩ collect(α[:V₂]))
+
+@test SigmaMigrationFunctor(idF, Graph, Graph)(Y) == Y
+
+# Sigma migrations with attributes
+#---------------------------------
+
+# Identity migration on weighted graphs.
+Y = @acset WeightedGraph{Symbol} begin
+  V=2; E=2; Weight=1; src=1; tgt=[1,2]; weight=[AttrVar(1), :X]
+end
+ΣF = SigmaMigrationFunctor(id(FinCat(SchWeightedGraph)),
+                           WeightedGraph{Symbol}, WeightedGraph{Symbol})
+@test is_isomorphic(ΣF(Y),Y)
+
+# Less trivial example.
+@present SchTwoThings(FreeSchema) begin
+  Th1::Ob
+  Th2::Ob
+  Property::AttrType
+  # The ID attribute keeps track of combinatorial objects as their
+  # non-meaningful integer IDs may be modified by the chase.
+  ID::AttrType
+  f::Hom(Th1,Th2)
+  id::Attr(Th1,ID)
+end
+@present SchThing1WithProp <: SchTwoThings begin
+  prop::Attr(Th1,Property)
+end
+@acset_type Thing1WithProp(SchThing1WithProp)
+@present SchThing2WithProp <: SchTwoThings begin
+  prop::Attr(Th2,Property)
+end
+@acset_type Thing2WithProp(SchThing2WithProp)
+
+X = @acset Thing2WithProp{Bool,String} begin
+  Th1 = 2
+  Th2 = 4
+  f = [1,3]
+  prop = [false,false,true,true]
+  id = ["ffee cup","doughnut"]
+end
+
+Y = @acset Thing1WithProp{Bool,String} begin
+  Th1 = 2
+  Th2 = 4
+  f = [1,3]
+  prop = [false,true]
+  id = ["ffee cup","doughnut"]
+end
+C1,C2 = FinCat(SchThing1WithProp),FinCat(SchThing2WithProp)
+th1,th2,property,ID = ob_generators(C1)
+f1,id1,prop1 = hom_generators(C1)
+f2,id2,prop2 = hom_generators(C2)
+
+F = FinFunctor(
+  Dict(th1 => th1, th2 => th2, property => property,ID=>ID),
+  Dict(f1 => f2, prop1 => [f2, prop2],id1=>id2),
+  SchThing1WithProp, SchThing2WithProp
+)
+
+ΔF = DataMigrationFunctor(F, Thing2WithProp{Bool,String}, Thing1WithProp{Bool,String})
+ΣF = SigmaMigrationFunctor(F, Thing1WithProp{Bool,String}, Thing2WithProp{Bool,String})
+
+YY = ΔF(X)
+XX = ΣF(Y)
+@test YY == Y
+@test incident(XX,false,[:f,:prop]) == incident(XX,"ffee cup",:id)
+
+# Terminal map
+#-------------
+@present ThSpan(FreeSchema) begin
+  (L1, L2, A)::Ob
+  l1::Hom(A, L1)
+  l2::Hom(A, L2)
+end
+@acset_type Span(ThSpan, index=[:l1, :l2])
+
+X = @acset Span begin
+  L1 = 3
+  L2 = 4
+  A = 3
+  l1 = [1,1,2]
+  l2 = [1,2,3]
+end
+
+@present ThInitial(FreeSchema) begin
+  I::Ob
+end
+@acset_type Initial(ThInitial)
+
+L1, L2, A = generators(ThSpan, :Ob)
+l1, l2 = generators(ThSpan, :Hom)
+I = generators(ThInitial)[1]
+
+bang = FinFunctor(
+  Dict(L1 => I, L2 => I, A => I),
+  Dict(l1 => id(I), l2 => id(I)),
+  ThSpan, ThInitial
+)
+
+Σbang = SigmaMigrationFunctor(bang, Span, Initial)
+Yd = Σbang(X; return_unit=true)
+α = diagram_map(Yd)
+@test length(unique([α[:A](1:2)...,α[:L1](1),α[:L2](1:2)...])) == 1
+Y = Initial(codom(Yd))
+@test nparts(Y, :I) == 4
+
+# Map from terminal C 
+#--------------------
+
+V = FinFunctor(Dict(I => VG), Dict(), ThInitial, SchGraph)
+E = FinFunctor(Dict(I => EG), Dict(), ThInitial, SchGraph)
+
+Z = SigmaMigrationFunctor(V, Initial, Graph)(Y)
+@test nparts(Z, :V) == 4
+@test nparts(Z, :E) == 0
+
+Z = SigmaMigrationFunctor(E, Initial, Graph)(Y)
+expected = foldl(⊕,fill(path_graph(Graph,2), 4))  
+@test is_isomorphic(Z,expected)
+
+# Using the equations of the schema 
+#----------------------------------
+F = FinFunctor(
+  Dict(:V => :V, :E=> :E),
+  Dict(:src=>:src, :tgt=>:tgt),
+  SchGraph, SchReflexiveGraph
+)
+G = path_graph(Graph,3)
+Σ = SigmaMigrationFunctor(F, Graph, ReflexiveGraph)
+expected = @acset ReflexiveGraph  begin 
+  V=3; E=5; refl=1:3; src=[1,2,3,1,2]; tgt=[1,2,3,2,3] 
+end 
+@test is_isomorphic(Σ(G), expected)
+
+# Sigma with attributes 
+#----------------------
+
+# Connected components must be monochromatic
+@present SchWG <: SchGraph begin
+  Color::AttrType
+  color::Attr(V,Color)
+  src ⋅ color == tgt ⋅ color
+end
+@acset_type WG(SchWG)
+
+F = FinFunctor(Dict(:V => :V, :E=> :E), Dict(:src=>:src, :tgt=>:tgt), SchGraph, SchWG)
+Σ = SigmaMigrationFunctor(F, Graph, WG{Float64})
+
+G = path_graph(Graph,3) ⊕ Graph(1) # two connected components
+expected = @acset WG{Float64} begin 
+  V=4; E=2; Color=2; src=[2,3]; tgt=[3,1]; color=AttrVar.([1,1,1,2]) 
+end
+
+@test is_isomorphic(Σ(G), expected)
+ 
+# Yoneda embedding
+#-----------------
+
+# Yoneda embedding for graphs (no attributes).
+yV, yE = Graph(1), @acset(Graph, begin V=2;E=1;src=2;tgt=1 end)
+@test representable(Graph, :V) == yV
+@test is_isomorphic(representable(Graph, :E), yE)
+
+y_Graph = yoneda(Graph)
+@test ob_map(y_Graph, :V) == yV
+@test is_isomorphic(ob_map(y_Graph, :E), yE)
+@test Set(hom_map.(Ref(y_Graph), [:src,:tgt])) == Set(
+  homomorphisms(yV, representable(Graph, :E)))
+
+F = @migration SchGraph begin
+  X => E
+  (I, O) => V
+  (i: X → I) => src
+  (o: X → O) => tgt
+end
+G = colimit_representables(F, y_Graph) # Delta migration.
+X = ob_map(G, :X)
+@test is_isomorphic(X, yE)
+i, o = hom_map(G, :i), hom_map(G, :o)
+@test sort(only.(collect.([i[:V],o[:V]]))) == [1,2]
+
+F = @migration SchGraph begin
+  X => @join begin
+    (e₁, e₂)::E
+    tgt(e₁) == src(e₂)
+  end
+  (I, O) => V
+  (i: X → I) => src(e₁)
+  (o: X → O) => tgt(e₂)
+end
+G = colimit_representables(F, y_Graph) # Conjunctive migration.
+X = ob_map(G, :X)
+@test is_isomorphic(X, path_graph(Graph, 3))
+i, o = hom_map(G, :i), hom_map(G, :o)
+@test isempty(inneighbors(X, only(collect(i[:V]))))
+@test isempty(outneighbors(X, only(collect(o[:V]))))
+
+# Yoneda embedding for weights graphs (has attributes).
+WGF = WeightedGraph{Float64}
+yV, yE = WGF(1), @acset(WGF, begin 
+  V=2;E=1;Weight=1;src=2;tgt=1; weight=[AttrVar(1)]
+end)
+@test representable(WGF, SchWeightedGraph, :V) == yV
+@test is_isomorphic(representable(WGF, SchWeightedGraph, :E), yE)
+
+yWG = yoneda(WGF)
+
+F = @migration SchWeightedGraph begin
+  X => E
+  (I, O) => V
+  (i: X → I) => src
+  (o: X → O) => tgt
+end
+G = colimit_representables(F, yWG) # Delta migration.
+X = ob_map(G, :X)
+@test is_isomorphic(X, yE)
+i, o = hom_map(G, :i), hom_map(G, :o)
+@test sort(only.(collect.([i[:V],o[:V]]))) == [1,2]
+
+
+d = @migration(SchWeightedGraph, begin
+    I => @join begin
+      (e1,e2,e3)::E
+      (w1,w3)::Weight
+      src(e1) == src(e2)      
+      weight(e1) == w1
+      w1 == 1.9     
+      weight(e2) == 1.8 
+      weight(e3) == w3
+    end
+end)
+
+expected = @acset WeightedGraph{Float64} begin
+  V=5; E=3; Weight=1; src=[1,1,3]; tgt=[2,4,5]; weight=[1.8,1.9,AttrVar(1)]
+end
+@test is_isomorphic(ob_map(colimit_representables(d, yWG), :I), expected)
+
+# Subobject classifier
+######################
+
+# Graph and ReflGraph have 'same' subobject classifier
+ΩG,_ = subobject_classifier(Graph, SchGraph)
+ΩrG,_ = subobject_classifier(ReflexiveGraph, SchReflexiveGraph)
+F = FinFunctor(Dict(:V=>:V, :E=>:E), Dict(:src=>:src, :tgt=>:tgt), 
+               SchGraph, SchReflexiveGraph)
+ΔF = DataMigrationFunctor(F, ReflexiveGraph, Graph)
+@test is_isomorphic(ΩG, ΔF(ΩrG))
+
+# Searching for maps into the subobject classifier is much faster than 
+# enumerating them via `subobject_graph`
+G = (star_graph(Graph, 2)⊗path_graph(Graph, 3))
+@test length(homomorphisms(G, ΩG)) == length(subobject_graph(G)[2])
+
+@present SchDDS42(FreeSchema) begin
+  X::Ob
+  Φ::Hom(X,X)
+  Φ⋅Φ⋅Φ⋅Φ == Φ⋅Φ
+end
+
+@acset_type DDS42(SchDDS42, index=[:Φ])
+ΩDDs, _ = subobject_classifier(DDS42, SchDDS42)
+@test is_isomorphic(ΩDDs, @acset DDS42 begin X=4; Φ=[1,3,4,4] end)
+
+# Internal Hom
+##############
+
+G = ReflexiveGraph(2)
+F = path_graph(ReflexiveGraph, 2)
+Fᴳ,_ = internal_hom(G,F, SchReflexiveGraph)
+Z = apex(terminal(ReflexiveGraph)) ⊕ path_graph(ReflexiveGraph, 3)
+@test length(homomorphisms(Z, Fᴳ)) == length(homomorphisms(Z ⊗ G, F)) # 64
+
+G = @acset DDS42 begin X=3; Φ=[2,3,3] end
+F = @acset DDS42 begin X=4; Φ=[2,2,4,4] end
+Fᴳ,_ = internal_hom(G,F, SchDDS42)
+Z = @acset DDS42 begin X=5; Φ=[2,3,4,3,4] end
+@test length(homomorphisms(Z, Fᴳ)) == length(homomorphisms(Z ⊗ G, F)) # 1024
+
+end # module

--- a/test/categorical_algebra/HomSearch.jl
+++ b/test/categorical_algebra/HomSearch.jl
@@ -23,14 +23,14 @@ end
 #-------
 
 g, h = path_graph(Graph, 3), path_graph(Graph, 4)
-homs = [CSetTransformation((V=[1,2,3], E=[1,2]), g, h),
-        CSetTransformation((V=[2,3,4], E=[2,3]), g, h)]
+homs = [ACSetTransformation((V=[1,2,3], E=[1,2]), g, h),
+        ACSetTransformation((V=[2,3,4], E=[2,3]), g, h)]
 @test homomorphisms(g, h) == homs
 @test homomorphisms(g, h, alg=HomomorphismQuery()) == homs
 @test !is_isomorphic(g, h)
 
 I = ob(terminal(Graph))
-α = CSetTransformation((V=[1,1,1], E=[1,1]), g, I)
+α = ACSetTransformation((V=[1,1,1], E=[1,1]), g, I)
 @test homomorphism(g, I) == α
 @test homomorphism(g, I, alg=HomomorphismQuery()) == α
 @test !is_homomorphic(g, I, monic=true)
@@ -38,7 +38,7 @@ I = ob(terminal(Graph))
 @test !is_homomorphic(I, h, alg=HomomorphismQuery())
 
 # Graph homomorphism starting from partial assignment, e.g. vertex assignment.
-α = CSetTransformation((V=[2,3,4], E=[2,3]), g, h)
+α = ACSetTransformation((V=[2,3,4], E=[2,3]), g, h)
 @test homomorphisms(g, h, initial=(V=[2,3,4],)) == [α]
 @test homomorphisms(g, h, initial=(V=Dict(1 => 2, 3 => 4),)) == [α]
 @test homomorphisms(g, h, initial=(E=Dict(1 => 2),)) == [α]


### PR DESCRIPTION
By considering CSetTransformations between ACSets (where naturality is **not** demanded on attributes) we can obtain two sorts of practical constructions: 

1. A kind of "labeled CSet" where we can think of the attributes as functioning as labels
2. A kind of limit construction for ACSets which acts purely on the combinatorial data. The apex can put whatever it wants for the attributes, but we can deliberately *pick* a representative of the isomorphism class to make it correspond to something meaningful (with valid ACSetTransformations), which Kevin has a nice categorical characterization of in an AlgebraicJulia [blog post](https://blog.algebraicjulia.org/post/2023/06/varacsets/).

Implementation-wise, this means we want an abstract type of `ACSetMorphism` which is implemented by `ACSetTransformation` and `CSetTransformation` (therefore, this is changing the meaning of `CSetTransformation`, which before was an `ACSetTransformation` that happened to be on a schema with no attributes). There is probably a lot of functionality which is written for `ACSetTransformation` which would straightforwardly work for `ACSetMorphism`, but the minimal required functionality (e.g. `dom`, `compose`) for getting limits to work is all that is generalized for now.

It may be the case that we want something in between, where a subset of the attributes are marked to be ignored. This would give us a kind of "LACSets" - but we would then lose the ability to do #2 above, which I see as the real value of this.

Edit: I also addressed a tiny bug in the HomSearch code where `monic` and `iso` fast failure constraints were not being checked for the combinatorial Attr data. 