### PR TITLE
Enumerate subobjects of acsets with attribute variables

### DIFF
--- a/test/categorical_algebra/HomSearch.jl
+++ b/test/categorical_algebra/HomSearch.jl
@@ -156,7 +156,7 @@ end
 ###########################
 
 G = path_graph(Graph, 3)
-subG, subobjs = subobject_graph(G) |> collect
+subG, subobjs = subobject_graph(G)
 @test length(subobjs) == 13 # ⊤,2x •→• •,2x •→•, •••,3x ••, 3x •, ⊥
 @test length(incident(subG, 13, :src)) == 13 # ⊥ is initial
 @test length(incident(subG, 1, :src)) == 1 # ⊤ is terminal
@@ -166,6 +166,14 @@ subG, _ = subobject_graph(path_graph(Graph, 2))
 subRG, sos = subobject_graph(path_graph(ReflexiveGraph, 2))
 @test all(is_natural, hom.(sos))
 @test is_isomorphic(subG, subRG)
+
+# With attributes
+G′ = path_graph(WeightedGraph{Bool}, 3)
+G′[:weight] = [false, AttrVar(add_part!(G′, :Weight))]
+subG′, subobjs′ = subobject_graph(G′)
+@test is_isomorphic(subG, subG′)
+@test nparts(dom(hom(first(subobjs′))), :Weight) == 1
+@test nparts(dom(hom(last(subobjs′))), :Weight) == 0
 
 # Partial overlaps 
 G, H = path_graph.(Graph, 2:3)

--- a/test/categorical_algebra/HomSearch.jl
+++ b/test/categorical_algebra/HomSearch.jl
@@ -161,12 +161,6 @@ subG, subobjs = subobject_graph(G)
 @test length(incident(subG, 13, :src)) == 13 # ⊥ is initial
 @test length(incident(subG, 1, :src)) == 1 # ⊤ is terminal
 
-# Graph and ReflexiveGraph should have same subobject structure
-subG, _ = subobject_graph(path_graph(Graph, 2))
-subRG, sos = subobject_graph(path_graph(ReflexiveGraph, 2))
-@test all(is_natural, hom.(sos))
-@test is_isomorphic(subG, subRG)
-
 # With attributes
 G′ = path_graph(WeightedGraph{Bool}, 3)
 G′[:weight] = [false, AttrVar(add_part!(G′, :Weight))]
@@ -174,6 +168,12 @@ subG′, subobjs′ = subobject_graph(G′)
 @test is_isomorphic(subG, subG′)
 @test nparts(dom(hom(first(subobjs′))), :Weight) == 1
 @test nparts(dom(hom(last(subobjs′))), :Weight) == 0
+
+# Graph and ReflexiveGraph should have same subobject structure
+subG2, _ = subobject_graph(path_graph(Graph, 2))
+subRG2, sos = subobject_graph(path_graph(ReflexiveGraph, 2))
+@test all(is_natural, hom.(sos))
+@test is_isomorphic(subG2, subRG2)
 
 # Partial overlaps 
 G, H = path_graph.(Graph, 2:3)


### PR DESCRIPTION
Previously, subobject enumeration would error if performed on an ACSet with AttrVars. 

This PR implements the following behavior: when a subobject is taken such that certain AttrVars are no longer referred to, we remove those AttrVars from the subobject, too.