### PR TITLE
Integer-typed UWDs

### DIFF
--- a/src/programs/RelationalPrograms.jl
+++ b/src/programs/RelationalPrograms.jl
@@ -145,7 +145,7 @@ function parse_relation_diagram(head::Expr, body::Expr)
     Expr(:where, expr, context) => (expr, parse_relation_context(context)...)
     _ => (head, nothing, nothing)
   end
-  var_types = if isnothing(all_types)    # Untyped case.
+  var_types = if isnothing(all_types)    # Untyped case
     vars -> length(vars)
   elseif typeof(all_types[1]) <: Int     # Int typed case
     var_type_map = Dict{Symbol,Int}(zip(all_vars, all_types))
@@ -255,6 +255,7 @@ function parse_relation_inferred_args(args)
       Expr(:kw, name::Symbol, var::Symbol) => (name => var)
       Expr(:(=), name::Symbol, var::Symbol) => (name => var)
       var::Symbol => var
+      Expr(:(::), _, _) => error("All variable types must be included in the where clause and not in the argument list")
       _ => error("Expected name as positional or keyword argument")
     end
   end

--- a/src/programs/RelationalPrograms.jl
+++ b/src/programs/RelationalPrograms.jl
@@ -149,17 +149,12 @@ function parse_relation_diagram(head::Expr, body::Expr)
   var_types = if isnothing(all_types) # Untyped case.
     vars -> length(vars)
   elseif typeof(all_types[1]) <: Int # Int typed case
-    println("int typed case")
     var_type_map = Dict{Symbol,Int}(zip(all_vars, all_types))
     vars -> getindex.(Ref(var_type_map), vars)
   elseif typeof(all_types[1]) <: Expr # Int typed case
-    println("expr typed case")
     var_type_map = Dict{Symbol,Expr}(zip(all_vars, all_types))
     vars -> getindex.(Ref(var_type_map), vars)
   else # Symbol typed case.
-    println("symbol typed case")
-    println(typeof(all_types))
-    println(all_types)
     var_type_map = Dict{Symbol,Symbol}(zip(all_vars, all_types))
     vars -> getindex.(Ref(var_type_map), vars)
 
@@ -199,7 +194,6 @@ function parse_relation_diagram(head::Expr, body::Expr)
 end
 
 function parse_relation_context(context)
-  println("here")
   terms = @match context begin
     Expr(:tuple) => return (Symbol[], nothing)
     Expr(:tuple, terms...) => terms
@@ -225,10 +219,8 @@ function parse_relation_context(context)
   elseif vars isa AbstractVector{Pair{Symbol,Symbol}}
     (first.(vars), last.(vars))
   elseif vars isa AbstractVector{Pair{Symbol, Int}}
-    println("symbol int case")
     (first.(vars), last.(vars))
   elseif vars isa AbstractVector{Pair{Symbol, Expr}}
-    println("symbol expr case")
     (first.(vars), last.(vars))
   else
     error("Context $context mixes typed and untyped variables")
@@ -265,7 +257,6 @@ function parse_relation_kw_args(args)
 end
 
 function parse_relation_inferred_args(args)
-  println("INSIDE PARSE RELATION INFERRED ARGS")
   @assert !isempty(args) # Need at least one argument to infer named/unnamed.
   args = map(args) do arg
     @match arg begin
@@ -282,14 +273,6 @@ function parse_relation_inferred_args(args)
   else
     error("Relation mixes named and unnamed arguments $args")
   end
-end
-
-function show_uwd(uwd)
-  to_graphviz(uwd, box_labels = :name, junction_labels = :variable, edge_attrs=Dict(:len => ".75"))
-end
-
-function show_uwd_types(uwd)   # Add better typing and error catching for if uwd is untyped
-  to_graphviz(uwd, box_labels = :name, junction_labels = :junction_type, edge_attrs=Dict(:len => ".75"))
 end
 
 end

--- a/src/programs/RelationalPrograms.jl
+++ b/src/programs/RelationalPrograms.jl
@@ -4,14 +4,13 @@ module RelationalPrograms
 export RelationDiagram, UntypedRelationDiagram, TypedRelationDiagram,
   SchRelationDiagram, SchTypedRelationDiagram,
   SchNamedRelationDiagram, SchTypedNamedRelationDiagram,
