### PR TITLE
Epic backtracking constraint

### DIFF
--- a/test/categorical_algebra/HomSearch.jl
+++ b/test/categorical_algebra/HomSearch.jl
@@ -77,6 +77,24 @@ g1, g2 = path_graph(Graph, 3), path_graph(Graph, 2)
 rem_part!(g1,:E,2)
 @test_throws ErrorException homomorphism(g1,g2;monic=true,error_failures=true)
 
+# Epic constraint
+g0, g1, g2 = Graph(2), Graph(2), Graph(2)
+add_edges!(g0, [1,1],[1,2]) # ↻•→•
+add_edges!(g1, [1,1],[2,2]) # •⇉•
+add_edges!(g2, [1,1,1],[1,1,2]) # ↻↻•→•
+@test length(homomorphisms(g1, g2, epic=[:V])) == 1
+@test length(homomorphisms(g1, g2, epic=[:E])) == 0
+@test length(homomorphisms(g2, g0, epic=[:E])) == 1
+@test length(homomorphisms(g2, g0, epic=[:V])) == 1
+
+g3, g4 = path_graph(Graph,3), path_graph(Graph,4)
+add_edges!(g3,[1,3],[1,3])  # g3: ↻•→•→• ↺
+@test length(homomorphisms(g4,g3)) == 6 # 2 for each: 1/2/3 edges sent to loop
+@test length(homomorphisms(g4,g3; epic=[:V])) == 2 # send only one edge to loop
+@test length(homomorphisms(g4,g3; epic=[:E])) == 0 # only have 3 edges to map
+
+@test length(homomorphisms(Graph(4),Graph(2); epic=true)) == 14 # 2^4 - 2
+
 # Symmetric graphs
 #-----------------
 


### PR DESCRIPTION
Just as we have a monic constraint option, the epic constraint keyword can be used to componentwise prune partial homomorphisms in the search process that have no chance of becoming an epic homomorphism.

By keeping track of how many elements have yet to be assigned in the domain and a vector for each element in the codomain (how many elements map to each element), we can check this. When assigning a new element, we decrement the domain unassigned counter and we increment the counter on the element in the codomain (vice-versa when unassigning an element).

This is a repost of https://github.com/AlgebraicJulia/Catlab.jl/pull/602 which cannot be rebased because HomSearch has now been moved to its own file.

This is relevant for incremental hom search.