### PR TITLE
Fix Heyting subtraction for ACSets with variables

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -1111,11 +1111,9 @@ end
 const SubCSet{S} = Subobject{<:StructCSet{S}}
 const SubACSet{S} = Subobject{<:StructACSet{S}}
 
-# Cast VarFunctions to FinFunctions
+# Componentwise subobjects
 components(A::SubACSet{S}) where S = 
-  NamedTuple(k => Subobject(
-    k ∈ ob(S) ? vs : FinFunction([v.val for v in collect(vs)], FinSet(codom(vs))))
-  for (k,vs) in pairs(components(hom(A)))
+  NamedTuple(k => Subobject(vs) for (k,vs) in pairs(components(hom(A)))
 )
 
 force(A::SubACSet) = Subobject(force(hom(A)))

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -25,7 +25,7 @@ import ..FinCats: force, ob_generators, hom_generators, ob_generator,
   ob_generator_name, graph, is_discrete
 using ..FinCats: dicttype
 import ..Limits: limit, colimit, universal, BipartiteColimit
-import ..Subobjects: Subobject
+import ..Subobjects: Subobject, SubobjectHom
 using ..Sets: IdentityFunction, SetFunctionCallable
 
 # Finite sets
@@ -1448,6 +1448,17 @@ SubFinSet(pred::AbstractBoolVector) = Subobject(FinSet(length(pred)), pred)
 ob(A::SubFinSetVector) = A.set
 hom(A::SubFinSetVector) = FinFunction(findall(A.predicate), A.set)
 predicate(A::SubFinSetVector) = A.predicate
+function predicate(A::SubobjectHom{<:VarSet}) 
+  f = hom(A)
+  pred = falses(length(codom(f)))
+  for x in AttrVar.(dom(f))
+    fx = f(x)
+    if fx isa AttrVar
+      pred[fx.val] = true
+    end
+  end
+  pred
+end
 
 function predicate(A::SubFinSet)
   f = hom(A)


### PR DESCRIPTION
The subtraction operation was not brought up to date with AttrVar refactor, so a minor tweak is needed.

It uses `all_subparts`, which gets all the other parts that a part is referencing; however, that method searched over `homs` and not `arrows`. When this change is made, the correct behavior is recovered.

The relevance of this is that complement is used in this PR https://github.com/AlgebraicJulia/AlgebraicRewriting.jl/pull/62