-  @relation, parse_relation_diagram, show_uwd, show_uwd_types
+  @relation, parse_relation_diagram
 
 using MLStyle: @match
 
 using GATlab
 using ...CategoricalAlgebra.CSets
 using ...WiringDiagrams.UndirectedWiringDiagrams
-using Catlab   # Could have greater specificity
 
 # Data types
 ############
@@ -146,18 +145,17 @@ function parse_relation_diagram(head::Expr, body::Expr)
     Expr(:where, expr, context) => (expr, parse_relation_context(context)...)
     _ => (head, nothing, nothing)
   end
-  var_types = if isnothing(all_types) # Untyped case.
+  var_types = if isnothing(all_types)    # Untyped case.
     vars -> length(vars)
-  elseif typeof(all_types[1]) <: Int # Int typed case
+  elseif typeof(all_types[1]) <: Int     # Int typed case
     var_type_map = Dict{Symbol,Int}(zip(all_vars, all_types))
     vars -> getindex.(Ref(var_type_map), vars)
-  elseif typeof(all_types[1]) <: Expr # Int typed case
+  elseif typeof(all_types[1]) <: Expr    # Expr typed case
     var_type_map = Dict{Symbol,Expr}(zip(all_vars, all_types))
     vars -> getindex.(Ref(var_type_map), vars)
-  else # Symbol typed case.
+  else                                   # Symbol typed case
     var_type_map = Dict{Symbol,Symbol}(zip(all_vars, all_types))
     vars -> getindex.(Ref(var_type_map), vars)
-
   end
 
   # Create wiring diagram and add outer ports and junctions.
@@ -204,18 +202,12 @@ function parse_relation_context(context)
       Expr(:(::), var::Symbol, type::Symbol) => (var => type)
       Expr(:(::), var::Symbol, type::Int) => (var => type)
       Expr(:(::), var::Symbol, type::Expr) => (var => type)
-
-      # Arbitrary expression types
-
-
       var::Symbol => var
       _ => error("Invalid syntax in term $term of context")
     end
   end
   if vars isa AbstractVector{Symbol}
     (vars, nothing)
-  # elseif vars isa AbstractVector{}
-  #   (vars, nothing)
   elseif vars isa AbstractVector{Pair{Symbol,Symbol}}
     (first.(vars), last.(vars))
   elseif vars isa AbstractVector{Pair{Symbol, Int}}
@@ -223,7 +215,7 @@ function parse_relation_context(context)
   elseif vars isa AbstractVector{Pair{Symbol, Expr}}
     (first.(vars), last.(vars))
   else
-    error("Context $context mixes typed and untyped variables")
+    error("Context $context mixes variable types")
   end
 end
 

--- a/src/programs/RelationalPrograms.jl
+++ b/src/programs/RelationalPrograms.jl
@@ -148,9 +148,8 @@ function parse_relation_diagram(head::Expr, body::Expr)
   var_types = if isnothing(all_types)    # Untyped case
     vars -> length(vars)
   else
-    var_type_map = Dict{Symbol,eltype(all_types)}(zip(all_vars, all_types))    # May have Integer problems
+    var_type_map = Dict(zip(all_vars, all_types)) 
     vars -> getindex.(Ref(var_type_map), vars)
-
   end
 
   # Create wiring diagram and add outer ports and junctions.
@@ -196,14 +195,7 @@ function parse_relation_context(context)
     @match term begin
       Expr(:(::), var::Symbol, type::Symbol) => (var => type)
       Expr(:(::), var::Symbol, type::Expr) => (var => type)
-
-      Expr(:(::), var::Symbol, type) => begin
-      if typeof(type) <: Integer
-        (var => type)
-      else
-        error("Invalid type: $type in term $term of context wasn't an integer")
-      end
-    end
+      Expr(:(::), var::Symbol, type::Integer) => (var => type)
       var::Symbol => var
       _ => error("Invalid syntax in term $term of context")
     end
