### PR TITLE
Fix construction of varacset from `FinDomFunctor`

### DIFF
--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -229,13 +229,15 @@ functor_key(expr::GATExpr{:generator}) = first(expr)
 function (::Type{ACS})(F::FinDomFunctor) where ACS <: ACSet
   X = if ACS isa UnionAll
     pres = presentation(dom(F))
-    ACS{(eltype(ob_map(F, c)) for c in generators(pres, :AttrType))...}()
+    ACS{(strip_attrvars(eltype(ob_map(F, c))) for c in generators(pres, :AttrType))...}()
   else
     ACS()
   end
   copy_parts!(X, F)
   return X
 end
+strip_attrvars(T) = T
+strip_attrvars(::Type{Union{AttrVar, T}}) where T = T
 
 """ Copy parts from a set-valued `FinDomFunctor` to an `ACSet`.
 """

--- a/src/categorical_algebra/CSets.jl
+++ b/src/categorical_algebra/CSets.jl
@@ -250,8 +250,13 @@ function ACSetInterface.copy_parts!(X::ACSet, F::FinDomFunctor)
     set_subpart!(X, dom_parts, nameof(f), codom_parts[collect(hom_map(F, f))])
   end
   for f in generators(pres, :Attr)
+    cd = nameof(codom(f))
     dom_parts = added[nameof(dom(f))]
-    set_subpart!(X, dom_parts, nameof(f), collect(hom_map(F, f)))
+    F_of_f = collect(hom_map(F,f))
+    n_attrvars_present = nparts(X, cd)
+    n_attrvars_needed = maximum(map(x->x.val,filter(x->x isa AttrVar,F_of_f)),init=0)
+    add_parts!(X,cd,n_attrvars_needed-n_attrvars_present)
+    set_subpart!(X, dom_parts, nameof(f), F_of_f)
   end
   added
 end

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -318,6 +318,7 @@ FinSet(s::VarSet) = FinSet(s.n) #Note this throws away `T`, most accurate when t
 Base.iterate(set::VarSet{T}, args...) where T = iterate(1:set.n, args...)
 Base.length(set::VarSet{T}) where T = set.n
 Base.in(set::VarSet{T}, elem) where T = in(elem, 1:set.n)
+Base.eltype(set::VarSet{T}) where T = T
 
 
 abstract type AbsVarFunction{T} end # either VarFunction or LooseVarFunction

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -651,7 +651,7 @@ f′ = homomorphism(A, X; initial=(Weight=[true,AttrVar(1)],))
 g′ = homomorphism(A, X; initial=(Weight=[true,AttrVar(2)],))
 fg = universal(AA, Cospan(f′,g′))
 
-# PUSHOUTS
+# PUSHOUTS wow
 V = @acset WG{Bool} begin Weight=1 end
 f = ACSetTransformation(Dict(:Weight=>[AttrVar(1)]), V, A)
 g = ACSetTransformation(Dict(:Weight=>[AttrVar(2)]), V, A)

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -541,6 +541,7 @@ end
 
 @test VarFunction(A,:weight) == VarFunction{Bool}([AttrVar(1), true], FinSet(2))
 
+
 f = ACSetTransformation(
   Dict(:V=>[1],:E=>[1,2],:Weight=>[AttrVar(2), AttrVar(1)]), A, A
 )
@@ -557,6 +558,10 @@ w1,w2,w3 = ws = [WG{x}() for x in [Symbol,Bool,Int]]
 [add_parts!(w, :Weight, 2) for w in ws]
 rem_part!(w1, :Weight, 1)
 @test [nparts(w, :Weight) for w in ws] == [1,2,2]
+
+A′ = WG{Bool}(FinDomFunctor(A))
+rem_part!(A,:Weight,2)
+@test is_isomorphic(A,A′)
 
 # Construct Tight/Loose ACSet Transformations
 #--------------------------------------------

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -651,7 +651,7 @@ f′ = homomorphism(A, X; initial=(Weight=[true,AttrVar(1)],))
 g′ = homomorphism(A, X; initial=(Weight=[true,AttrVar(2)],))
 fg = universal(AA, Cospan(f′,g′))
 
-# PUSHOUTS wow
+# PUSHOUTS
 V = @acset WG{Bool} begin Weight=1 end
 f = ACSetTransformation(Dict(:Weight=>[AttrVar(1)]), V, A)
 g = ACSetTransformation(Dict(:Weight=>[AttrVar(2)]), V, A)

--- a/test/categorical_algebra/CSets.jl
+++ b/test/categorical_algebra/CSets.jl
@@ -559,9 +559,17 @@ w1,w2,w3 = ws = [WG{x}() for x in [Symbol,Bool,Int]]
 rem_part!(w1, :Weight, 1)
 @test [nparts(w, :Weight) for w in ws] == [1,2,2]
 
-A′ = WG{Bool}(FinDomFunctor(A))
-rem_part!(A,:Weight,2)
-@test is_isomorphic(A,A′)
+A′ = WG(FinDomFunctor(A))
+rem_part!(A,:Weight,2) #remove the dangling attrvar from A
+
+C = FinCat(SchWeightedGraph)
+obs = Dict(x=>x for x in ob_generators(C))
+homs = Dict(f=> f for f in hom_generators(C))
+F = FinDomFunctor(obs,homs,C,C)
+A′′ = WG(compose(F,FinDomFunctor(A)))
+#Test both A′ and A′′ for constructing an acset from 
+# an ACSetFunctor, respectively, a FinDomFunctorMap.
+@test A == A′ == A′′
 
 # Construct Tight/Loose ACSet Transformations
 #--------------------------------------------


### PR DESCRIPTION
`(::Type{ACS})(F::FinDomFunctor)` would previously give back an `ACS{Any}` if `ob_map(F,:someAttr)` was a `VarSet` and an `ACS{Union{AttrVar,T}}` if `ob_map(F,:someAttr)` was `TypeSet{Union{AttrVar,T}}`. 