### PR TITLE
Smoothing interaction between VarSets and actual sets and functions

### DIFF
--- a/src/categorical_algebra/Sets.jl
+++ b/src/categorical_algebra/Sets.jl
@@ -29,7 +29,7 @@ Note: This type is more abstract than the built-in Julia types `AbstractSet` and
 encompassed by the subtype [`FinSet`](@ref).
 """
 abstract type SetOb{T} end
-
+SetOb(S::SetOb) = S
 Base.eltype(::Type{<:SetOb{T}}) where T = T
 
 """ A Julia data type regarded as a set.

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -594,7 +594,4 @@ f = FinDomFunction([:a, :b, :a], FinSet(3), TypeSet(Symbol))
 @test f(2) == :b
 @test f(3) == :a
 
-S = SetOb(VarSet{Union{}}(5))
-@test SetOb(S) == S
-
 end

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -575,4 +575,26 @@ f = VarFunction{Bool}(AttrVar.([1,2,true]),FinSet(2))
 # Create 
 @test dom(create(VarSet{Int}(1))) == VarSet{Int}(0)
 
+# VarSets to FinSets
+#############
+f = FinDomFunction([:a, :b, :c])
+@test FinDomFunction(f) == f
+
+s = VarSet{Union{}}(2)
+@test SetOb(s) == FinSet(s)
+
+@test SetOb(VarSet{Int}(4)) == TypeSet(Union{AttrVar,Int64})
+
+f = VarFunction{Bool}(AttrVar.([1, 2]), FinSet(2))
+fin_f = FinDomFunction(Union{AttrVar,Bool}[AttrVar(1), AttrVar(2)], FinSet(2), TypeSet(Union{AttrVar,Bool}))
+@test FinDomFunction(f) == fin_f
+
+f = FinDomFunction([:a, :b, :a], FinSet(3), TypeSet(Symbol))
+@test f(1) == :a
+@test f(2) == :b
+@test f(3) == :a
+
+S = SetOb(VarSet{Union{}}(5))
+@test SetOb(S) == S
+
 end

--- a/test/categorical_algebra/Sets.jl
+++ b/test/categorical_algebra/Sets.jl
@@ -2,6 +2,7 @@ module TestSets
 using Test
 
 using Catlab.Theories, Catlab.CategoricalAlgebra
+using Catlab.CategoricalAlgebra.FinSets: VarSet
 
 # Sets from Julia types
 #######################

--- a/test/categorical_algebra/Sets.jl
+++ b/test/categorical_algebra/Sets.jl
@@ -124,4 +124,8 @@ colim = colimit(SingletonDiagram(TypeSet(Int)))
 f = SetFunction(string, TypeSet(Int), TypeSet(String))
 @test universal(colim, SMulticospan{1}(f)) === f
 
+# VarSets
+S = SetOb(VarSet{Union{}}(5))
+@test SetOb(S) == S
+
 end


### PR DESCRIPTION
The changes below are to enable smoother data migrations of acsets with some `AttrVar` attribute values as requested here: https://github.com/AlgebraicJulia/DataMigrations.jl/issues/159