### PR TITLE
Reexport GATlab

### DIFF
--- a/docs/literate/graphs/graphs_label.jl
+++ b/docs/literate/graphs/graphs_label.jl
@@ -1,10 +1,9 @@
 # # Labeled Graphs
 # This example demonstrates how to define new C-Sets from existing C-Sets via the example of adding labels to a graph. We treat labels as members of an arbitrary FinSet of labels rather than a data attribute for pedagogical reasons. When you think of graphs where the labels are numbers, colors, or values of some kind, you would want to make them attributes. The motivation for this example is to be the simplest extension to the theory of graphs that you could possibly make. 
 
-using GATlab, Catlab.Theories
-using Catlab.CategoricalAlgebra
-using Catlab.Graphs
-using Catlab.Graphics
+using Catlab.Theories, Catlab.CategoricalAlgebra
+using Catlab.Graphs, Catlab.Graphics
+
 using Colors
 draw(g) = to_graphviz(g, node_labels=true, edge_labels=true)
 

--- a/docs/literate/sketches/meets.jl
+++ b/docs/literate/sketches/meets.jl
@@ -9,10 +9,9 @@
 using Core: GeneratedFunctionStub
 using Test
 
-using GATlab, Catlab.Theories, Catlab.CategoricalAlgebra
-using Catlab.Graphics
-
+using Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.Graphics
 import Catlab.Theories: compose
+
 using DataStructures
 
 # # Defining some basic preorders

--- a/docs/literate/sketches/preorders.jl
+++ b/docs/literate/sketches/preorders.jl
@@ -12,7 +12,7 @@
 using Core: GeneratedFunctionStub
 using Test
 
-using GATlab, Catlab.Theories, Catlab.CategoricalAlgebra
+using Catlab.Theories, Catlab.CategoricalAlgebra
 import Catlab.Theories: compose
 
 #=

--- a/docs/literate/wiring_diagrams/wd_cset.jl
+++ b/docs/literate/wiring_diagrams/wd_cset.jl
@@ -1,10 +1,7 @@
 # # Wiring Diagrams as Attributed C-Sets
 # Catlab supports many different flavors of diagrammatic syntax. These support the different combinatorial data structures that we use for representing categorical constructions. We will discuss DirectedWiringDiagrams, UndirectedWiringDiagrams, and CPortGraphs in this document.
