### PR TITLE
Redesign ACSetFunctors when there are AttrVars

### DIFF
--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -2,7 +2,7 @@
 """
 module FinSets
 export FinSet, FinFunction, FinDomFunction, TabularSet, TabularLimit,
-  force, is_indexed, preimage, VarFunction, LooseVarFunction,
+  force, is_indexed, preimage, VarSet, VarFunction, LooseVarFunction,
   JoinAlgorithm, SmartJoin, NestedLoopJoin, SortMergeJoin, HashJoin,
   SubFinSet, SubOpBoolean, is_monic, is_epic, is_iso
 
@@ -322,9 +322,13 @@ Base.in(set::VarSet{T}, elem) where T = in(elem, 1:set.n)
 
 abstract type AbsVarFunction{T} end # either VarFunction or LooseVarFunction
 """
-Data type of a map out of a set of attribute variables
+Data type for a morphism of VarSet{T}s. Note we can equivalently view these 
+as morphisms [n]+T -> [m]+T fixing T or as morphisms [n] -> [m]+T, in the typical
+Kleisli category yoga. 
 
-Currently, domains are FinSet{Int} and codomains are expected to be FinSet{Int}.
+Currently, domains are treated as VarSets. The codom field is treated as a FinSet{Int}.
+Note that the codom accessor gives a VarSet while the codom field is just that VarSet's 
+FinSet of AttrVars.
 This could be generalized to being FinSet{Symbol} to allow for
 symbolic attributes. (Likewise, AttrVars will have to wrap Any rather than Int)
 """
@@ -338,15 +342,20 @@ symbolic attributes. (Likewise, AttrVars will have to wrap Any rather than Int)
 end
 VarFunction(f::AbstractVector{Int},cod::Int) = VarFunction(FinFunction(f,cod))
 VarFunction(f::FinDomFunction) = VarFunction{Union{}}(AttrVar.(collect(f)),codom(f))
+VarFunction{T}(f::FinDomFunction,cod::FinSet) where T = VarFunction{T}(collect(f),cod)
 FinFunction(f::VarFunction{T}) where T = FinFunction(
   [f.fun(i) isa AttrVar ? f.fun(i).val : error("Cannot cast to FinFunction") 
    for i in dom(f)], f.codom)
 FinDomFunction(f::VarFunction{T}) where T = f.fun
 Base.length(f::AbsVarFunction{T}) where T = length(collect(f.fun))
 Base.collect(f::AbsVarFunction{T}) where T = collect(f.fun)
+# XX: Does it really make sense that VarFunctions can only be evaluated 
+#     on AttrVars, say in the case they're giving an attribute?
 (f::VarFunction{T})(v::T) where T = v 
 (f::AbsVarFunction{T})(v::AttrVar) where T = f.fun(v.val) 
 
+#XX if a VarSet could contain an arbitrary FinSet of variables this
+#   wouldn't need to be so violent
 dom(f::AbsVarFunction{T}) where T = VarSet{T}(length(collect(f.fun)))
 codom(f::VarFunction{T}) where T = VarSet{T}(length(f.codom))
 id(s::VarSet{T}) where T = VarFunction{T}(AttrVar.(1:s.n), FinSet(s.n))
@@ -373,6 +382,10 @@ compose(f::VarFunction{T},g::VarFunction{T}) where {T} =
 compose(f::VarFunction{T}, g::FinFunction) where T =
   VarFunction{T}([elem isa AttrVar ? AttrVar(g(elem.val)) : elem 
                   for elem in collect(f)], g.codom)
+
+"""Compose [n]->[m] with [m]->[p]+T, yielding a [n]->T+[p]"""
+compose(f::FinFunction,g::VarFunction{T}) where T =
+  VarFunction{T}(compose(f,g.fun), g.codom)
 
 preimage(f::VarFunction{T}, v::AttrVar) where T = preimage(f.fun, v)
 preimage(f::VarFunction{T}, v::T) where T = preimage(f.fun, v)

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -349,8 +349,7 @@ FinFunction(f::VarFunction{T}) where T = FinFunction(
 FinDomFunction(f::VarFunction{T}) where T = f.fun
 Base.length(f::AbsVarFunction{T}) where T = length(collect(f.fun))
 Base.collect(f::AbsVarFunction{T}) where T = collect(f.fun)
-# XX: Does it really make sense that VarFunctions can only be evaluated 
-#     on AttrVars, say in the case they're giving an attribute?
+ 
 (f::VarFunction{T})(v::T) where T = v 
 (f::AbsVarFunction{T})(v::AttrVar) where T = f.fun(v.val) 
 

--- a/test/categorical_algebra/FinSets.jl
+++ b/test/categorical_algebra/FinSets.jl
@@ -535,11 +535,18 @@ end
 ##############
 # Construction 
 f = VarFunction{Vector{Int}}([AttrVar(1),[1,2,3]], FinSet(1))
+g = VarFunction{Vector{Int}}(FinDomFunction([AttrVar(1),[1,2,3]]),FinSet(1))
+@test f == g
 @test f([1,2]) == [1,2]
+@test f(AttrVar(2)) == [1,2,3]
 
 # Composition 
 f = VarFunction{Bool}(([AttrVar(2),AttrVar(1), true]),FinSet(3))
+g = FinFunction([2,3])
+h = FinFunction([2,2,1])
 @test collect(f⋅ f) == [AttrVar(1),AttrVar(2), true]
+@test collect(compose(g,f)) == [AttrVar(1),true]
+@test collect(compose(f,h)) == [AttrVar(2),AttrVar(2), true]
 
 @test force(f) == f
 @test f.(AttrVar.(3:-1:1)) == [true, AttrVar.(1:2)...]


### PR DESCRIPTION
Modifications to make attrvars play nicer with data migrations. The key change in CSets is to redefine `ACSetFunctor`s, which are used critically in data migrations to compose with ordinary functors representing the migrations themselves, to again always take values in `FinSetInt`s and `FinDomFunction`s when possible. Previously, the `ACSetFunctor` of an `ACSet` containing any `Attrvar`s would take values entirely in `VarSet`s, which both confused the difference between actual `Attrvar`s and combinatorial data and interfaced badly with the `Limit`s API. 

To make this work I also defined how to compose `FinFunction`s with `VarFunction`s on the left.