### PR TITLE
Add Sheaf implementation 

### DIFF
--- a/docs/literate/sketches/sheaves.jl
+++ b/docs/literate/sketches/sheaves.jl
@@ -1,0 +1,111 @@
+# # Basic Sheaf Constructions
+# This example shows how to use a sheaf Catlab.
+# We use the DiagramTopology on FinSet and the Free Vector Space functor
+# to illustrate this process.
+
+using Test
+using Catlab.CategoricalAlgebra
+using Catlab.CategoricalAlgebra.Categories
+using Catlab.Sheaves
+import Catlab.CategoricalAlgebra.Categories: do_ob_map, do_hom_map
+using Catlab.CategoricalAlgebra.Matrices: MatrixDom
+import Catlab.Sheaves: pullback_matrix, FinSetCat
+
+# The Topology that we are using is the `DiagramTopology`, which says that a cover of an object `c` is any diagram with `c` as its colimit.
+# The cocone of the diagram gives you a basis for the sieve that covers `c`.
+# The legs of the cocone can be interpreted as open subsets of `c` whose union is `c`.
+# Because colimits are functorial and the base category is adhesive, the diagram topology is well defined.
+#
+# We have two different implementations of equivalent sheaves.
+# The `VectSheaf` implementation uses julia functions and the `VectSheafMat` implementation uses sparse matrices.
+
+VectSheaf = Sheaf(DiagramTopology(), FVectPullback())
+VectSheafMat = Sheaf(DiagramTopology(), FMatPullback())
+
+# We want to introduce a cover of the set ${1...4}$ with two open sets ${1,2,3}$ and ${1,2,4}$.
+# To do that, we will construct a pushout.
+f = FinFunction([1,2], 3)
+g = FinFunction([1,2], 3)
+S = ColimCover(pushout(f,g))
+
+# The main API of a sheaf is that you can:
+# 1. restrict sections along a morphism,
+# 1. check if a collection of local sections match on the overlaps,
+# 1. and extend a collection of local sections if they match.
+
+# We can restrict a global section along the first leg
+v = [1,2,3,4]
+v₁ = restrict(VectSheaf, v, legs(S)[1])
+
+# Or the second leg.
+v₂ = restrict(VectSheaf, v, legs(S)[2])
+
+# Notice that we got two different values, but that the first two entries of those restricted vectors agree.
+# That is because our two legs have an overlap in the first two dimensions.
+# If we restrict again by the arrows in our diagram (f,g) we should get the same answer.
+
+restrict(VectSheaf, v₁, f)  == restrict(VectSheaf, v₂, g)
+
+# A sheaf requires:
+# - a notion of dividing up a space into pieces (the open coverage),
+# - a way of measuring data over the pieces (the set of sections given by the functor on objects), along with
+# - ways of relating measurements on a piece to measurements on a subpiece (the restriction maps given by the functor).
+# Functoriality of the the sheaf tells you that restricting the same data
+# along commuting paths will always give you the same data on the common piece.
+
+# The sheaf condition requires that you can compute an extension of local data to global data.
+# There is no way to derive this operation from the contravariant functor of the sheaf
+# so providing it is part of the API in defining a new sheaf.
+extend(VectSheaf, S, [[1.0, 2,3], [1,2.0,6]])
+
+# If the local sections don't match, then extending will fail.
+@test_throws MatchingError extend(VectSheaf, S, [[1.0, 2,3], [1,3.0,6]])
+# extend(VectSheaf, S, [[1.0, 2,3], [1,3.0,6]])
+
+# Pushouts are the covers with only two subobjects, but the sheaf works on diagrams of any size.
+
+D = FreeDiagram(FinSet.([3,2,3,3]), # list of objects
+ [ # list of (hom, src, tgt) tuples
+  (FinFunction([1,2], 3), 2,1),
+  (FinFunction([1,2], 3), 2,3),
+  (FinFunction([1,2], 3), 2,4)
+  ]
+)
+
+K = ColimCover(D)
+
+section_data = [Float64[1,2,3],
+   Float64[1,2],
+   Float64[1,2,5],
+   Float64[1,2,6]]
+
+v = extend(VectSheaf, K, section_data; debug=true)
+
+# Our two sheaves should agree, because they are just two different implementations of the same sheaf.
+
+global_section = extend(VectSheafMat, K, section_data)
+v == global_section
+
+# If you put in bad data, you get MatchingErrors
+section_data_bad = [Float64[1,2,3],
+   Float64[1,2],
+   Float64[1,3,5],
+   Float64[1,3,6]]
+
+@test_throws MatchingError extend(VectSheaf, K, section_data_bad)
+@test_throws MatchingError extend(VectSheafMat, K, section_data_bad)
+
+# if we disable the checks, VectSheafMat will solve a least squares problem instead of last write wins.
+extend(VectSheafMat, K, section_data_bad, check=false)
+
+# Last write wins definition is different.
+extend(VectSheaf, K, section_data_bad, check=false) 
+
+# You can diagnose a matching error from the exception that extend throws.
+try
+  extend(VectSheaf, K, section_data_bad)
+catch e
+  e
+end
+
+# This concludes our discussion of the sheaf API.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -55,6 +55,7 @@ makedocs(
         "generated/sketches/meets.md",
         "generated/sketches/smc.md",
         "generated/sketches/cat_elements.md",
