### PR TITLE
BUILD: fix BenchmarkCI assumption that `origin/master` exists

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -12,6 +12,6 @@ jobs:
       - name: Install dependencies
         run: julia -e 'using Pkg; pkg"add PkgBenchmark BenchmarkCI@0.1"'
       - name: Run benchmarks
-        run: julia -e 'using BenchmarkCI; BenchmarkCI.judge()'
+        run: julia -e 'using BenchmarkCI; BenchmarkCI.judge(; baseline = "origin/main")'
       - name: Print results
         run: julia -e 'using BenchmarkCI; BenchmarkCI.displayjudgement()'

--- a/.github/workflows/reviewchecklist.yml
+++ b/.github/workflows/reviewchecklist.yml
@@ -9,7 +9,7 @@ jobs:
     name: Review Checklist
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v4
+      - uses: actions/github-script@v6
         with:
           script: |
             const issues = await github.paginate(github.rest.issues.listComments({
@@ -24,7 +24,7 @@ jobs:
               }
             }
 
-            github.issues.createComment({
+            github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
Not sure why the default `baseline` is not set to the default branch set in the git repo smh