### PR TITLE
Add titles to uwds

### DIFF
--- a/src/graphics/GraphvizGraphs.jl
+++ b/src/graphics/GraphvizGraphs.jl
@@ -121,6 +121,12 @@ function to_graphviz(g::AbstractPropertyGraph)::Graphviz.Graph
     end
   end
 
+  # Add title if it exists.
+  title = gprops(g)[:title]
+  if !isnothing(title)
+    push!(stmts, title)
+  end
+
   attrs = gprops(g)
   Graphviz.Graph(
     name = get(attrs, :name, "G"),

--- a/src/graphics/GraphvizGraphs.jl
+++ b/src/graphics/GraphvizGraphs.jl
@@ -122,7 +122,7 @@ function to_graphviz(g::AbstractPropertyGraph)::Graphviz.Graph
   end
 
   # Add title if it exists.
-  title = gprops(g)[:title]
+  title = get(gprops(g), :title, nothing)
   if !isnothing(title)
     push!(stmts, title)
   end

--- a/src/graphics/GraphvizWiringDiagrams.jl
+++ b/src/graphics/GraphvizWiringDiagrams.jl
@@ -73,6 +73,7 @@ into a wiring diagram. This function requires Graphviz v2.42 or higher.
   If disabled, no incoming or outgoing wires will be shown either!
 - `anchor_outer_ports=true`: whether to enforce ordering of the outer box's
   input and output, i.e., ordering of the incoming and outgoing wires
+- `title::Union{Nothing, Graphviz.Label}=nothing: title of diagram
 - `graph_attrs=Dict()`: top-level graph attributes
 - `node_attrs=Dict()`: top-level node attributes
 - `edge_attrs=Dict()`: top-level edge attributes
@@ -401,6 +402,7 @@ becoming nodes of the second kind.
 - `junction_size="0.075"`: size of junction nodes, in inches
 - `implicit_junctions=false`: whether to represent a junction implicity as a
   wire when it has exactly two incident ports
+- `title::Union{Nothing, Graphviz.Label}=nothing: title of diagram
 - `graph_attrs=Dict()`: top-level graph attributes
 - `node_attrs=Dict()`: top-level node attributes
 - `edge_attrs=Dict()`: top-level edge attributes
@@ -414,11 +416,12 @@ function to_graphviz_property_graph(d::UndirectedWiringDiagram;
     box_labels::Union{Bool,Symbol}=false, port_labels::Bool=false,
     junction_labels::Union{Bool,Symbol}=false,
     junction_size::String="0.075", implicit_junctions::Bool=false,
+    title::Union{Nothing, Graphviz.Label}=nothing,
     graph_attrs::AbstractDict=Dict(), node_attrs::AbstractDict=Dict(),
     edge_attrs::AbstractDict=Dict())::SymmetricPropertyGraph
   default_attrs = default_undirected_graphviz_attrs
   graph = SymmetricPropertyGraph{Any}(
-    name = graph_name, prog = prog,
+    name = graph_name, prog = prog, title=title,
     graph = merge(default_attrs.graph, Graphviz.as_attributes(graph_attrs)),
     node = merge(default_attrs.node, Graphviz.as_attributes(node_attrs)),
     edge = merge(default_attrs.edge, Graphviz.as_attributes(edge_attrs)),


### PR DESCRIPTION
PR #570 added titles to DWDs. I tried to ape what was there to support titles for UWDs.

Example output:
```julia-repl
julia> compose_klausmeier = @relation () begin
         phyto(N, W)
         hydro(N, W)
       end;

julia> b = Catlab.Graphics.Graphviz.Label("Foo", "Klausmeier");

julia> Catlab.Graphics.Graphviz.view_graphviz(to_graphviz(compose_klausmeier, title=b, box_labels=:name, junction_labels=:variable, prog="circo"))
Process(`open /var/folders/0j/9wfk7fvn41b1bskzfrh85m240000gq/T/jl_HSHaPKd4Ts.png`, ProcessRunning)

```
![klausmeier](https://github.com/user-attachments/assets/8efc7c89-89fa-4aeb-94df-3fa38acfae3b)
