### PR TITLE
Overlap iterator output span order bugfix + ignoring of specific attrtypes 

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -1322,12 +1322,13 @@ preimage(f::ACSetTransformation,Y::StructACSet) =
 
 """
 For any ACSet, X, a canonical map A→X where A has distinct variables for all
-subparts.
+attributes valued in attrtypes present in `abstract` (by default: all attrtypes)
 """
-function abstract_attributes(X::ACSet)
+function abstract_attributes(X::ACSet, abstract=nothing)
   S = acset_schema(X)
+  abstract = isnothing(abstract) ? attrtypes(S) : abstract
   A = copy(X)
-  comps = Dict{Any, Any}(map(attrtypes(S)) do at
+  comps = Dict{Any, Any}(map(abstract) do at
     rem_parts!(A, at, parts(A, at))
     comp = Union{AttrVar, attrtype_type(X, at)}[]
     for (f, d, _) in attrs(S; to=at)

--- a/test/categorical_algebra/HomSearch.jl
+++ b/test/categorical_algebra/HomSearch.jl
@@ -162,39 +162,63 @@ subG, subobjs = subobject_graph(G) |> collect
 @test length(incident(subG, 1, :src)) == 1 # ⊤ is terminal
 
 # Graph and ReflexiveGraph should have same subobject structure
-subG = subobject_graph(path_graph(Graph, 2)) |> first
+subG, _ = subobject_graph(path_graph(Graph, 2))
 subRG, sos = subobject_graph(path_graph(ReflexiveGraph, 2))
 @test all(is_natural, hom.(sos))
 @test is_isomorphic(subG, subRG)
 
 # Partial overlaps 
-G,H = path_graph.(Graph, 2:3)
-os = collect(partial_overlaps(G,G))
+G, H = path_graph.(Graph, 2:3)
+os = collect(partial_overlaps(G, G))
 @test length(os) == 7 # ⊤, ••, 4× •, ⊥
 
-po = partial_overlaps([G,H])
+po = partial_overlaps([G, H])
 @test length(collect(po))==12  # 2×⊤, 3×••, 6× •, ⊥
 @test all(m -> apex(m) == G, Iterators.take(po, 2)) # first two are •→•
 @test all(m -> apex(m) == Graph(2), 
           Iterators.take(Iterators.drop(po, 2), 3)) # next three are • •
 
+# Partial overlaps with attributes 
+
+@present SchVELabeledGraph <: SchGraph begin
+  VL::AttrType; EL::AttrType; vlabel::Attr(V,VL); elabel::Attr(E,EL)
+end
+
+@acset_type VELabeledGraph(SchVELabeledGraph) <: AbstractGraph
+const LGraph = VELabeledGraph{Bool,Bool}
+
+G = @acset LGraph begin 
+  V=3; E=2; src=[1,2]; tgt=[2,3]; vlabel=Bool[0,1,1]; elabel=Bool[0,1]
+end
+H = @acset LGraph begin 
+  V=3; E=2; src=[1,2]; tgt=[2,3]; vlabel=Bool[0,0,1]; elabel=Bool[0,0]
+end
+os = partial_overlaps(G, H); # abstract=true
+@test count(apx->nparts(apx,:E)==2, apex.(os)) == 1
+os = partial_overlaps(G, H; abstract=[:VL]);
+@test count(apx->nparts(apx,:E)==2, apex.(os)) == 0
+@test count(apx->nparts(apx,:E)==1, apex.(os)) == 4
+os = partial_overlaps(G, H; abstract=false);
+@test count(apx->nparts(apx,:E)==2, apex.(os)) == 0
+@test count(apx->nparts(apx,:E)==1, apex.(os)) == 1
+
 # Maximum Common C-Set
 ######################
-
+const WG = WeightedGraph{Bool}
 """
 Searching for overlaps: •→•→•↺  vs ↻•→•→•
 Two results: •→•→• || •↺ •→• 
 """
-g1 = @acset WeightedGraph{Bool} begin 
+g1 = @acset WG begin 
   V=3; E=3; src=[1,1,2]; tgt=[1,2,3]; weight=[true,false,false]
 end
-g2 = @acset WeightedGraph{Bool} begin 
+g2 = @acset WG begin 
   V=3; E=3; src=[1,2,3]; tgt=[2,3,3]; weight=[true,false,false] 
 end
-apex1 = @acset WeightedGraph{Bool} begin
+apex1 = @acset WG begin
   V=3; E=2; Weight=2; src=[1,2]; tgt=[2,3]; weight=AttrVar.(1:2)
 end
-apex2 = @acset WeightedGraph{Bool} begin 
+apex2 = @acset WG begin 
   V=3; E=2; Weight=2; src=[1,3]; tgt=[2,3]; weight=AttrVar.(1:2)
 end
 
@@ -212,5 +236,9 @@ results = first(is_iso1) ? results : reverse(results)
 @test collect(L2[:V]) == [1,2,3]
 @test collect(R2[:V]) == [3,1,2]
 @test L2(apx2) == Subobject(g1, V=[1,2,3], E=[1,3])
+
+# If we demand equality on attributes, max overlap is one false edge and all vertices.
+exp = @acset WG begin V=3; E=1; src=1; tgt=2; weight=[false] end
+@test first(first(maximum_common_subobject(g1, g2; abstract=false))) == exp
 
 end # module


### PR DESCRIPTION
Addresses https://github.com/AlgebraicJulia/Catlab.jl/issues/885 and https://github.com/AlgebraicJulia/Catlab.jl/issues/884.