@@ -211,7 +203,7 @@ function parse_relation_context(context)
 
   if vars isa AbstractVector{Symbol}
     (vars, nothing)
-  elseif all(x -> x isa Pair{Symbol, <:Union{Symbol, Integer, Expr}}, vars)
+  elseif eltype(vars) <: Pair
     (first.(vars), last.(vars))
   else
     error("Context $context mixes typed and untyped variables")

--- a/test/programs/RelationalPrograms.jl
+++ b/test/programs/RelationalPrograms.jl
@@ -60,9 +60,6 @@ parsed = @relation (x,y,z) where (x::X, y::Y, z::Z, w::W) begin
   T(z,w)
 end
 
-show_uwd(parsed)
-show_uwd_types(parsed)
-
 d = RelationDiagram([:X,:Y,:Z])
 add_box!(d, [:X,:W], name=:R)
 add_box!(d, [:Y,:W], name=:S)
@@ -96,31 +93,21 @@ set_junction!(d, [1,2,3], outer=true)
 # Typed by Expressions
 #------
 
-function n()
-end
-
 parsed = @relation (x,y,z) where (x::n(1), y::n(2), z::n(3), w::n(4)) begin
   R(x,w)
   S(y,w)
   T(z,w)
 end
 
-
-
 # Testing doesn't work right now because Julia doesn't like calling n as a function
-d = RelationDiagram([Expr(n(1)), Expr(n(1)), Expr(n(1))])
-add_box!(d, [:n(1),:n(4)], name=:R)
-add_box!(d, [:n(2),:n(4)], name=:S)
-add_box!(d, [:n(3),:n(4)], name=:T)
-add_junctions!(d, [:n(1),:n(2),:n(3),:n(4)], variable=[:x,:y,:z,:w])
-set_junction!(d, [1,4,2,4,3,4])
-set_junction!(d, [1,2,3], outer=true)
-@test parsed == d
-
-
-
-
-
+# d = RelationDiagram([Expr(n(1)), Expr(n(1)), Expr(n(1))])
+# add_box!(d, [:n(1),:n(4)], name=:R)
+# add_box!(d, [:n(2),:n(4)], name=:S)
+# add_box!(d, [:n(3),:n(4)], name=:T)
+# add_junctions!(d, [:n(1),:n(2),:n(3),:n(4)], variable=[:x,:y,:z,:w])
+# set_junction!(d, [1,4,2,4,3,4])
+# set_junction!(d, [1,2,3], outer=true)
+# @test parsed == d
 
 
 # Special case: closed diagram.

--- a/test/programs/RelationalPrograms.jl
+++ b/test/programs/RelationalPrograms.jl
@@ -1,4 +1,5 @@
 module TestRelationalPrograms
+
 using Test
 
 using Catlab.CategoricalAlgebra.CSets
@@ -49,7 +50,8 @@ d = RelationDiagram(0)
 add_box!(d, 0, name=:A)
 @test parsed == d
 
-# Typed
+
+# Typed by Symbols
 #------
 
 parsed = @relation (x,y,z) where (x::X, y::Y, z::Z, w::W) begin
@@ -57,6 +59,10 @@ parsed = @relation (x,y,z) where (x::X, y::Y, z::Z, w::W) begin
   S(y,w)
   T(z,w)
 end
+
+show_uwd(parsed)
+show_uwd_types(parsed)
+
 d = RelationDiagram([:X,:Y,:Z])
 add_box!(d, [:X,:W], name=:R)
 add_box!(d, [:Y,:W], name=:S)
@@ -65,6 +71,57 @@ add_junctions!(d, [:X,:Y,:Z,:W], variable=[:x,:y,:z,:w])
 set_junction!(d, [1,4,2,4,3,4])
 set_junction!(d, [1,2,3], outer=true)
 @test parsed == d
