### PR TITLE
Adding missing `compose` and `id` methods for pointed set schemas

### DIFF
--- a/src/categorical_algebra/FinCats.jl
+++ b/src/categorical_algebra/FinCats.jl
@@ -360,8 +360,8 @@ hom(::Union{FinCatPresentation{ThSchema.Meta.T},FinCatPresentation{ThPointedSetS
   gat_typeof(f) ∈ (:Hom, :Attr, :AttrType) ? f :
     error("Expression $f is not a morphism or attribute")
 
-id(C::FinCatPresentation{ThSchema.Meta.T}, x::AttrTypeExpr) = x
-compose(C::FinCatPresentation{ThSchema.Meta.T}, f::AttrTypeExpr, g::AttrTypeExpr) =
+id(C::Union{FinCatPresentation{ThSchema.Meta.T},FinCatPresentation{ThPointedSetSchema.Meta.T}}, x::AttrTypeExpr) = x
+compose(C::Union{FinCatPresentation{ThSchema.Meta.T},FinCatPresentation{ThPointedSetSchema.Meta.T}}, f::AttrTypeExpr, g::AttrTypeExpr) =
   (f == g) ? f : error("Invalid composite of attribute type identities: $f != $g")
 
 function Base.show(io::IO, C::FinCatPresentation)


### PR DESCRIPTION
Just needed to expand a signature for the method of `id` relevant to attrtypes to make sure everything in a category presented by a schema with zero maps still has an identity morphism.