### PR TITLE
Forward compatibility for mark-as-deleted acsets

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -1009,7 +1009,7 @@ be mutated even when the assignment fails.
 """
 assign_elem!(state::BacktrackingState{<:StructACSet{S}}, depth, c, x, y) where S = 
   _assign_elem!(Val{S}, state, depth,Val{c},x,y)
-assign_elem!(state::BacktrackingState{DynamicACSet}, depth, c, x, y) = 
+assign_elem!(state::BacktrackingState{<:DynamicACSet}, depth, c, x, y) =
   runtime(_assign_elem!,acset_schema(state.dom), state, depth,c,x,y)
 
 
@@ -1062,7 +1062,7 @@ end
 """
 unassign_elem!(state::BacktrackingState{<:StructACSet{S}}, depth, c, x) where S = 
   _unassign_elem!(Val{S}, state, depth,Val{c},x)
-unassign_elem!(state::BacktrackingState{DynamicACSet}, depth, c, x) = 
+unassign_elem!(state::BacktrackingState{<:DynamicACSet}, depth, c, x) =
   runtime(_unassign_elem!,acset_schema(state.dom), state, depth,c,x)
 
 @ct_enable function _unassign_elem!(@ct(S), state::BacktrackingState, depth, @ct(c), x) 
@@ -1214,7 +1214,6 @@ function colimit(::Type{<:Tuple{ACS,TightACSetTransformation}}, diagram) where {
   Xs = cocone_objects(diagram)
   colimit_attrs!(pack_colimit(ACS, S, diagram, Xs, colimits), S, Ts, Xs)
 end
-
 
 function colimit(::Type{<:Tuple{DynamicACSet,TightACSetTransformation}}, diagram) 
   Xs = cocone_objects(diagram)

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -679,15 +679,20 @@ g1 = @acset WeightedGraph{Bool} begin
 end
 g2 = @acset WeightedGraph{Bool} begin 
   V=3; E=3; src=[1,2,3]; tgt=[2,3,3]; weight=[true,false,false] 
-end 
-(apx1,((L1,R1),)), (apx2,((L2,R2),)) = collect(maximum_common_subobject(g1, g2))
+end
 apex1 = @acset WeightedGraph{Bool} begin
   V=3; E=2; Weight=2; src=[1,2]; tgt=[2,3]; weight=AttrVar.(1:2)
 end
 apex2 = @acset WeightedGraph{Bool} begin 
   V=3; E=2; Weight=2; src=[1,3]; tgt=[2,3]; weight=AttrVar.(1:2)
 end
-@test is_isomorphic(apx1, apex1)
+
+results = collect(maximum_common_subobject(g1, g2))
+@test length(results) == 2
+is_iso1 = map(result -> is_isomorphic(first(result), apex1), results)
+@test sum(is_iso1) == 1
+results = first(is_iso1) ? results : reverse(results)
+(apx1,((L1,R1),)), (apx2,((L2,R2),)) = results
 @test collect(L1[:V]) == [1,2,3]
 @test collect(R1[:V]) == [1,2,3]
 @test L1(apx1) == Subobject(g1, V=[1,2,3], E=[2,3])


### PR DESCRIPTION
This branch has been tested with https://github.com/AlgebraicJulia/ACSets.jl/pull/32.