### PR TITLE
Simplify, upgrade, and type-stabilize dom_to_graph

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -598,7 +598,7 @@ coerce_type_component(type::Symbol, f, dom_type::Type, codom_type::Type) =
   
 """
 Check naturality condition for a purported ACSetTransformation, α: X→Y. 
-For each hom in the schema, e.g. h: m → n, the following square commute must:
+For each hom in the schema, e.g. h: m → n, the following square must commute:
 
 ```text
      αₘ

--- a/src/categorical_algebra/FinCats.jl
+++ b/src/categorical_algebra/FinCats.jl
@@ -559,15 +559,18 @@ end
 """
 Reinterpret a functor on a finitely presented category
 as a functor on the equivalent category (ignoring equations)
-free on a graph.
+free on a graph. Also normalizes the input to have vector ob_map
+and hom_map, with valtype optionally specified. This is useful when
+the domain is empty or when the maps might be tightly typed but need to
+allow for types such as that of identity morphisms upon mutation.
 """
-function dom_to_graph(F::FinDomFunctor{<:FinCatPresentation,<:Cat{Ob,Hom}}) where {Ob,Hom}
+function dom_to_graph(F::FinDomFunctor{Dom,<:Cat{Ob,Hom}},obtype=Ob,homtype=Hom) where {Dom,Ob,Hom} 
   D = dom(F)
-  g , obs, homs = graph(D),Dict(pairs(ob_generators(D))), Dict(pairs(hom_generators(D)))
-  C = FinCat(g)
-  FinDomFunctorMap(Ob[ob_map(F,obs[i]) for i in 1:length(obs)],Hom[hom_map(F,homs[i]) for i in 1:length(homs)],C,codom(F))
+  C = FinCat(graph(D))
+  new_obs = obtype[ob_map(F,ob) for ob in ob_generators(D)]
+  new_homs = homtype[hom_map(F,hom) for hom in hom_generators(D)]
+  FinDomFunctorMap(new_obs,new_homs,C,TypeCat(obtype,homtype))
 end
-dom_to_graph(F::FinDomFunctor) = F
 function Base.show(io::IO, F::T) where T <: FinDomFunctorMap
   Categories.show_type_constructor(io, T); print(io, "(")
   show(io, F.ob_map)


### PR DESCRIPTION
`DataMigrations.jl` uses the `dom_to_graph` function to convert a category from a presentation to a graph so that it can be fed into the `Limits` functionality. At the same time it has to do some typecasting to handle the fact that its diagrams might containing at least three concrete types--`SetFunctionCallable`,`SetFunctionId`,`FinDomFunctionInt`--while also allowing for mutations during the process of populating partially defined diagram and then constructing bipartite graphs for the limit. 

This PR modifies `dom_to_graph` to ensure that the output will always have `dom` a `FinCatGraph`, `ob_map` a vector of `obtype`, and `hom_map` a vector of `homtype`. There seems to be no reason as yet to allow `codom(F)` to be modified, although maybe there will be such a need someday.

Requesting a patch release. In some sense this is a breaking change since the old function wouldn't change  a functor with domain other than a `FinCatPresentation`, but I don't have any reason to believe this function's ever been called outside of the `DataMigrations.jl` context. And the breaking could only occur if somebody was relying excessively on implementation details of the input functor such as the `ob_map` being a `Dict` anyway--this function doesn't change the functor's semantics.