### PR TITLE
Support for mark-as-deleted in acsets

### DIFF
--- a/src/categorical_algebra/ACSetsGATsInterop.jl
+++ b/src/categorical_algebra/ACSetsGATsInterop.jl
@@ -66,8 +66,9 @@ function Presentation(s::BasicSchema{Symbol})
 end
 
 function DenseACSets.struct_acset(name::Symbol, parent, p::Presentation;
-                                  index::Vector=[], unique_index::Vector=[])
-  DenseACSets.struct_acset(name, parent, Schema(p); index, unique_index)
+                                  index::Vector=[], unique_index::Vector=[], 
+                                  part_type::Type{<:PartsType}=IntParts)
+  DenseACSets.struct_acset(name, parent, Schema(p); index, unique_index, part_type)
 end
 
 function DenseACSets.DynamicACSet(

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -610,21 +610,16 @@ Xₕ ↓  ✓  ↓ Yₕ
 
 You're allowed to run this on a named tuple partly specifying an ACSetTransformation,
 though at this time the domain and codomain must be fully specified ACSets.
-
-`only_combinatorial=true` means to only test naturality in combinatorial data
 """
-function is_natural(α::LooseACSetTransformation; only_combinatorial=false) 
-  is_natural(dom(α),codom(α),α.components,type_components(α); only_combinatorial)
+function is_natural(α::LooseACSetTransformation) 
+  is_natural(dom(α), codom(α), α.components, type_components(α))
 end
-function is_natural(α::ACSetTransformation; only_combinatorial=false)
-  is_natural(dom(α),codom(α),α.components; only_combinatorial)
-end
-function is_natural(α::CSetTransformation; only_combinatorial=true)
-  is_natural(dom(α),codom(α),α.components; only_combinatorial)
+function is_natural(α::ACSetMorphism)
+  is_natural(dom(α), codom(α), α.components)
 end
 
-is_natural(dom,codom,comps...; only_combinatorial=false) =
-  all(isempty, last.(collect(naturality_failures(dom, codom, comps...; only_combinatorial))))
+is_natural(dom, codom, comps...) =
+  all(isempty, last.(collect(naturality_failures(dom, codom, comps...))))
 
 """
 Returns a dictionary whose keys are contained in the names in `arrows(S)`
@@ -633,18 +628,15 @@ over the elements of X(c) on which α's naturality square
 for f does not commute. Components should be a NamedTuple or Dictionary
 with keys contained in the names of S's morphisms and values vectors or dicts
 defining partial functions from X(c) to Y(c).
-
-`only_combinatorial=true` means to only look for naturality failures in 
-combinatorial data.
 """
-function naturality_failures(X,Y,comps; only_combinatorial=false)
+function naturality_failures(X, Y, comps)
   type_comps = Dict(attr => SetFunction(identity, SetOb(X,attr), SetOb(X,attr)) 
                     for attr in attrtype(acset_schema(X)))
-  naturality_failures(X, Y, comps, type_comps; only_combinatorial)
+  naturality_failures(X, Y, comps, type_comps)
 end
-function naturality_failures(X, Y, comps, type_comps; only_combinatorial=false)
+function naturality_failures(X, Y, comps, type_comps)
   S = acset_schema(X)
-  Fun = Union{SetFunction,VarFunction,LooseVarFunction}
+  Fun = Union{SetFunction, VarFunction, LooseVarFunction}
   comps = Dict(a => isa(comps[a],Fun) ? comps[a] : FinDomFunction(comps[a])  
                for a in keys(comps))
   type_comps = Dict(a => isa(type_comps[a], Fun) ? type_comps[a] : 

--- a/src/categorical_algebra/HomSearch.jl
+++ b/src/categorical_algebra/HomSearch.jl
@@ -239,13 +239,13 @@ function backtracking_search(f, X::ACSet, Y::ACSet;
 
   # Initialize state variables for search.
   assignment = merge(
-    NamedTuple{Ob}(zeros(Int, nparts(X, c)) for c in Ob),
+    NamedTuple{Ob}(zeros(Int, maxpart(X, c)) for c in Ob),
     NamedTuple{Attr}(Pair{Int,Union{AttrVar,attrtype_type(X,c)}}[
-      0 => AttrVar(0) for _ in parts(X,c)] for c in Attr)
+      0 => AttrVar(0) for _ in 1:maxpart(X,c)] for c in Attr)
   )
   assignment_depth = map(copy, assignment)
   inv_assignment = NamedTuple{ObAttr}(
-    (c in monic ? zeros(Int, nparts(Y, c)) : nothing) for c in ObAttr)
+    (c in monic ? zeros(Int, maxpart(Y, c)) : nothing) for c in ObAttr)
   loosefuns = NamedTuple{Attr}(
     isnothing(type_components) ? identity : get(type_components, c, identity) for c in Attr)
   state = BacktrackingState(assignment, assignment_depth, 
@@ -305,8 +305,8 @@ function find_mrv_elem(state::BacktrackingState, depth)
   S = acset_schema(state.dom)
   mrv, mrv_elem = Inf, nothing
   Y = state.codom
-  for c in ob(S), (x, y) in enumerate(state.assignment[c])
-    y == 0 || continue
+  for c in ob(S), x in parts(state.dom, c)
+    state.assignment[c][x] == 0 || continue
     n = count(can_assign_elem(state, depth, c, x, y) for y in parts(Y, c))
     if n < mrv
       mrv, mrv_elem = n, (c, x)

--- a/src/categorical_algebra/HomSearch.jl
+++ b/src/categorical_algebra/HomSearch.jl
@@ -234,7 +234,7 @@ function backtracking_search(f, X::ACSet, Y::ACSet;
   end
 
   pred_nt = NamedTuple{Ob}(let dic = get(predicates, c, Dict()); 
-    Union{Set{Int}, Nothing}[haskey(dic, p) ? Set(dic[p]) : nothing for p in parts(X,c)] 
+    Union{Set{Int}, Nothing}[haskey(dic, p) ? Set(dic[p]) : nothing for p in 1:maxpart(X,c)] 
   end for c in Ob)
 
   # Initialize state variables for search.

--- a/test/categorical_algebra/HomSearch.jl
+++ b/test/categorical_algebra/HomSearch.jl
@@ -241,4 +241,16 @@ results = first(is_iso1) ? results : reverse(results)
 exp = @acset WG begin V=3; E=1; src=1; tgt=2; weight=[false] end
 @test first(first(maximum_common_subobject(g1, g2; abstract=false))) == exp
 
+# Mark as deleted
+#################
+@acset_type AbsMADGraph(SchWeightedGraph, part_type=BitSetParts) <: AbstractGraph
+const MADGraph = AbsMADGraph{Symbol}
+
+v1, v2 = MADGraph.(1:2)
+@test !is_isomorphic(v1,v2)
+rem_part!(v2, :V, 1)
+@test is_isomorphic(v1,v2)
+@test is_isomorphic(v2,v1)
+
+
 end # module


### PR DESCRIPTION
This branch incorporates [mark as deleted](https://github.com/AlgebraicJulia/ACSets.jl/pull/32) into Catlab. As was the case with VarACSets, the priority is getting support for hom search. Colimits would be the next natural thing to do. In the course of working on this, the problem of Catlab having it's own version of everything in ACSets (FinFunction machinery vs column + index machinery) was very painful. 

There could be no difference in the data structure for a morphism between MaD ACSets if we just treat the data in position `i` of a FinFunction (when `i` has been deleted in the domain) as to-be-ignored.  

Constructing the ACSetTransformation data structure (e.g. as the result of a hom search) posed a challenge, as the data gets validated in many ways which do not work when parts have been deleted. 

There are many challenges in making colimits work. However, since AlgebraicRewriting has support for in-place colimits (for MaD ACSets), there is no need to integrate with the normal colimit infrastructure just yet. 