### PR TITLE
Category of elements for general C-sets

### DIFF
--- a/src/categorical_algebra/CatElements.jl
+++ b/src/categorical_algebra/CatElements.jl
@@ -32,7 +32,8 @@ This transformation converts an instance of C into a Graph homomorphism. The cod
 homomorphism is a graph shaped like the schema. This is one half of the isomorphism between
 databases and knowledge graphs.
 """
-function elements(X::StructACSet{S}) where S
+function elements(X::ACSet)
+  S = acset_schema(X)
   Y = Elements{Symbol}()
 
   obs = ob(S)
@@ -80,7 +81,7 @@ the ACSet type that it's going to try to create
 If the typed graph tries to assert conflicting values for a foreign key, fail.
 If no value is specified for a foreign key, the result will have 0's.
 """
-function inverse_elements(X::AbstractElements, typ::StructACSet)
+function inverse_elements(X::AbstractElements, typ::ACSet)
   res = typeof(typ)()
   o_ids = ob_ids(X)
   for (o, is) in pairs(o_ids)
@@ -110,7 +111,7 @@ end
 
 Compute inverse grothendieck transformation on a morphism of Elements
 """
-function inverse_elements(f::ACSetTransformation, typ::StructACSet)
+function inverse_elements(f::ACSetTransformation, typ::ACSet)
   iX, iY = [inverse_elements(x, typ) for x in [dom(f), codom(f)]]
   oX, oY = ob_ids.([dom(f), codom(f)])
   comps = map(dom(f)[:nameo]) do ob
@@ -155,4 +156,4 @@ function presentation(X::AbstractElements)
   add_generators!(P, values(homs))
   return P, obs, homs
 end
-end
+end # module

--- a/test/categorical_algebra/CatElements.jl
+++ b/test/categorical_algebra/CatElements.jl
@@ -6,7 +6,9 @@ arr = path_graph(Graph, 2)
 
 dyn_arr = DynamicACSet("Grph", SchGraph)
 add_part!(dyn_arr, :E, src=add_part!(dyn_arr,:V), tgt=add_part!(dyn_arr,:V))
+
 elarr = elements(arr)
+@test elarr == elements(dyn_arr)
 
 @testset "Arrow Elements" begin
   @test nparts(elarr, :El)  == 3

--- a/test/categorical_algebra/CatElements.jl
+++ b/test/categorical_algebra/CatElements.jl
@@ -2,12 +2,10 @@ module TestCatElements
 using Test
 using Catlab.GATs, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
 
-arr = @acset Graph begin
-  V = 2
-  E = 1
-  src=[1]
-  tgt=[2]
-end
+arr = path_graph(Graph, 2)
+
+dyn_arr = DynamicACSet("Grph", SchGraph)
+add_part!(dyn_arr, :E, src=add_part!(dyn_arr,:V), tgt=add_part!(dyn_arr,:V))
 elarr = elements(arr)
 
 @testset "Arrow Elements" begin
@@ -26,12 +24,7 @@ elarr = elements(arr)
   @test inverse_elements(elarr, Graph()) == arr
 end
 
-b = @acset Graph begin
-  V = 2
-  E = 1
-  src = [1]
-  tgt = [2]
-end
+b = path_graph(Graph, 2)
 elb = elements(b)
 ThBPG, obmap, hommap = CatElements.presentation(elb)
 @test Symbol.(generators(ThBPG)) == [:V_1, :V_2, :E_1, :src_E_1, :tgt_E_1]
@@ -114,4 +107,5 @@ end
     @test inverse_elements(elements(h), sir_eltsch) == h
   end
 end
+
 end # module


### PR DESCRIPTION
There was an unnecessarily strict typing on the the argument to `elements` which required it to be a `StructACSet` - this PR relaxes that constraint.