### PR TITLE
Fix constructor of acset from `FinDomFunctor` in varacset case

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -250,8 +250,13 @@ function ACSetInterface.copy_parts!(X::ACSet, F::FinDomFunctor)
     set_subpart!(X, dom_parts, nameof(f), codom_parts[collect(hom_map(F, f))])
   end
   for f in generators(pres, :Attr)
+    cd = nameof(codom(f))
     dom_parts = added[nameof(dom(f))]
-    set_subpart!(X, dom_parts, nameof(f), collect(hom_map(F, f)))
+    F_of_f = collect(hom_map(F,f))
+    n_attrvars_present = nparts(X, cd)
+    n_attrvars_needed = maximum(map(x->x.val,filter(x->x isa AttrVar,F_of_f)),init=0)
+    add_parts!(X,cd,n_attrvars_needed-n_attrvars_present)
+    set_subpart!(X, dom_parts, nameof(f), F_of_f)
   end
   added
 end

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -541,6 +541,7 @@ end
 
 @test VarFunction(A,:weight) == VarFunction{Bool}([AttrVar(1), true], FinSet(2))
 
+
 f = ACSetTransformation(
   Dict(:V=>[1],:E=>[1,2],:Weight=>[AttrVar(2), AttrVar(1)]), A, A
 )
@@ -557,6 +558,10 @@ w1,w2,w3 = ws = [WG{x}() for x in [Symbol,Bool,Int]]
 [add_parts!(w, :Weight, 2) for w in ws]
 rem_part!(w1, :Weight, 1)
 @test [nparts(w, :Weight) for w in ws] == [1,2,2]
+
+A′ = WG{Bool}(FinDomFunctor(A))
+rem_part!(A,:Weight,2)
+@test is_isomorphic(A,A′)
 
 # Construct Tight/Loose ACSet Transformations
 #--------------------------------------------


### PR DESCRIPTION
The constructor `(T)(::FinDomFunctor) where T<:ACSet` did not previously add any parts at `AttrType`s, which is necessary in case where some of the input's attributes take `AttrVar` values. We now add such `AttrVar`s, only when they're definitely needed, to avoid dangling `AttrVar`s, which are quite dangerous.