### PR TITLE
Consistent whitespace in runtests.jl

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 using Test
 
 @testset "GATs" begin
-include("gats/GATs.jl")
+  include("gats/GATs.jl")
 end
 
 @testset "Theories" begin


### PR DESCRIPTION
Added two spaces on line 4 in runtests.jl to make it consistent with the other include statements.

Really really minor.