### PR TITLE
Fix omitted case in `leftmost_arg`

### DIFF
--- a/src/programs/DiagrammaticPrograms.jl
+++ b/src/programs/DiagrammaticPrograms.jl
@@ -1105,7 +1105,7 @@ end
 function parse_mapping_ast(body, dom; kw...)
   parse_mapping_ast((rhs, _) -> parse_ob_ast(rhs), body, dom; kw...)
 end
-
+#ugh wtf is leftmost arg's even deal with \circ
 function parse_apply_ast(expr, X, target)
   y::Symbol, f = @match expr begin
     ::Symbol => (expr, nothing)
@@ -1166,6 +1166,8 @@ function reparse_arrows(expr)
 end
 
 """ Left-most argument plus remainder of left-associated binary operations.
+`ops` denotes the operations that won't need to be reversed for the desired
+parser output (AST.Apply or AST.Coapply).
 """
 function leftmost_arg(expr, ops; all_ops=nothing)
   isnothing(all_ops) && (all_ops = ops)
@@ -1177,6 +1179,7 @@ function leftmost_arg(expr, ops; all_ops=nothing)
         (x, Expr(:call, op2, rest, z))
       end
       Expr(:call, op, x, y) && if op ∈ ops end => (x, y)
+      Expr(:call, op, x, y) => (y,x)
       _ => (nothing, expr)
     end
   end

--- a/src/programs/DiagrammaticPrograms.jl
+++ b/src/programs/DiagrammaticPrograms.jl
@@ -1105,7 +1105,6 @@ end
 function parse_mapping_ast(body, dom; kw...)
   parse_mapping_ast((rhs, _) -> parse_ob_ast(rhs), body, dom; kw...)
 end
-#ugh wtf is leftmost arg's even deal with \circ
 function parse_apply_ast(expr, X, target)
   y::Symbol, f = @match expr begin
     ::Symbol => (expr, nothing)

--- a/test/programs/DiagrammaticPrograms.jl
+++ b/test/programs/DiagrammaticPrograms.jl
@@ -267,6 +267,18 @@ M = @migration SchGraph SchGraph begin
   src => e₁ ⋅ src
   tgt => e₂ ⋅ tgt
 end
+#Syntactic variant
+@migration SchGraph SchGraph begin
+  V => V
+  E => @join begin
+    v::V
+    (e₁, e₂)::E
+    (e₁ → v)::tgt
+    (e₂ → v)::src
+  end
+  src => e₁ ⋅ src
+  tgt => e₂ ⋅ tgt
+end
 @test M isa DataMigrations.ConjSchemaMigration
 F = functor(M)
 F_E = diagram(ob_map(F, :E))

--- a/test/programs/DiagrammaticPrograms.jl
+++ b/test/programs/DiagrammaticPrograms.jl
@@ -276,8 +276,8 @@ end
     (e₁ → v)::tgt
     (e₂ → v)::src
   end
-  src => e₁ ⋅ src
-  tgt => e₂ ⋅ tgt
+  src => src∘e₁
+  tgt => tgt∘e₁
 end
 @test M isa DataMigrations.ConjSchemaMigration
 F = functor(M)


### PR DESCRIPTION
Resolves #805 .

The `leftmost_arg` function that's used to build `AST.Apply` and `AST.Coapply`s was missing a case for what to do when giving a composition operator that works in the opposite order of the target AST type.