### PR TITLE
Fix empty collection typing bug

### DIFF
--- a/src/categorical_algebra/HomSearch.jl
+++ b/src/categorical_algebra/HomSearch.jl
@@ -264,7 +264,7 @@ function backtracking_search(f, X::ACSet, Y::ACSet;
   for a_type in attrtypes(S) 
     a_type ∈ (monic ∪ iso ∪ no_bind) && continue # attrvars ↦ attrvars
     attrs′ = attrs(S, just_names=true, to=a_type)
-    avars = union(collect.([filter(x->x isa AttrVar, X[f]) for f in attrs′])...)
+    avars = union(AttrVar[],collect.([filter(x->x isa AttrVar, X[f]) for f in attrs′])...)
     assigned = partial_assignments(get(initial, a_type, []); is_attr=true)
     assigned′ = first.(collect(assigned))
     unassigned = setdiff(parts(X, a_type), [v.val for v in avars] ∪ assigned′)


### PR DESCRIPTION
Commit 3f95da1 introduced a regression for constructing Yoneda in the case of a schema that has an `AttrTypes` with no `Attrs` pointing to it, which surprisingly enough is sometimes useful (in case you want to migrate from a schema with `AttrTypes` to one without for migrations including code.) The problem was that `union` has no method for empty input since it can't decide on the output type, because typing Julia collections in empty cases is our entire job here. I fixed it.