### PR TITLE
Get rid of a bad use of SetFunctionCallable causing vector typing bugs

### DIFF
--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -925,7 +925,7 @@ end
 ensure_type_set(s::FinSet) = TypeSet(eltype(s))
 ensure_type_set(s::TypeSet) = s
 ensure_type_set_codom(f::FinFunction) =
-  SetFunctionCallable(f, dom(f), TypeSet(eltype(codom(f))))
+  FinDomFunction([f(i) for i in dom(f)], dom(f), TypeSet(eltype(codom(f))))
 ensure_type_set_codom(f::IndexedFinFunctionVector) =
   IndexedFinDomFunctionVector(f.func, index=f.index)
 ensure_type_set_codom(f::FinDomFunction) = f


### PR DESCRIPTION
At some point I made the `FinFunction` method of `ensure_type_set_codom` return an explicit `SetFunctionCallable`, which causes explosions when it collides with vectors of `FinDomFunctionVector`s during `limit`.