### PR TITLE
More support for subacsets with variables

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -1174,7 +1174,7 @@ function limit(::Type{Tuple{ACS,Hom}}, diagram; product_attrs::Bool=false) where
   type_components = [
     Dict(d=>legs(attr_lims[d])[i] for d in attrtypes(S)) for i in eachindex(Xs)]
   
-  limits = NamedTuple(Dict([k=>v for (k,v) in pairs(limits) if k ∈ objects(S)]))
+  limits = NamedTuple(k=>v for (k,v) in pairs(limits) if k ∈ objects(S))
   lim = pack_limit(LimitACS, diagram, Xs, limits; type_components = type_components)
   Y = ob(lim)
   for (f, c, d) in attrs(S)
@@ -1399,9 +1399,10 @@ const SubACSet{S} = Subobject{<:StructACSet{S}}
 
 # Cast VarFunctions to FinFunctions
 components(A::SubACSet{S}) where S = 
-  NamedTuple(Dict(map(collect(pairs(components(hom(A))))) do (k,vs)
-    k => Subobject(k ∈ ob(S) ? vs : FinFunction([v.val for v in collect(vs)], FinSet(codom(vs))))
-end))
+  NamedTuple(k => Subobject(
+    k ∈ ob(S) ? vs : FinFunction([v.val for v in collect(vs)], FinSet(codom(vs))))
+  for (k,vs) in pairs(components(hom(A)))
+)
 
 force(A::SubACSet) = Subobject(force(hom(A)))
 
@@ -1497,7 +1498,7 @@ subtraction of sub-C-sets ([`subtract`](@ref)).
 function implies(A::SubACSet{S}, B::SubACSet{S}, ::SubOpBoolean) where S
   X = common_ob(A, B)
   A, B = map(predicate, components(A)), map(predicate, components(B))
-  D = NamedTuple(Dict([o => trues(nparts(X, o)) for o in types(S)]))
+  D = NamedTuple([o => trues(nparts(X, o)) for o in types(S)])
   function unset!(c, x)
     D[c][x] = false
     for (c′,x′) in all_incident(X, Val{c}, x)
@@ -1523,7 +1524,7 @@ for all ``c ∈ C`` and ``x ∈ X(c)``. Compare with [`implies`](@ref).
 function subtract(A::SubACSet{S}, B::SubACSet{S}, ::SubOpBoolean) where S
   X = common_ob(A, B)
   A, B = map(predicate, components(A)), map(predicate, components(B))
-  D = NamedTuple(Dict([o => falses(nparts(X, o)) for o in types(S)]))
+  D = NamedTuple(o => falses(nparts(X, o)) for o in types(S))
 
   function set!(c, x)
     D[c][x] = true

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -4,7 +4,7 @@ module FinSets
 export FinSet, FinFunction, FinDomFunction, TabularSet, TabularLimit,
   force, is_indexed, preimage, VarFunction, LooseVarFunction,
   JoinAlgorithm, SmartJoin, NestedLoopJoin, SortMergeJoin, HashJoin,
-  SubFinSet, SubOpBoolean, is_monic, is_epic, SubVarSet
+  SubFinSet, SubOpBoolean, is_monic, is_epic
 
 using StructEquality
 using DataStructures: OrderedDict, IntDisjointSets, union!, find_root!
@@ -1463,29 +1463,5 @@ join(A::SubFinSet{Int}, B::SubFinSet{Int}, ::SubOpBoolean) =
   SubFinSet(predicate(A) .| predicate(B))
 top(X::FinSet{Int}, ::SubOpBoolean) = SubFinSet(trues(length(X)))
 bottom(X::FinSet{Int}, ::SubOpBoolean) = SubFinSet(falses(length(X)))
