### PR TITLE
Basic nauty integration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -35,6 +35,7 @@ Graphviz_jll = "3c863552-8265-54e4-a6dc-903eb78fde85"
 MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
 SCS = "c946c3f1-0d1f-5ce8-9dea-7daa1f7e2d13"
 TikzPictures = "37f6aa50-8035-52d0-81c2-5a1d08754b2d"
+nauty_jll = "55c6dc9b-343a-50ca-8ff2-b71adb3733d5"
 
 [extensions]
 CatlabConvexExt = "Convex"
@@ -42,6 +43,7 @@ CatlabDataFramesExt = "DataFrames"
 CatlabGraphsExt = "Graphs"
 CatlabGraphvizExt = "Graphviz_jll"
 CatlabMetaGraphsExt = "MetaGraphs"
+CatlabNautyExt = "nauty_jll"
 CatlabSCSExt = "SCS"
 CatlabTikzPicturesExt = "TikzPictures"
 

--- a/ext/CatlabNautyExt.jl
+++ b/ext/CatlabNautyExt.jl
@@ -1,0 +1,92 @@
+module CatlabNautyExt
+
+using nauty_jll
+import Catlab.CategoricalAlgebra.CSets: ACSetTransformation, Multispan, 
+  Multicospan, apex, legs
+using Catlab.Theories: ⋅
+using ACSets
+import ACSets: call_nauty, strhsh, orbits, ngroup, canon, dom, codom
+using StructEquality
+
+# Morphisms up to isomorphism
+#----------------------------
+
+"""
+Given an ACSet X and a canonical element of the iso class, [X], obtain either
+a map X -> [X] or (if `inv=true`) [X]->X
+"""
+function ACSetTransformation(start::ACSet, n::CSetNautyRes; inv::Bool=false) 
+  comps = Dict([k => (inv ? invperm(v) : v) for (k, v) in pairs(canonmap(n))])
+  args = (inv ? reverse : identity)([start, canon(n)])
+  ACSetTransformation(args...; comps...)
+end
+
+"""
+Given an ACSetTransformation A -> B (and canonical isos A→A' and B→B′), we 
+construct a canonical ACSetTransformation A′→B′.
+"""
+@struct_hash_equal struct ACSetTransformationNautyRes <: NautyRes 
+  dom::CSetNautyRes
+  codom::CSetNautyRes
+  canon::ACSetTransformation # Cache the computation of this
+end
+
+"""Optionally pass in the CSetNautyRes for (co)dom if known"""
+function call_nauty(f::ACSetTransformation; dom_canon=nothing, codom_canon=nothing) 
+  d, cd = map([dom=>dom_canon, codom=>codom_canon]) do (get, canon)
+    isnothing(canon) ? call_nauty(get(f)) : canon
+  end
+  d′ = ACSetTransformation(dom(f), d; inv=true)
+  cd′ = ACSetTransformation(codom(f), cd)
+  ACSetTransformationNautyRes(d, cd, d′⋅f⋅cd′)
+end
+
+dom(n::ACSetTransformationNautyRes) = n.dom
+codom(n::ACSetTransformationNautyRes) = n.codom
+
+strhsh(n::ACSetTransformationNautyRes) = strhsh(n.dom) * strhsh(n.codom) 
+orbits(n::ACSetTransformationNautyRes) = orbits(dom(n)) => orbits(codom(n))
+generators(n::ACSetTransformationNautyRes) = generators(dom(n)) => generators(codom(n))
+ngroup(n::ACSetTransformationNautyRes) = ngroup(dom(n)) => ngroup(codom(n))
+canon(n::ACSetTransformationNautyRes) = n.canon
+
+# (Co)spans up to isomorphism
+#----------------------------
+
+abstract type SpanCospanNautyRes <: NautyRes end
+
+@struct_hash_equal struct MultispanNautyRes <: SpanCospanNautyRes 
+  apex::CSetNautyRes
+  legs::AbstractVector{ACSetTransformationNautyRes}
+end
+
+@struct_hash_equal struct MulticospanNautyRes <: SpanCospanNautyRes 
+  apex::CSetNautyRes
+  legs::AbstractVector{ACSetTransformationNautyRes}
+end
+
+apex(s::SpanCospanNautyRes) = s.apex
+legs(s::SpanCospanNautyRes) = s.legs
+Base.length(s::SpanCospanNautyRes) = length(s.legs)
+
+function call_nauty(f::Multispan)
+  ap = call_nauty(apex(f))
+  MultispanNautyRes(ap, call_nauty.(f; dom_canon=ap))
+end
+
+function call_nauty(f::Multicospan)
+  ap = call_nauty(apex(f))
+  MulticospanNautyRes(ap, call_nauty.(f; codom_canon=ap))
+end
+
+
+strhsh(n::SpanCospanNautyRes) = join(strhsh.(legs(n)))
+orbits(n::SpanCospanNautyRes) = [orbits(apex(n)), orbits.(codom.(legs(n)))...]
+generators(n::SpanCospanNautyRes) = [generators(apex(n)), generators.(codom.(legs(n)))...]
+ngroup(n::SpanCospanNautyRes) = [ngroup(apex(n)), ngroup.(codom.(legs(n)))...]
+canon(n::SpanCospanNautyRes) = Multispan(canon.(legs(n)))
+
+# C-Set diagrams up to isomorphism - TODO
+#----------------------------------------
+
+end # module

--- a/src/categorical_algebra/FreeDiagrams.jl
+++ b/src/categorical_algebra/FreeDiagrams.jl
@@ -25,7 +25,7 @@ using ACSets
 using GATlab
 using ...Theories, ...Graphs, ..FinCats
 import AlgebraicInterfaces: ob, hom, dom, codom
-import ..FinCats: FreeCatGraph, FinDomFunctor, collect_ob, collect_hom
+import ..FinCats: FreeCatGraph, FinDomFunctor, collect_ob, collect_hom, force
 
 # Diagram interface
 ###################
@@ -161,6 +161,8 @@ Base.iterate(span::Multispan, args...) = iterate(span.legs, args...)
 Base.eltype(span::Multispan) = eltype(span.legs)
 Base.length(span::Multispan) = length(span.legs)
 
+force(span::Multispan) = Multispan(apex(span), force.(legs(span)))
+
 """ Multicospan of morphisms in a category.
 
 A multicospan is like a [`Cospan`](@ref) except that it may have a number of
@@ -202,6 +204,8 @@ cone_objects(cospan::Multicospan) = feet(cospan)
 Base.iterate(cospan::Multicospan, args...) = iterate(cospan.legs, args...)
 Base.eltype(cospan::Multicospan) = eltype(cospan.legs)
 Base.length(cospan::Multicospan) = length(cospan.legs)
+
+force(span::Multicospan) = Multicospan(apex(span), force.(legs(span)))
 
 """ Bundle together legs of a multi(co)span.
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -17,6 +17,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+nauty_jll = "55c6dc9b-343a-50ca-8ff2-b71adb3733d5"
 
 [compat]
 Graphs = "^1"


### PR DESCRIPTION
Extend canonical iso from ACSets to ACSetTransformations and Multi(co)spans.

It would be straightforward to generalize this to diagrams in an ACSet category, but, until that's needed for something, that could probably wait.

An example of testing a pullback (span) up to isomorphism is in the tests.