-using GATlab, Catlab.Theories
-using Catlab.CategoricalAlgebra
-using Catlab.WiringDiagrams
-using Catlab.Programs
-using Catlab.Graphics
+using Catlab.Theories, Catlab.CategoricalAlgebra
+using Catlab.WiringDiagrams, Catlab.Programs, Catlab.Graphics
 using Catlab.Graphics: Graphviz
 
 draw(d::WiringDiagram) = to_graphviz(d,

--- a/experiments/Markov/src/MarkovCategories.jl
+++ b/experiments/Markov/src/MarkovCategories.jl
@@ -3,7 +3,6 @@ export ThMarkovCategory, FreeMarkovCategory,
   Ob, Hom, dom, codom, compose, ⋅, ∘, otimes, ⊗, braid, mcopy, Δ, delete, ◊,
   expectation, 𝔼
 
-using GATlab
 using Catlab.Theories, Catlab.WiringDiagrams
 import GATlab: show_latex
 import Catlab.Theories: Ob, Hom, dom, codom, compose, ⋅, ∘, otimes, ⊗, braid,

--- a/experiments/Markov/src/StochExpr.jl
+++ b/experiments/Markov/src/StochExpr.jl
@@ -1,6 +1,6 @@
 export crand
 
-using GATlab, Catlab.Theories
+using Catlab.Theories
 
 
 # How do you give semantics to a stochastic map? You call it.

--- a/experiments/Markov/test/StochMapsExpr.jl
+++ b/experiments/Markov/test/StochMapsExpr.jl
@@ -1,6 +1,6 @@
 using Test
 
-using GATlab, Catlab.Theories
+using Catlab.Theories
 using Markov
 
 X = Ob(FreeCartesianCategory, :Float64)

--- a/src/categorical_algebra/CatElements.jl
+++ b/src/categorical_algebra/CatElements.jl
@@ -3,7 +3,6 @@ export SchElements, AbstractElements, Elements, elements, inverse_elements
 
 using DataStructures: OrderedDict
 
-using GATlab
 using ...Theories
 using ..CSets, ..FinSets, ..HomSearch
 

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -15,7 +15,6 @@ import Tables, PrettyTables
 
 using ACSets
 @reexport using ..Sets
-using GATlab
 using ...Theories, ...Graphs
 using ..FinCats, ..FreeDiagrams, ..Limits, ..Subobjects
 import ...Theories: Ob, meet, ∧, join, ∨, top, ⊤, bottom, ⊥, ⋅, dom, codom,

--- a/src/graphics/GraphvizCategories.jl
+++ b/src/graphics/GraphvizCategories.jl
@@ -3,7 +3,6 @@
 module GraphvizCategories
 export to_graphviz, to_graphviz_property_graph
 
-using GATlab
 using ...Theories, ...CategoricalAlgebra, ...Graphs, ..GraphvizGraphs
 import ..Graphviz
 import ..GraphvizGraphs: to_graphviz, to_graphviz_property_graph

--- a/src/graphs/BipartiteGraphs.jl
+++ b/src/graphs/BipartiteGraphs.jl
@@ -18,7 +18,6 @@ export HasBipartiteVertices, HasBipartiteGraph,
   rem_edge₁₂!, rem_edge₂₁!, rem_edges₁₂!, rem_edges₂₁!
 
 using ACSets, ...ACSetsGATsInterop
-using GATlab
 using ...Theories
 using ..BasicGraphs: flatten
 import ..BasicGraphs: nv, ne, vertices, edges, src, tgt, add_edge!, add_edges!,

--- a/src/graphs/PropertyGraphs.jl
+++ b/src/graphs/PropertyGraphs.jl
@@ -6,7 +6,6 @@ export AbstractPropertyGraph, PropertyGraph, SchPropertyGraph,
   set_gprop!, set_vprop!, set_eprop!, set_gprops!, set_vprops!, set_eprops!
 
 using ACSets
-using GATlab
 using ...Theories
 using ..BasicGraphs
 import ..BasicGraphs: nv, ne, src, tgt, inv, edges, vertices,

--- a/src/theories/Theories.jl
+++ b/src/theories/Theories.jl
@@ -6,11 +6,13 @@ are also included.
 module Theories
 export CategoryExpr, ObExpr, HomExpr
 
+using Reexport
+
 import Base: ≤, +, *, inv, zero, join, show, collect, ndims
 import AlgebraicInterfaces: dom, codom, compose, id, Ob, ob, Hom, hom, munit,
   mcompose, ocompose, oapply, attr, attrtype
 
-using GATlab
+@reexport using GATlab
 import GATlab: show_unicode, show_latex
 
 """ Base type for GAT expressions in categories or other categorical structures.

--- a/src/wiring_diagrams/CPortGraphs.jl
+++ b/src/wiring_diagrams/CPortGraphs.jl
@@ -3,7 +3,6 @@ export SchCPortGraph, SchOpenCPortGraph, SchSymCPortGraph, SchOpenSymCPortGraph,
   CPortGraph, OpenCPortGraph, SymCPortGraph, OpenSymCPortGraph,
   ThBundledCPG, BundledCPG
 
-using GATlab
 using ...Theories, ...CategoricalAlgebra, ...Graphs
 import ...CategoricalAlgebra: migrate!
 import ..DirectedWiringDiagrams: ocompose

--- a/src/wiring_diagrams/MonoidalDirected.jl
+++ b/src/wiring_diagrams/MonoidalDirected.jl
@@ -13,7 +13,6 @@ export Ports, Junction, PortOp, BoxOp, functor, permute,
 
 using StructEquality
 
-using GATlab
 using ...Theories
 import GATlab: functor, head
 import ...Theories: dom, codom, id, compose, ⋅, ∘,

--- a/test/categorical_algebra/ACSetsGATsInterop.jl
+++ b/test/categorical_algebra/ACSetsGATsInterop.jl
@@ -1,8 +1,7 @@
 module TestACSetsGATsInterop
 using Test
 
-using GATlab
-using Catlab.CategoricalAlgebra
+using GATlab, Catlab.CategoricalAlgebra
 using Catlab.Graphs: SchGraph, SchWeightedGraph
 
 @present SchDendrogram(FreeSchema) begin

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -1,7 +1,6 @@
 module TestCSets
 using Test
 
-using GATlab
 using Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
 
 @present SchDDS(FreeSchema) begin

--- a/test/categorical_algebra/CatElements.jl
+++ b/test/categorical_algebra/CatElements.jl
@@ -1,6 +1,6 @@
 module TestCatElements
 using Test
-using GATlab
+
 using Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
 
 arr = path_graph(Graph, 2)

--- a/test/categorical_algebra/Categories.jl
+++ b/test/categorical_algebra/Categories.jl
@@ -1,7 +1,6 @@
 module TestCategories
 using Test
 
-using GATlab
 using Catlab.Theories
 using Catlab.CategoricalAlgebra
 

--- a/test/categorical_algebra/Chase.jl
+++ b/test/categorical_algebra/Chase.jl
@@ -1,7 +1,6 @@
 module TestChase
 using Test
 
-using GATlab
 using Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.Graphs
 using Catlab.CategoricalAlgebra.Chase: egd, tgd, crel_type, pres_to_eds,
   from_c_rel, collage

--- a/test/categorical_algebra/DataMigrations.jl
+++ b/test/categorical_algebra/DataMigrations.jl
@@ -1,7 +1,7 @@
 module TestDataMigrations
 using Test
 
-using GATlab, Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
+using Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
 using Catlab.Programs.DiagrammaticPrograms
 
 @present SchSet(FreeSchema) begin

--- a/test/categorical_algebra/FinCats.jl
+++ b/test/categorical_algebra/FinCats.jl
@@ -1,7 +1,6 @@
 module TestFinCats
 using Test
 
-using GATlab
 using Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.Graphs
 
 # Categories on graphs

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -1,7 +1,6 @@
 module TestFinSets
 using Test
 
-using GATlab
 using Catlab.Theories, Catlab.CategoricalAlgebra
 using Catlab.CategoricalAlgebra.FinSets: VarSet
 

--- a/test/categorical_algebra/FunctorialDataMigrations.jl
+++ b/test/categorical_algebra/FunctorialDataMigrations.jl
@@ -1,7 +1,6 @@
 module TestFunctorialDataMigrations
 using Test
 
-using GATlab
 using Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
 
 @present SchSet(FreeSchema) begin

--- a/test/categorical_algebra/StructuredCospans.jl
+++ b/test/categorical_algebra/StructuredCospans.jl
@@ -1,7 +1,6 @@
 module TestStructuredCospans
 using Test
 
-using GATlab
 using Catlab.Theories, Catlab.Graphs, Catlab.CategoricalAlgebra
 
 # Structured cospans of C-sets

--- a/test/graphics/GraphvizCategories.jl
+++ b/test/graphics/GraphvizCategories.jl
@@ -1,7 +1,6 @@
 module TestGraphvizCategories
 using Test
 
-using GATlab
 using Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.Graphs
 using Catlab.Graphics.GraphvizCategories
 using Catlab.Graphics: Graphviz

--- a/test/programs/GenerateJuliaPrograms.jl
+++ b/test/programs/GenerateJuliaPrograms.jl
@@ -1,8 +1,6 @@
 module TestGenerateJuliaPrograms
-
 using Test
 
-using GATlab
 using Catlab.Theories
 using Catlab.Programs.GenerateJuliaPrograms
 

--- a/test/programs/ParseJuliaPrograms.jl
+++ b/test/programs/ParseJuliaPrograms.jl
@@ -1,8 +1,6 @@
 module TestParseJuliaPrograms
-
 using Test
 
-using GATlab
 using Catlab.Theories, Catlab.WiringDiagrams
 using Catlab.Programs
 using Catlab.Programs.ParseJuliaPrograms: normalize_arguments

--- a/test/theories/Theories.jl
+++ b/test/theories/Theories.jl
@@ -1,7 +1,6 @@
 module TestTheories
 using Test
 
-using GATlab
 using Catlab.Theories
 
 sexpr(expr::GATExpr) = sprint(show_sexpr, expr)


### PR DESCRIPTION
Reexport GATlab from `Catlab.Theories` and thus also from `Catlab`. Closes #863.