### PR TITLE
Rename `Slices` to `SliceCategories` to avoid name conflict

### DIFF
--- a/src/categorical_algebra/CategoricalAlgebra.jl
+++ b/src/categorical_algebra/CategoricalAlgebra.jl
@@ -21,7 +21,7 @@ include("CatElements.jl")
 include("Chase.jl")
 include("FunctorialDataMigrations.jl")
 include("StructuredCospans.jl")
-include("Slices.jl")
+include("SliceCategories.jl")
 
 @reexport using .Categories
 @reexport using .FinCats
@@ -41,6 +41,6 @@ include("Slices.jl")
 @reexport using .Chase
 @reexport using .FunctorialDataMigrations
 @reexport using .StructuredCospans
-@reexport using .Slices
+@reexport using .SliceCategories
 
 end

--- a/src/categorical_algebra/SliceCategories.jl
+++ b/src/categorical_algebra/SliceCategories.jl
@@ -1,4 +1,4 @@
-module Slices
+module SliceCategories
 export Slice, SliceHom
 
 using StructEquality

--- a/test/categorical_algebra/CategoricalAlgebra.jl
+++ b/test/categorical_algebra/CategoricalAlgebra.jl
@@ -56,8 +56,8 @@ end
   include("StructuredCospans.jl")
 end
 
-@testset "Slices" begin
-  include("Slices.jl")
+@testset "SliceCategories" begin
+  include("SliceCategories.jl")
 end
 
 

--- a/test/categorical_algebra/SliceCategories.jl
+++ b/test/categorical_algebra/SliceCategories.jl
@@ -1,4 +1,4 @@
-module TestSlices
+module TestSliceCategories
 using Test
 
 using Catlab.Theories, Catlab.CategoricalAlgebra, Catlab.Graphs


### PR DESCRIPTION
Julia complains all the time now about Catlab and Base both exporting the word `Slices`. Can we just change the name? This would be a breaking change, not sure whether there's a better approach but I think leaving it as is isn't a serious option in that the attempted export wouldn't actually work if you tried to use `Slices` unqualified.