### PR TITLE
Fix bugs in `Base.in` methods and empty comprehension

### DIFF
--- a/src/categorical_algebra/FinRelations.jl
+++ b/src/categorical_algebra/FinRelations.jl
@@ -54,7 +54,7 @@ FinRel(set::S) where {T,S<:AbstractSet{T}} = FinRel{S,T}(set)
 Base.eltype(::Type{FinRel{S,T}}) where {S,T} = T
 Base.iterate(s::FinRel, args...) = iterate(iterable(s), args...)
 Base.length(s::FinRel) = length(iterable(s))
-Base.in(s::FinRel, elem) = in(s, iterable(s))
+Base.in(elem, s::FinRel) = in(elem, iterable(s))
 iterable(s::FinRel{Int}) = 1:s.set
 iterable(s::FinRel{<:AbstractSet}) = s.set
 

--- a/src/categorical_algebra/FinSets.jl
+++ b/src/categorical_algebra/FinSets.jl
@@ -55,7 +55,7 @@ FinSet(n::Int) = FinSetInt(n)
 
 Base.iterate(set::FinSetInt, args...) = iterate(1:set.n, args...)
 Base.length(set::FinSetInt) = set.n
-Base.in(set::FinSetInt, elem) = in(elem, 1:set.n)
+Base.in(elem, set::FinSetInt) = in(elem, 1:set.n)
 
 Base.show(io::IO, set::FinSetInt) = print(io, "FinSet($(set.n))")
 
@@ -75,7 +75,7 @@ FinSet(collection::S) where {T, S<:Union{AbstractVector{T},AbstractSet{T}}} =
 
 Base.iterate(set::FinSetCollection, args...) = iterate(set.collection, args...)
 Base.length(set::FinSetCollection) = length(set.collection)
-Base.in(set::FinSetCollection, elem) = in(elem, set.collection)
+Base.in(elem, set::FinSetCollection) = in(elem, set.collection)
 
 function Base.show(io::IO, set::FinSetCollection)
   print(io, "FinSet(")
@@ -320,7 +320,7 @@ The iterable part of a varset is its collection of `AttrVar`s.
 """
 Base.iterate(set::VarSet{T}, args...) where T = iterate(AttrVar.(1:set.n), args...)
 Base.length(set::VarSet{T}) where T = set.n
-Base.in(set::VarSet{T}, elem) where T = in(elem, 1:set.n)
+Base.in(elem, set::VarSet{T}) where T = in(elem, 1:set.n)
 Base.eltype(set::VarSet{T}) where T = Union{AttrVar,T}
 
 

--- a/src/wiring_diagrams/Algebras.jl
+++ b/src/wiring_diagrams/Algebras.jl
@@ -263,9 +263,9 @@ function is_homomorphic(X::ACSet, Y::ACSet, ::HomomorphismQuery)
   length(query(Y, homomorphism_query(X, count=true)...)) > 0
 end
 
-function make_homomorphism(row, X::StructACSet{S}, Y::StructACSet{S}) where S
+function make_homomorphism(row::AbstractVector{T}, X::StructACSet{S}, Y::StructACSet{S}) where {T, S}
   components = let i = 0
-    NamedTuple{ob(S)}([row[i+=1] for _ in parts(X,c)] for c in ob(S))
+    NamedTuple{ob(S)}(T[row[i+=1] for _ in parts(X,c)] for c in ob(S))
   end
   ACSetTransformation(components, X, Y)
 end


### PR DESCRIPTION
- The `in` functions were not really causing problems, since Julia was defaulting to iterating over the container. However, it was creating method ambiguities (I caught it with Aqua).
- In the function `make_homomorphism` the comprehension `[row[i+=1] for _ in parts(X,c)]` is creating a vector of type `Any` if `parts(X, c)` is empty.