### PR TITLE
Fix `abstract_attributes` function

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -1619,20 +1619,21 @@ subparts.
 """
 function abstract_attributes(X::ACSet)
   S = acset_schema(X)
-  A = copy(X); 
-  comps = Dict{Any,Any}(map(attrtypes(S)) do at
-    rem_parts!(A, at, parts(A,at))
-    comp = Union{AttrVar,attrtype_type(X,at)}[]
+  A = deepcopy(X);
+  comps = Dict{Any, Any}(map(attrtypes(S)) do at
+    rem_parts!(A, at, parts(A, at))
+    comp = Union{AttrVar,attrtype_type(X, at)}[]
     for (f, d, _) in attrs(S; to=at)
-      append!(comp, A[f])
-      A[f] = AttrVar.(add_parts!(A, at, nparts(A,d)))
-    end 
+      append!(comp, X[f])
+      A[f] = AttrVar.(add_parts!(A, at, nparts(A, d)))
+    end
     at => comp
   end)
-  for o in ob(S) comps[o]=parts(X,o) end
-  res = ACSetTransformation(A,X; comps...)
-  return res
-end 
+  for o in ob(S)
+    comps[o] = parts(X, o)
+  end
+  ACSetTransformation(A,X; comps...)
+end
 
 # Maximum Common C-Set
 ######################

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -10,7 +10,8 @@ export ACSetTransformation, CSetTransformation, StructACSetTransformation,
   homomorphism, homomorphisms, is_homomorphic,
   isomorphism, isomorphisms, is_isomorphic,
   @acset_transformation, @acset_transformations,
-  subobject_graph, partial_overlaps, maximum_common_subobject
+  subobject_graph, partial_overlaps, maximum_common_subobject,
+  abstract_attributes
 
 using Base.Iterators: flatten
 using Base.Meta: quot
@@ -1619,10 +1620,10 @@ subparts.
 """
 function abstract_attributes(X::ACSet)
   S = acset_schema(X)
-  A = deepcopy(X);
+  A = copy(X)
   comps = Dict{Any, Any}(map(attrtypes(S)) do at
     rem_parts!(A, at, parts(A, at))
-    comp = Union{AttrVar,attrtype_type(X, at)}[]
+    comp = Union{AttrVar, attrtype_type(X, at)}[]
     for (f, d, _) in attrs(S; to=at)
       append!(comp, X[f])
       A[f] = AttrVar.(add_parts!(A, at, nparts(A, d)))
@@ -1632,7 +1633,7 @@ function abstract_attributes(X::ACSet)
   for o in ob(S)
     comps[o] = parts(X, o)
   end
-  ACSetTransformation(A,X; comps...)
+  ACSetTransformation(A, X; comps...)
 end
 
 # Maximum Common C-Set

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -822,6 +822,16 @@ clim = colimit(Span(f,g));
 @test apex(clim)[:weight] == [true,true,AttrVar(2),true]
 @test collect(legs(clim)[1][:Weight]) == [true,AttrVar(1)]
 
+# Abstracting
+using Catlab.CategoricalAlgebra.CSets: abstract_attributes
+X = @acset WG{Bool} begin 
+  V=1; E=2; Weight=1; src=1; tgt=1; weight=[AttrVar(1), true]
+end
+h = abstract_attributes(X)
+@test nparts(dom(h), :Weight) == 2
+@test codom(h) == X
+@test is_natural(h)
+
 # Subobjects with variables 
 #--------------------------
 X = @acset SetAttr{Bool} begin X=2;D=1;f=[true, AttrVar(1)] end

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -823,7 +823,6 @@ clim = colimit(Span(f,g));
 @test collect(legs(clim)[1][:Weight]) == [true,AttrVar(1)]
 
 # Abstracting
-using Catlab.CategoricalAlgebra.CSets: abstract_attributes
 X = @acset WG{Bool} begin 
   V=1; E=2; Weight=1; src=1; tgt=1; weight=[AttrVar(1), true]
 end
@@ -831,6 +830,10 @@ h = abstract_attributes(X)
 @test nparts(dom(h), :Weight) == 2
 @test codom(h) == X
 @test is_natural(h)
+
+# Mutation of codom of A->X should not modify domain
+rem_part!(X, :E, 2)
+@test nparts(dom(h), :E) == 2
 
 # Subobjects with variables 
 #--------------------------


### PR DESCRIPTION
`abstract_attributes` is currently an unexported function. It takes an acset `X` and makes a map `A -> X` where `A` is 'all variables'. This is useful in AlgebraicRewriting. It might be more generally useful such that it should be an exported function. 

Regardless, the implementation in Catlab was broken and this PR fixes it and adds a test.