### PR TITLE
Add missing SigmaMigrationFunctor constructors for DynamicACSets

### DIFF
--- a/src/categorical_algebra/FunctorialDataMigrations.jl
+++ b/src/categorical_algebra/FunctorialDataMigrations.jl
@@ -188,6 +188,9 @@ functor(F::SigmaMigrationFunctor) = functor(migration(F))
 SigmaMigrationFunctor(f,::Type{T},c::ACSet) where T<:StructACSet = SigmaMigrationFunctor(f,T(),constructor(c))
 SigmaMigrationFunctor(f,d::ACSet,::Type{T}) where T<:StructACSet = SigmaMigrationFunctor(f,d,T())
 SigmaMigrationFunctor(f,d::Type{T′},::Type{T}) where {T<:StructACSet, T′<:StructACSet} = SigmaMigrationFunctor(f,d,T())
+SigmaMigrationFunctor(f,T,c::ACSet)  = SigmaMigrationFunctor(f,T(),constructor(c))
+SigmaMigrationFunctor(f,d::ACSet,T)  = SigmaMigrationFunctor(f,d,T())
+SigmaMigrationFunctor(f,T′,T) = SigmaMigrationFunctor(f,d,T())
 
 """
 Create a C-Set for the collage of the functor. Initialize data in the domain 

--- a/test/categorical_algebra/FunctorialDataMigrations.jl
+++ b/test/categorical_algebra/FunctorialDataMigrations.jl
@@ -293,6 +293,8 @@ y_Graph = yoneda(Graph)
 @test is_isomorphic(ob_map(y_Graph, :E), yE)
 @test Set(hom_map.(Ref(y_Graph), [:src,:tgt])) == Set(
   homomorphisms(yV, representable(Graph, :E)))
+y_Graph_Dynamic = yoneda(DynamicACSet(Graph()))
+@test all([is_isomorphic(DynamicACSet(ob_map(y_Graph,x)),ob_map(y_Graph_Dynamic,x)) for x in [:V,:E]])
 
 # Subobject classifier
 ######################


### PR DESCRIPTION
Add functionality and tests for building SigmaMigrationFunctors and yoneda embeddings with dynamic acsets. Before the methods of `SigmaMigrationFunctor` assumed that `constructor(X)` would be a `Type` for any acset `X`, but this is only true for `StructACSet`s.

This caused a bug for @aaguinal today so might be worth a patch release, though it's an easy workaround.