+        "generated/sketches/sheaves.md",
         ],
       "Graphs" => Any[
         "generated/graphs/graphs.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -84,6 +84,7 @@ makedocs(
       "apis/wiring_diagrams.md",
       "apis/graphics.md",
       "apis/programs.md",
+      "apis/sheaves.md",
     ],
     "Developer Docs" => Any[
       "devdocs/style.md",

--- a/docs/src/apis/sheaves.md
+++ b/docs/src/apis/sheaves.md
@@ -1,0 +1,11 @@
+# [Sheaves](@id sheaves)
+
+Sheaves are useful for modeling spatial data. The classic example is continuous functions over a topological space. If you have a function defined at every point in a topological space, then you can think about covers of your space and how that function restricts to subspaces of their domain. When you have locally defined functions that agree on overlapping domains, you can extend them to one function defined on the union of their domains.
+
+Sheaves are a generalization of this idea. The motivating example of sheaves of vectors is implemented and described in the vignettes.
+
+```@autodocs
+Modules = [
+  Sheaves
+  ]
+```

--- a/src/Catlab.jl
+++ b/src/Catlab.jl
@@ -10,6 +10,7 @@ include("categorical_algebra/CategoricalAlgebra.jl")
 include("wiring_diagrams/WiringDiagrams.jl")
 include("graphics/Graphics.jl")
 include("programs/Programs.jl")
+include("sheaves/Sheaves.jl")
 
 @reexport using .GATs
 @reexport using .Theories
@@ -18,5 +19,6 @@ include("programs/Programs.jl")
 @reexport using .WiringDiagrams
 @reexport using .Graphics
 @reexport using .Programs
+@reexport using .Sheaves
 
 end

--- a/src/sheaves/FVect.jl
+++ b/src/sheaves/FVect.jl
@@ -1,0 +1,90 @@
+struct FinVect <: Category{FinSet, Function, SmallCatSize} end
+
+"""    FVectPullback{T} where T <: Number
+
+The contravariant free vector space functor. 
+The returned function f✶ restricts via precomposition.
+"""
+struct FVectPullback <: Functor{FinSetOpT, FinVect} end
+dom(::FVectPullback) = FinSetOpT
+codom(::FVectPullback) = FinVect
+do_ob_map(::FVectPullback, n::FinSet) = n
+do_hom_map(::FVectPullback, f::FinFunction) = (v->v[f.(dom(f))])
+# as a callable functor this would be: FVectPullback = Functor(identity, f->(v->v[f.(dom(f))]), OppositeCat(FinSetCat()), FinVect())
+
+"""    FreeVect{T} where T <: Number
+
+The covariant free vector space functor. 
+The returned  function f✶ sums over preimages.
+"""
+FVectPushforward = Functor(identity, # identity on objects
+  # specify the pushforward construction
+  f->(v->map(dom(f)) do i
+    sum(v[j] for j in preimage(f,i))
+  end),
+  # covariant functor from FinSetCat to FinVect
+  FinSetCat(), FinVect()
+)
+
+const FinMat = TypeCat(MatrixDom, Matrix)
+const FinMatT = typeof(FinMat)
+
+# call a matrix on a vector multiplies by it.
+function (M::SparseArrays.SparseMatrixCSC{Int64, Int64})(x::AbstractVector)
+  M*x
+end
+
+function pullback_matrix(f::FinFunction)
+    n = length(dom(f))
+    sparse(1:n, f.(dom(f)), ones(Int,n), dom(f).n, codom(f).n)
+end
+
+function pushforward_matrix(f::FinFunction)
+  pullback_matrix(f)'
+end
+
+struct FMatPullback <: Functor{FinSetOpT, FinMatT} end
+dom(::FMatPullback) = FinSetOpT
+codom(::FMatPullback) = FinMat
+do_ob_map(::FMatPullback, n::FinSet) = MatrixDom{AbstractMatrix}(n.n)
+do_hom_map(::FMatPullback, f::FinFunction) = pullback_matrix(f)
+
+FMatPushforward = Functor(n->MatrixDom(n.n),
+  pushforward_matrix,
+  FinSetCat(), FinVect()
+)
+
+"""    extend(X::Sheaf{T, FVectPullback}, cover::ColimCover, sections::Vector{Vector{R}}; check=true, debug=false) where {T<:DiagramTopology, R}
+
+This method implements the extension operation for the diagram topology on FinSet for the Free Vector Space functor.
+The implementation does copies the value of the ith section into the jth spot as indicated by the legs of the cocone.
+"""
+function extend(X::Sheaf{T, FVectPullback}, cover::ColimCover, sections::Vector{Vector{R}}; check=true, debug=false) where {T<:DiagramTopology, R}
+  length(sections) == length(legs(cover)) || throw(ArgumentError("There are $(length(sections)) but only $(length(legs(cover))) legs in the cover"))
+  v = zeros(R, apex(cover))
+  if check
+    match_errors = diagnose_match(X, cover, sections; debug=debug)
+    length(match_errors) == 0 || throw(MatchingError(match_errors))
+  end
+  for (i, l) in enumerate(legs(cover))
+    for j in dom(l)
+      # copy the value of the ith section into the jth spot
+      # last write wins is fine,
+      # because the sections have to agree on the overlapping indices
+      v[l(j)] = sections[i][j]
+    end
+  end
+  return v
+end
+
+function extend(X::Sheaf{T, FMatPullback}, cover::ColimCover, sections::Vector{Vector{R}};check=true, debug=false) where {T<:DiagramTopology, R}
+  length(sections) == length(legs(cover)) || throw(ArgumentError("There are $(length(sections)) but only $(length(legs(cover))) legs in the cover"))
+  v = zeros(R, apex(cover))
+  if check
+    match_errors = diagnose_match(X, cover, sections; debug=debug)
+    length(match_errors) == 0 || throw(MatchingError(match_errors))
+  end
+  f = copair(legs(cover))
+  M = do_hom_map(functor(X), f)
+  return Float64.(M) \ direct_sum(sections)
+end

--- a/src/sheaves/Sheaves.jl
+++ b/src/sheaves/Sheaves.jl
@@ -1,0 +1,323 @@
+module Sheaves
+using LinearAlgebra
+using SparseArrays
+using ...CategoricalAlgebra
+using ...CategoricalAlgebra.Categories
+using ...CategoricalAlgebra.FinSets
+using ...CategoricalAlgebra.Matrices
+using ...GATs
+using ...Theories
+import ..CategoricalAlgebra.Categories: CatSize
+import ...Theories: dom, codom, id, ob, hom
+import ...CategoricalAlgebra: legs, apex
+import ...CategoricalAlgebra.Categories: do_ob_map, do_hom_map
+
+export AbstractSheaf, AbstractFunctor, AbstractCover, AbstractCoverage,
+  FinSetCat, FinVect, FinSetOp, FinSetOpT,
+  FVectPullback, FVectPushforward,
+  FMatPullback, FMatPushforward,
+  ColimCover, DiagramTopology, is_coverage,
+  Sheaf, diagnose_match, extend, restrict, MatchingError, MatchingFailure
+
+
+abstract type SmallCatSize <: CatSize end
+Base.zeros(T, n::FinSet) = zeros(T, length(n))
+direct_sum(vs) = reduce(vcat, vs)
+
+abstract type AbstractSheaf end
+abstract type AbstractFunctor end
+abstract type AbstractCover end
+abstract type AbstractCoverage end
+
+struct FinSetCat <: Category{FinSet, FinFunction, SmallCatSize} end
+struct FinVect <: Category{FinSet, Function, SmallCatSize} end
+
+const FinSetOp = op(FinSetCat())
+const FinSetOpT = typeof(FinSetOp)
+
+"""    FVectPullback{T} where T <: Number
+
+The contravariant free vector space functor. 
+The returned function f✶ restricts via precomposition.
+"""
+struct FVectPullback <: Functor{FinSetOpT, FinVect} end
+dom(::FVectPullback) = FinSetOpT
+codom(::FVectPullback) = FinVect
+do_ob_map(::FVectPullback, n::FinSet) = n
+do_hom_map(::FVectPullback, f::FinFunction) = (v->v[f.(dom(f))])
+# as a callable functor this would be: FVectPullback = Functor(identity, f->(v->v[f.(dom(f))]), OppositeCat(FinSetCat()), FinVect())
+
+"""    FreeVect{T} where T <: Number
+
+The covariant free vector space functor. 
+The returned  function f✶ sums over preimages.
+"""
+FVectPushforward = Functor(identity, # identity on objects
+  # specify the pushforward construction
+  f->(v->map(dom(f)) do i
+    sum(v[j] for j in preimage(f,i))
+  end),
+  # covariant functor from FinSetCat to FinVect
+  FinSetCat(), FinVect()
+)
+
+const FinMat = TypeCat(MatrixDom, Matrix)
+const FinMatT = typeof(FinMat)
+
+# call a matrix on a vector multiplies by it.
+function (M::SparseArrays.SparseMatrixCSC{Int64, Int64})(x::AbstractVector)
+  M*x
+end
+
+function pullback_matrix(f::FinFunction)
+    n = length(dom(f))
+    sparse(1:n, f.(dom(f)), ones(Int,n), dom(f).n, codom(f).n)
+end
+
+function pushforward_matrix(f::FinFunction)
+  pullback_matrix(f)'
+end
+
+struct FMatPullback <: Functor{FinSetOpT, FinMatT} end
+dom(::FMatPullback) = FinSetOpT
+codom(::FMatPullback) = FinMat
+do_ob_map(::FMatPullback, n::FinSet) = MatrixDom{AbstractMatrix}(n.n)
+do_hom_map(::FMatPullback, f::FinFunction) = pullback_matrix(f)
+
+FMatPushforward = Functor(n->MatrixDom(n.n),
+  pushforward_matrix,
+  FinSetCat(), FinVect()
+)
+
+struct Sieve{T} <: AbstractCover
+  basis::T
+end
+
+Base.show(io::IO, S::AbstractCover) = begin
+  print(io, "$(typeof(S))($(apex(S))):")
+  for l in legs(S)
+    print(io, "\n  ")
+    show(io, l)
+  end
+end
+
+legs(s::Sieve) = legs(s.basis)
+apex(s::Sieve) = apex(s.basis)
+
+struct ColimCover <: AbstractCover
+  colimit
+end
+
+ColimCover(d::FreeDiagram) = ColimCover(colimit(d))
+
+legs(s::ColimCover) = legs(s.colimit)
+apex(s::ColimCover) = apex(s.colimit)
+Base.enumerate(s::ColimCover) = enumerate(legs(s))
+
+struct DiagramTopology <: AbstractCoverage end
+
+function is_coverage(top::AbstractCoverage, S::AbstractCover, object) 
+  error("To implement a GTopology, you have to be able to check if a Sieve covers an object.")
+end
+
+function is_coverage(::DiagramTopology, S::ColimCover, object)
+  apex(S) == object
+end
+
+struct Sheaf{T<:AbstractCoverage,F<:Functor} <: AbstractSheaf
+  coverage::T
+  functor::F
+end
+
+coverage(s::Sheaf) = s.coverage
+functor(s::Sheaf) = s.functor
+
+abstract type AbstractSection end
+
+struct Section{S,D,V} <: AbstractSection
+  sheaf::S
+  domain::D
+  value::V
+end
+
+
+"""    restrict(X::AbstractSheaf, s::Section, f::Hom) where Hom
+
+If you supply a wrapped section, you should get a back a wrapped section.
+"""
+function restrict(X::AbstractSheaf, s::Section, f::Hom) where Hom
+  Section(X, domain(s), do_hom_map(functor(X), f)(value(s)))
+end
+
+"""    restrict(X::AbstractSheaf, s::Data, f::Hom) where {Data, Hom}
+
+Restrict a section along a morphism in the sheaf.
+This is to apply the sheaf's functor to the morphism f and then apply that function to the data supplied. 
+We can assume that you can directly call that applied functor on data, because sheaves take C to **Set**.
+"""
+function restrict(X::AbstractSheaf, s::Data, f::Hom) where {Data, Hom}
+  do_hom_map(functor(X), f)(s)
+end
+
+"""    extend(X::AbstractSheaf, cover::AbstractCover, sections::AbstractVector)
+
+Extend a collection of sections to the unique section that restricts to the sections provided.
+The `sections` vector needs to be indexed in the same order as `enumerate(cover)`.
+"""
+function extend(X::AbstractSheaf, cover::AbstractCover, sections::AbstractVector)
+  error("In order to define a sheaf, you must implement restrict and extend")
+end
+
+"""    MatchingFailure
+
+An type for when sections over a sheaf fail to match, that is when they don't agree on the overlaps implied by a cover.
+"""
+struct MatchingFailure
+  sheaf::AbstractSheaf
+  hom1
+  hom2
+  sec1
+  sec2
+  res1
+  res2
+end
+
+Base.show(io::IO, m::MatchingFailure) = println(io, "$(typeof(m).name.name): Sections don't match on:\n\t$(m.hom1) and\n\t$(m.hom2)\n\t$(m.res1) ◁ $(m.sec1) but\n\t$(m.res2) ◁ $(m.sec2)")
+
+"""    MatchingError
+
+An Exception type for when sections over a sheaf fail to match, that is when they don't agree on the overlaps implied by a cover.
+This stores the list MatchingFailures encountered when walking the cover.
+"""
+struct MatchingError{T} <: Exception where T<:MatchingFailure
+  failures::Vector{T}
+end
+
+function Base.show(io::IO, m::MatchingError)
+  println(io, "$(typeof(m).name.name): Sections don't match on $(length(m.failures)) overlaps:")
+  map(m.failures) do f
+    show(io, f)
+  end
+end
+
+
+"""    diagnose_match(X::Sheaf, cover, sections; debug=false)
+
+For each object X in the diagram, check that all the sections restrict to the same value along the Hom(X, -).
+
+The arguments haave the same interpretation as in `extend`.
+"""
+function diagnose_match(X::Sheaf, cover, sections; debug=false)
+  match_errors = MatchingFailure[]
+  for (i,l₁) in enumerate(cover)
+    for (j,l₂) in enumerate(cover)
+      # we only need to check the upper triangle. i < j.
+      if i >= j 
+        continue
+      end
+      P = pullback(l₁,l₂)
+      if debug
+        println("Computing intersection of opens $i,$j")
+        @show l₁
+        @show l₂
+        @show apex(P)
+      end
+      v₁ = restrict(X, sections[i], legs(P)[1])
+      v₂ = restrict(X, sections[j], legs(P)[2])
+      v₁ == v₂ || push!(match_errors, MatchingFailure(X, l₁, l₂, sections[i], sections[j], v₁, v₂))
+    end
+  end
+  return match_errors
+end
+
+"""    extend(X::Sheaf{T, FVectPullback}, cover::ColimCover, sections::Vector{Vector{R}}; check=true, debug=false) where {T<:DiagramTopology, R}
+
+This method implements the extension operation for the diagram topology on FinSet for the Free Vector Space functor.
+The implementation does copies the value of the ith section into the jth spot as indicated by the legs of the cocone.
+"""
+function extend(X::Sheaf{T, FVectPullback}, cover::ColimCover, sections::Vector{Vector{R}}; check=true, debug=false) where {T<:DiagramTopology, R}
+  length(sections) == length(legs(cover)) || throw(ArgumentError("There are $(length(sections)) but only $(length(legs(cover))) legs in the cover"))
+  v = zeros(R, apex(cover))
+  if check
+    match_errors = diagnose_match(X, cover, sections; debug=debug)
+    length(match_errors) == 0 || throw(MatchingError(match_errors))
+  end
+  for (i, l) in enumerate(legs(cover))
+    for j in dom(l)
+      # copy the value of the ith section into the jth spot
+      # last write wins is fine,
+      # because the sections have to agree on the overlapping indices
+      v[l(j)] = sections[i][j]
+    end
+  end
+  return v
+end
+
+function extend(X::Sheaf{T, FMatPullback}, cover::ColimCover, sections::Vector{Vector{R}};check=true, debug=false) where {T<:DiagramTopology, R}
+  length(sections) == length(legs(cover)) || throw(ArgumentError("There are $(length(sections)) but only $(length(legs(cover))) legs in the cover"))
+  v = zeros(R, apex(cover))
+  if check
+    match_errors = diagnose_match(X, cover, sections; debug=debug)
+    length(match_errors) == 0 || throw(MatchingError(match_errors))
+  end
+  f = copair(legs(cover))
+  M = do_hom_map(functor(X), f)
+  return Float64.(M) \ direct_sum(sections)
+end
+
+end
+
+#=
+W = @fincat begin
+  A, B, C
+  U, V
+  ua: U → A
+  ub: U → B
+  vb: V → B
+  vc: V → C
+end
+
+dW = @finfunctor W FinSet begin
+  A => 3
+  B => 2
+  C => 3
+  U => 2
+  V => 1
+  ua => [2,3]
+  ub => [1,2]
+
+  vb => [2]
+  vc => [1]
+end
+
+@diagram FinSet{Int} begin
+  v::FinSet(3)
+end
+
+function glue(X::CoSheaf{T, ContraFreeVect{T}}, cover, sections)
+  f✶ = apply(FreeVect{T}(), copair(legs(cover.basis)))
+  v = direct_sum(reduce(vcat, sections))
+  return f✶(v)
+end
+
+struct FreeVect{T} <: AbstractFunctor where T<:Number end
+const RVecPushforward = FreeVect{Float64}()
+
+apply(F::FreeVect{T}, n::FinSet) where T = Vector{T}
+apply(F::FreeVect{T}, f::FinFunction) where T = begin
+  f✶(x) = map(dom(f)) do i
+    sum(x[j] for j in preimage(f, i))
+  end
+  return f✶
+end
+
+struct ContraFreeVect{T} <: AbstractFunctor where T<:Number end
+
+const RVec = ContraFreeVect{Float64}()
+
+apply(F::ContraFreeVect{T}, n::FinSet) where T = Vector{T}
+apply(F::ContraFreeVect{T}, f::FinFunction) where T = begin
+  f✶(x) = x[f.(dom(f))]
+  return f✶
+end
+=#

--- a/src/sheaves/Sheaves.jl
+++ b/src/sheaves/Sheaves.jl
@@ -5,7 +5,6 @@ using ...CategoricalAlgebra
 using ...CategoricalAlgebra.Categories
 using ...CategoricalAlgebra.FinSets
 using ...CategoricalAlgebra.Matrices
-using ...GATs
 using ...Theories
 import ..CategoricalAlgebra.Categories: CatSize
 import ...Theories: dom, codom, id, ob, hom
@@ -30,64 +29,9 @@ abstract type AbstractCover end
 abstract type AbstractCoverage end
 
 struct FinSetCat <: Category{FinSet, FinFunction, SmallCatSize} end
-struct FinVect <: Category{FinSet, Function, SmallCatSize} end
 
 const FinSetOp = op(FinSetCat())
 const FinSetOpT = typeof(FinSetOp)
-
-"""    FVectPullback{T} where T <: Number
-
-The contravariant free vector space functor. 
-The returned function f✶ restricts via precomposition.
-"""
-struct FVectPullback <: Functor{FinSetOpT, FinVect} end
-dom(::FVectPullback) = FinSetOpT
-codom(::FVectPullback) = FinVect
-do_ob_map(::FVectPullback, n::FinSet) = n
-do_hom_map(::FVectPullback, f::FinFunction) = (v->v[f.(dom(f))])
-# as a callable functor this would be: FVectPullback = Functor(identity, f->(v->v[f.(dom(f))]), OppositeCat(FinSetCat()), FinVect())
-
-"""    FreeVect{T} where T <: Number
-
-The covariant free vector space functor. 
-The returned  function f✶ sums over preimages.
-"""
-FVectPushforward = Functor(identity, # identity on objects
-  # specify the pushforward construction
-  f->(v->map(dom(f)) do i
-    sum(v[j] for j in preimage(f,i))
-  end),
-  # covariant functor from FinSetCat to FinVect
-  FinSetCat(), FinVect()
-)
-
-const FinMat = TypeCat(MatrixDom, Matrix)
-const FinMatT = typeof(FinMat)
-
-# call a matrix on a vector multiplies by it.
-function (M::SparseArrays.SparseMatrixCSC{Int64, Int64})(x::AbstractVector)
-  M*x
-end
-
-function pullback_matrix(f::FinFunction)
-    n = length(dom(f))
-    sparse(1:n, f.(dom(f)), ones(Int,n), dom(f).n, codom(f).n)
-end
-
-function pushforward_matrix(f::FinFunction)
-  pullback_matrix(f)'
-end
-
-struct FMatPullback <: Functor{FinSetOpT, FinMatT} end
-dom(::FMatPullback) = FinSetOpT
-codom(::FMatPullback) = FinMat
-do_ob_map(::FMatPullback, n::FinSet) = MatrixDom{AbstractMatrix}(n.n)
-do_hom_map(::FMatPullback, f::FinFunction) = pullback_matrix(f)
-
-FMatPushforward = Functor(n->MatrixDom(n.n),
-  pushforward_matrix,
-  FinSetCat(), FinVect()
-)
 
 struct Sieve{T} <: AbstractCover
   basis::T
@@ -230,94 +174,6 @@ function diagnose_match(X::Sheaf, cover, sections; debug=false)
   return match_errors
 end
 
-"""    extend(X::Sheaf{T, FVectPullback}, cover::ColimCover, sections::Vector{Vector{R}}; check=true, debug=false) where {T<:DiagramTopology, R}
-
-This method implements the extension operation for the diagram topology on FinSet for the Free Vector Space functor.
-The implementation does copies the value of the ith section into the jth spot as indicated by the legs of the cocone.
-"""
-function extend(X::Sheaf{T, FVectPullback}, cover::ColimCover, sections::Vector{Vector{R}}; check=true, debug=false) where {T<:DiagramTopology, R}
-  length(sections) == length(legs(cover)) || throw(ArgumentError("There are $(length(sections)) but only $(length(legs(cover))) legs in the cover"))
-  v = zeros(R, apex(cover))
-  if check
-    match_errors = diagnose_match(X, cover, sections; debug=debug)
-    length(match_errors) == 0 || throw(MatchingError(match_errors))
-  end
-  for (i, l) in enumerate(legs(cover))
-    for j in dom(l)
-      # copy the value of the ith section into the jth spot
-      # last write wins is fine,
-      # because the sections have to agree on the overlapping indices
-      v[l(j)] = sections[i][j]
-    end
-  end
-  return v
-end
-
-function extend(X::Sheaf{T, FMatPullback}, cover::ColimCover, sections::Vector{Vector{R}};check=true, debug=false) where {T<:DiagramTopology, R}
-  length(sections) == length(legs(cover)) || throw(ArgumentError("There are $(length(sections)) but only $(length(legs(cover))) legs in the cover"))
-  v = zeros(R, apex(cover))
-  if check
-    match_errors = diagnose_match(X, cover, sections; debug=debug)
-    length(match_errors) == 0 || throw(MatchingError(match_errors))
-  end
-  f = copair(legs(cover))
-  M = do_hom_map(functor(X), f)
-  return Float64.(M) \ direct_sum(sections)
-end
+include("FVect.jl")
 
 end
-
-#=
-W = @fincat begin
-  A, B, C
-  U, V
-  ua: U → A
-  ub: U → B
-  vb: V → B
-  vc: V → C
-end
-
-dW = @finfunctor W FinSet begin
-  A => 3
-  B => 2
-  C => 3
-  U => 2
-  V => 1
-  ua => [2,3]
-  ub => [1,2]
-
-  vb => [2]
-  vc => [1]
-end
-
-@diagram FinSet{Int} begin
-  v::FinSet(3)
-end
-
-function glue(X::CoSheaf{T, ContraFreeVect{T}}, cover, sections)
-  f✶ = apply(FreeVect{T}(), copair(legs(cover.basis)))
-  v = direct_sum(reduce(vcat, sections))
-  return f✶(v)
-end
-
-struct FreeVect{T} <: AbstractFunctor where T<:Number end
-const RVecPushforward = FreeVect{Float64}()
-
-apply(F::FreeVect{T}, n::FinSet) where T = Vector{T}
-apply(F::FreeVect{T}, f::FinFunction) where T = begin
-  f✶(x) = map(dom(f)) do i
-    sum(x[j] for j in preimage(f, i))
-  end
-  return f✶
-end
-
-struct ContraFreeVect{T} <: AbstractFunctor where T<:Number end
-
-const RVec = ContraFreeVect{Float64}()
-
-apply(F::ContraFreeVect{T}, n::FinSet) where T = Vector{T}
-apply(F::ContraFreeVect{T}, f::FinFunction) where T = begin
-  f✶(x) = x[f.(dom(f))]
-  return f✶
-end
-=#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,9 @@
 using Test
 
+@testset "Sheaves" begin
+include("sheaves/sheaves.jl")
+end
+
 @testset "GATs" begin
 include("gats/GATs.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,5 @@
 using Test
 
-@testset "Sheaves" begin
-include("sheaves/sheaves.jl")
-end
 
 @testset "GATs" begin
 include("gats/GATs.jl")
@@ -30,4 +27,8 @@ end
 
 @testset "Programs" begin
   include("programs/Programs.jl")
+end
+
+@testset "Sheaves" begin
+  include("sheaves/sheaves.jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using Test
 
-
 @testset "GATs" begin
 include("gats/GATs.jl")
 end

--- a/test/sheaves/sheaves.jl
+++ b/test/sheaves/sheaves.jl
@@ -1,0 +1,54 @@
+using Test
+using Catlab.CategoricalAlgebra
+using Catlab.CategoricalAlgebra.Categories
+using Catlab.Sheaves
+
+import Catlab.CategoricalAlgebra.Categories: do_ob_map, do_hom_map
+using Catlab.CategoricalAlgebra.Matrices: MatrixDom
+import Catlab.Sheaves: pullback_matrix, FinSetCat
+
+VectSheaf = Sheaf(DiagramTopology(), FVectPullback())
+VectSheafMat = Sheaf(DiagramTopology(), FMatPullback())
+
+f = FinFunction([1,2], 3)
+g = FinFunction([1,2], 3)
+
+@test isa(FinSetCat(), Category)
+@test isa(FinVect(), Category)
+@test do_hom_map(FVectPullback(), FinFunction([1,2,2],4))(1:4) == [1,2,2]
+
+@test pullback_matrix(FinFunction([1,2,2], 4)) == [1 0 0 0; 0 1 0 0; 0 1 0 0]
+@test do_ob_map(FMatPullback(), FinSet(3)) == MatrixDom{AbstractMatrix}(3)
+@test do_hom_map(FMatPullback(), FinFunction([1,2,2], 4)) == [1 0 0 0; 0 1 0 0; 0 1 0 0]
+S = ColimCover(pushout(f,g))
+
+extend(VectSheaf, S, [[1.0, 2,3], [1,2.0,6]])
+@test_throws MatchingError extend(VectSheaf, S, [[1.0, 2,3], [1,3.0,6]])
+# extend(VectSheaf, S, [[1.0, 2,3], [1,3.0,6]])
+
+D = FreeDiagram(FinSet.([3,2,3]), # list of objects
+ [ # list of (hom, src, tgt) tuples
+  (FinFunction([1,2], 3), 2,1),
+  (FinFunction([1,2], 3), 2,3),
+  ]
+)
+
+K = ColimCover(D)
+
+section_data = [Float64[1,2,3],
+   Float64[1,2],
+   Float64[1,2,5]]
+
+v = extend(VectSheaf, K, section_data; debug=true)
+
+global_section = extend(VectSheafMat, K, section_data)
+@test v == global_section
+
+section_data_bad = [Float64[1,2,3],
+   Float64[1,2],
+   Float64[1,3,5]]
+@test_throws MatchingError extend(VectSheaf, K, section_data_bad)
+@test_throws MatchingError extend(VectSheafMat, K, section_data_bad)
+
+# if we disable the checks, VectSheafMat will solve a least squares problem instead of last write wins.
+@test extend(VectSheafMat, K, section_data_bad, check=false) != extend(VectSheaf, K, section_data_bad, check=false) 


### PR DESCRIPTION
This PR adds a module for sheaves, including abstract types. It has an example for free vector space as a sheaf over Diag(FinSet).