### PR TITLE
Constrain acset hom search to specified subsets

### DIFF
--- a/src/categorical_algebra/HomSearch.jl
+++ b/src/categorical_algebra/HomSearch.jl
@@ -77,11 +77,11 @@ default, a backtracking search algorithm is used ([`BacktrackingSearch`](@ref)).
 Use the keyword argument error_failures = true to get errors explaining 
 any immediate inconsistencies in specified initial data.
 
-The keyword `valid` accepts a Dict{Ob->Dict{Int->Union{Nothing, Set{Int}}}}
-For each part of the domain, we have the option to give a constraint stating 
-which parts of the codomain are allowable values for assignment. E.g. 
-`valid=Dict(:E => Dict(2=>Set([2,4,6])))` would only find matches which assigned 
-edge#2 to edge #2, #4, or #6 in the codomain.
+The keyword `predicates` accepts a Dict{Ob, Dict{Int, Union{Nothing, AbstractVector{Int}}}}
+For each part of the domain, we have the option to give a constraint as a
+boolean function of the current assignment and tentative value to assign. E.g.
+`predicates = (E = Dict(2 => [2,4,6]))` would only find matches
+which assigned edge#2 to edge #2, #4, or #6 in the codomain.
 
 See also: [`homomorphisms`](@ref), [`isomorphism`](@ref).
 """
@@ -176,7 +176,7 @@ been bound.
 struct BacktrackingState{
   Dom <: ACSet, Codom <: ACSet,
   Assign <: NamedTuple, PartialAssign <: NamedTuple, LooseFun <: NamedTuple,
-  Valid <: NamedTuple
+  Predicates <: NamedTuple
   }
   assignment::Assign
   assignment_depth::Assign
@@ -184,11 +184,11 @@ struct BacktrackingState{
   dom::Dom
   codom::Codom
   type_components::LooseFun
-  valid_range::Valid
+  predicates::Predicates
 end
 
 function backtracking_search(f, X::ACSet, Y::ACSet;
-    monic=false, iso=false, random=false, valid=(;),
+    monic=false, iso=false, random=false, predicates=(;),
     type_components=(;), initial=(;), error_failures=false)
   S, Sy = acset_schema.([X,Y])
   S == Sy || error("Schemas must match for morphism search")
@@ -233,8 +233,8 @@ function backtracking_search(f, X::ACSet, Y::ACSet;
       error(sprint(show_naturality_failures, uns))
   end
 
-  valid_nt = NamedTuple{Ob}(let dic = get(valid, c, Dict()); 
-    Union{Set{Int},Nothing}[haskey(dic,p) ? Set(dic[p]) : nothing for p in parts(X,c)] 
+  pred_nt = NamedTuple{Ob}(let dic = get(predicates, c, Dict()); 
+    Union{Set{Int}, Nothing}[haskey(dic, p) ? Set(dic[p]) : nothing for p in parts(X,c)] 
   end for c in Ob)
 
   # Initialize state variables for search.
@@ -249,7 +249,7 @@ function backtracking_search(f, X::ACSet, Y::ACSet;
   loosefuns = NamedTuple{Attr}(
     isnothing(type_components) ? identity : get(type_components, c, identity) for c in Attr)
   state = BacktrackingState(assignment, assignment_depth, 
-                                  inv_assignment, X, Y, loosefuns, valid_nt)
+                                  inv_assignment, X, Y, loosefuns, pred_nt)
 
   # Make any initial assignments, failing immediately if inconsistent.
   for (c, c_assignments) in pairs(initial)
@@ -349,9 +349,7 @@ assign_elem!(state::BacktrackingState{<:DynamicACSet}, depth, c, x, y) =
     return false
   end
 
-  if !isnothing(state.valid_range[c][x]) && y ∉ state.valid_range[c][x]
-    return false
-  end
+  isnothing(state.predicates[c][x]) || y ∈ state.predicates[c][x] || return false
 
   # Check attributes first to fail as quickly as possible.
   X, Y = state.dom, state.codom

--- a/test/categorical_algebra/HomSearch.jl
+++ b/test/categorical_algebra/HomSearch.jl
@@ -56,6 +56,10 @@ add_edge!(g2, 1, 2)  # double arrow
 @test length(homomorphisms(g2, g1, monic=[:E])) == 2 # two for 2->3
 @test length(homomorphisms(g2, g1, iso=[:E])) == 0
 
+# valid constraint
+@test length(homomorphisms(g2, g1; valid=(V=Dict([1 => [1,3]]),))) == 3
+@test length(homomorphisms(g2, g1; valid=(E=Dict([1 => [1,3]]),))) == 2
+
 # Loose
 s1 = SetAttr{Int}()
 add_part!(s1, :X, f=1)

--- a/test/categorical_algebra/HomSearch.jl
+++ b/test/categorical_algebra/HomSearch.jl
@@ -57,8 +57,8 @@ add_edge!(g2, 1, 2)  # double arrow
 @test length(homomorphisms(g2, g1, iso=[:E])) == 0
 
 # valid constraint
-@test length(homomorphisms(g2, g1; valid=(V=Dict([1 => [1,3]]),))) == 3
-@test length(homomorphisms(g2, g1; valid=(E=Dict([1 => [1,3]]),))) == 2
+@test length(homomorphisms(g2, g1; predicates=(V=Dict([1 => [1,3]]),))) == 3
+@test length(homomorphisms(g2, g1; predicates=(E=Dict([1 => [1,3]]),))) == 2
 
 # Loose
 s1 = SetAttr{Int}()


### PR DESCRIPTION
This constraint allows one to say, e.g. when searching for maps from the path graph with two edges into some big graph, that V2 *must* be sent to either vertex 2, 5, or 6 in the codomain, and that E1 *must* be sent to edge 3 or 7 in the codomain, etc. I.e. we have the option to restrict valid assignments to an arbitrary subset of the codomain for each part in the domain.

This is a required feature for my implementation of [incremental hom search](https://github.com/AlgebraicJulia/AlgebraicRewriting.jl/pull/36).

This is technically a generalization of the `initial` keyword argument, which would be `valid` assigning a singleton set to some part of the domain. However, the way that case is treated (immediately beginning hom search with that assignment) is very different from the general case (a check when making an assignment arbitrarily deep in the tree), so it's helpful to be able to declare these separately.