+
+
+# Typed by Ints
+#------
+
+parsed = @relation (x,y,z) where (x::1, y::2, z::3, w::4) begin
+  R(x,w)
+  S(y,w)
+  T(z,w)
+end
+
+d = RelationDiagram([:1,:2,:3])
+add_box!(d, [:1,:4], name=:R)
+add_box!(d, [:2,:4], name=:S)
+add_box!(d, [:3,:4], name=:T)
+add_junctions!(d, [:1,:2,:3,:4], variable=[:x,:y,:z,:w])
+set_junction!(d, [1,4,2,4,3,4])
+set_junction!(d, [1,2,3], outer=true)
+@test parsed == d
+
+
+
+# Typed by Expressions
+#------
+
+function n()
+end
+
+parsed = @relation (x,y,z) where (x::n(1), y::n(2), z::n(3), w::n(4)) begin
+  R(x,w)
+  S(y,w)
+  T(z,w)
+end
+
+
+
+# Testing doesn't work right now because Julia doesn't like calling n as a function
+d = RelationDiagram([Expr(n(1)), Expr(n(1)), Expr(n(1))])
+add_box!(d, [:n(1),:n(4)], name=:R)
+add_box!(d, [:n(2),:n(4)], name=:S)
+add_box!(d, [:n(3),:n(4)], name=:T)
+add_junctions!(d, [:n(1),:n(2),:n(3),:n(4)], variable=[:x,:y,:z,:w])
+set_junction!(d, [1,4,2,4,3,4])
+set_junction!(d, [1,2,3], outer=true)
+@test parsed == d
+
+
+
+
+
+
 
 # Special case: closed diagram.
 sird_uwd = @relation () where (S::Pop, I::Pop, R::Pop, D::Pop) begin

--- a/test/programs/RelationalPrograms.jl
+++ b/test/programs/RelationalPrograms.jl
@@ -70,7 +70,7 @@ set_junction!(d, [1,2,3], outer=true)
 @test parsed == d
 
 
-# Typed by Ints
+# Typed by Integers
 #------
 
 parsed = @relation (x,y,z) where (x::1, y::2, z::3, w::4) begin
@@ -99,15 +99,35 @@ parsed = @relation (x,y,z) where (x::n(1), y::n(2), z::n(3), w::n(4)) begin
   T(z,w)
 end
 
-# Testing doesn't work right now because Julia doesn't like calling n as a function
-# d = RelationDiagram([Expr(n(1)), Expr(n(1)), Expr(n(1))])
-# add_box!(d, [:n(1),:n(4)], name=:R)
-# add_box!(d, [:n(2),:n(4)], name=:S)
-# add_box!(d, [:n(3),:n(4)], name=:T)
-# add_junctions!(d, [:n(1),:n(2),:n(3),:n(4)], variable=[:x,:y,:z,:w])
-# set_junction!(d, [1,4,2,4,3,4])
-# set_junction!(d, [1,2,3], outer=true)
-# @test parsed == d
+d = RelationDiagram([:(n(1)), :(n(2)), :(n(3))])
+add_box!(d, [:(n(1)),:(n(4))], name=:R)
+add_box!(d, [:(n(2)),:(n(4))], name=:S)
+add_box!(d, [:(n(3)),:(n(4))], name=:T)
+add_junctions!(d, [:(n(1)),:(n(2)),:(n(3)),:(n(4))], variable=[:x,:y,:z,:w])
+set_junction!(d, [1,4,2,4,3,4])
+set_junction!(d, [1,2,3], outer=true)
+@test parsed == d
+
+# Mixed types
+#------
+
+parsed = @relation (x,y,z) where (x::n(1), y::2, z::C, w::nothing) begin
+  R(x,w)
+  S(y,w)
+  T(z,w)
+end
+
+d = RelationDiagram([:(n(1)), :2, :C])
+add_box!(d, [:(n(1)),:nothing], name=:R)
+add_box!(d, [:2,:nothing], name=:S)
+add_box!(d, [:C,:nothing], name=:T)
+add_junctions!(d, [:(n(1)),:2,:C,:nothing], variable=[:x,:y,:z,:w])
+set_junction!(d, [1,4,2,4,3,4])
+set_junction!(d, [1,2,3], outer=true)
+@test parsed == d
+
+
+
 
 
 # Special case: closed diagram.


### PR DESCRIPTION
Adds additional compatibility to typed UWDs to allow for Int types and Expr types. (Currently, only Symbol types are supported.)