### PR TITLE
Unbreak `makemap` from `attrMigr` branch

### DIFF
--- a/src/categorical_algebra/FinCats.jl
+++ b/src/categorical_algebra/FinCats.jl
@@ -794,13 +794,11 @@ dicttype(::Type{<:Iterators.Pairs}) = Dict
 @inline make_map(f, xs) = make_map(f, xs, Any)
 
 """
-If `xs` is a UnitRange, make a vector of the desired
-type by mapping `f` over `xs`. Otherwise, make a dictionary
-with the desired valtype.
+Maps `f` over a `UnitRange` to produce a `Vector`,
+or else over anything to produce a `Dict`. The type paramter
+functions to ensure the return type is as desired even when the
+input is empty.
 """
-#make_map(f, xs::UnitRange{Int}, ::Type{Any}) = map(f, xs)
-#make_map(f, xs, ::Type{Any}) = Dict(x => f(x) for x in xs)
-
 function make_map(f, xs::UnitRange{Int}, ::Type{T}) where T
   if isempty(xs)
     T[]

--- a/src/categorical_algebra/FinCats.jl
+++ b/src/categorical_algebra/FinCats.jl
@@ -798,8 +798,8 @@ If `xs` is a UnitRange, make a vector of the desired
 type by mapping `f` over `xs`. Otherwise, make a dictionary
 with the desired valtype.
 """
-make_map(f, xs::UnitRange{Int}, ::Type{Any}) = map(f, xs)
-make_map(f, xs, ::Type{Any}) = Dict(x => f(x) for x in xs)
+#make_map(f, xs::UnitRange{Int}, ::Type{Any}) = map(f, xs)
+#make_map(f, xs, ::Type{Any}) = Dict(x => f(x) for x in xs)
 
 function make_map(f, xs::UnitRange{Int}, ::Type{T}) where T
   if isempty(xs)
@@ -807,7 +807,7 @@ function make_map(f, xs::UnitRange{Int}, ::Type{T}) where T
   else
     ys = map(f, xs)
     eltype(ys) <: T || error("Element(s) of $ys are not instances of $T")
-    T[y for y in ys]
+    ys
   end
 end
 
@@ -817,7 +817,7 @@ function make_map(f, xs, ::Type{T}) where T
   else
     xys = Dict(x => f(x) for x in xs)
     valtype(xys) <: T || error("Value(s) of $xys are not instances of $T")
-    Dict{keytype(xys),T}(x=>y for (x,y) in xys)
+    xys
   end
 end
 


### PR DESCRIPTION
I made `make_map` force the output to a specific type while writing `attrMigr`, a functionality which can cause all kinds of problems and was only actually being used in one quite narrow case. This PR resets it to the original functionality of only forcing the type for empty outputs.