### PR TITLE
Infer LooseACSetTransformation when a Julia function is passed as a component

### DIFF
--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -310,6 +310,7 @@ uns = naturality_failures(β)
 
 # Loose morphisms.
 α = LooseACSetTransformation((V=[1,2], E=[1]), (Weight=x->x/2,), g, h)
+α = ACSetTransformation(g, h, V=[1,2], E=[1], Weight=x->x/2,)
 @test α isa LooseACSetTransformation
 @test type_components(α)[:Weight](10.0) == 5.0
 @test is_natural(α)

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -309,8 +309,10 @@ uns = naturality_failures(β)
   collect(uns[:weight]) == [(1,1.0,2.0)]
 
 # Loose morphisms.
-α = LooseACSetTransformation((V=[1,2], E=[1]), (Weight=x->x/2,), g, h)
-α = ACSetTransformation(g, h, V=[1,2], E=[1], Weight=x->x/2,)
+half = x->x/2
+α = LooseACSetTransformation((V=[1,2], E=[1]), (Weight=half,), g, h)
+α′ = ACSetTransformation(g, h, V=[1,2], E=[1], Weight=half,)
+@test α == α′
 @test α isa LooseACSetTransformation
 @test type_components(α)[:Weight](10.0) == 5.0
 @test is_natural(α)


### PR DESCRIPTION
`ACSetTransformation(args...)` will try to deduce from the arguments whether it is a `Tight` or `Loose` transformation. It's a safe assumption that a Julia function for an attrtype means one wants a LooseACSetTransformation. This recovers pre-VarACSets behavior. Addresses https://github.com/AlgebraicJulia/Catlab.jl/issues/838 