### PR TITLE
Loosen type in `to_graphviz_property_graph`

### DIFF
--- a/src/graphics/GraphvizGraphs.jl
+++ b/src/graphics/GraphvizGraphs.jl
@@ -152,7 +152,7 @@ This function is an intermediate step in many methods of the generic function
 [`to_graphviz`](@ref), but can be useful in its own right for customizing the
 Graphviz graph beyond whatever options are supported by [`to_graphviz`](@ref).
 """
-function to_graphviz_property_graph(g::AbstractGraph;
+function to_graphviz_property_graph(g::HasGraph;
     prog::AbstractString="dot", graph_attrs::AbstractDict=Dict(),
     node_attrs::AbstractDict=Dict(), edge_attrs::AbstractDict=Dict(),
     node_labels::Union{Symbol,Bool}=false, edge_labels::Union{Symbol,Bool}=false)


### PR DESCRIPTION
The type in `to_graphviz_property_graph` is too narrow, the function calls down to the `PropertyGraph` constructor which is defined for type `HasGraph`.