### PR TITLE
add DiagrammaticEquations.jl to downstream.yml

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -17,6 +17,7 @@ jobs:
           - { user: AlgebraicJulia, repo: CategoricalTensorNetworks.jl }
           - { user: AlgebraicJulia, repo: CombinatorialSpaces.jl }
           - { user: AlgebraicJulia, repo: DataMigrations.jl }
+          - { user: AlgebraicJulia, repo: DiagrammaticEquations.jl }
           - { user: AlgebraicJulia, repo: Decapodes.jl }
 
     steps:


### PR DESCRIPTION
To prevent problems with DiagrammaticEquations.jl when we update Catlab.