-
-# SubVarSets
-
-""" Subset of a finite varset.
-"""
-const SubVarSet{T} = Subobject{VarSet{T}}
-
-Subobject(X::VarSet{T}, f::AbstractVector) where T = 
-  Subobject(VarFunction{T}(AttrVar.(f), FinSet(X)))
-
-@instance ThSubobjectLattice{VarSet,SubVarSet} begin
-  @import ob
-  meet(A::SubVarSet, B::SubVarSet) = meet(A,B,SubOpBoolean())
-  join(A::SubVarSet, B::SubVarSet) = join(A,B,SubOpBoolean())
-  top(X::VarSet) = top(X,SubOpBoolean())
-  bottom(X::VarSet) = bottom(X,SubOpBoolean())
-end
-
-meet(A::SubVarSet{T}, B::SubVarSet{T}, ::SubOpBoolean) where T =
-  Subobject(codom(hom(A)),[a.val for a in collect(hom(A)) ∩ collect(hom(B))])
-join(A::SubVarSet, B::SubVarSet, ::SubOpBoolean) =
-  Subobject(codom(hom(A)),unique([a.val for a in [collect(hom(A))...,collect(hom(B))...]]))
-top(X::VarSet, ::SubOpBoolean) = Subobject(codom(hom(X)),1:length(X))
-bottom(X::VarSet, ::SubOpBoolean) = Subobject(codom(hom(X)),1:0)
 
 end

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -812,26 +812,38 @@ clim = colimit(Span(f,g));
 @test collect(legs(clim)[1][:Weight]) == [true,AttrVar(1)]
 
 # Subobjects with variables 
-
+#--------------------------
 X = @acset SetAttr{Bool} begin X=2;D=1;f=[true, AttrVar(1)] end
 A = Subobject(X, X=[1])
 B = Subobject(X, X=[2], D=[1])
 @test A ∧ B |> force == ⊥(X) |> force
 @test A ∨ B |> force == ⊤(X) |> force
 
-# Lattice of sub-C-sets.
-X = @acset VELabeledGraph{Symbol} begin V=6; E=5; Label=5
+const VES = VELabeledGraph{Symbol}
+X = @acset VES begin V=6; E=5; Label=5
   src=[1,2,3,4,4]; tgt=[3,3,4,5,6];
   vlabel=[:a,:b,:c,:d,:e,:f]; elabel=AttrVar.(1:5)
 end
 A, B = Subobject(X, V=1:4, E=1:3, Label=1:3), Subobject(X, V=3:6, E=3:5, Label=3:5)
 @test A ∧ B |> force == Subobject(X, V=3:4, E=3:3, Label=3:3) |> force
-expected = @acset VELabeledGraph{Symbol} begin V=2; E=1; Label=1;
+expected = @acset VES begin V=2; E=1; Label=1;
   src=1; tgt=2; vlabel=[:c,:d]; elabel=[AttrVar(1)]
 end
 @test is_isomorphic(dom(hom(A ∧ B )), expected)
 @test A ∨ B |> force == Subobject(X, V=1:6, E=1:5, Label=1:5) |> force
 @test ⊤(X) |> force == A ∨ B |> force
 @test ⊥(X) |> force == Subobject(X, V=1:0, E=1:0, Label=1:0) |> force
+@test force(implies(A, B)) == force(¬(A) ∨ B)
+@test ¬(A ∧ B) == ¬(A) ∨ ¬(B)
+@test ¬(A ∧ B) != ¬(A) ∨ B
+@test (A ∧ implies(A,B)) == B ∧ (A ∧ implies(A,B))
+@test (B ∧ implies(B,A)) == A ∧ (B ∧ implies(B,A))
+@test ¬(A ∨ (¬B)) == ¬(A) ∧ ¬(¬(B))
+@test ¬(A ∨ (¬B)) == ¬(A) ∧ B
+@test A ∧ ¬(¬(A)) == ¬(¬(A))
+@test implies((A∧B), A) == A∨B
+@test dom(hom(subtract(A,B))) == @acset VES begin V=3; E=2; Label=2
+  src=[1,2]; tgt=3; vlabel=[:a,:b,:c]; elabel=AttrVar.(1:2)
+end
 
 end


### PR DESCRIPTION
This PR extends https://github.com/AlgebraicJulia/Catlab.jl/pull/808 to support negation / subtraction / implication for VarACSets.

Because monic VarFunctions are representable by FinFunctions, a lot of redundant code was eliminated by just treating the components of the AttrType parts the same as the Ob parts - the only care that's needed is to map over the components with `AttrVar` when constructing the ACSetTransformation components (and undoing this when going in the reverse direction).