### PR TITLE
Simple `@acset_colim` macro 

### DIFF
--- a/test/categorical_algebra/pointwise/csetcats/Yoneda.jl
+++ b/test/categorical_algebra/pointwise/csetcats/Yoneda.jl
@@ -69,4 +69,19 @@ Z = @acset DDS42 begin X=5; Φ=[2,3,4,3,4] end
 ZG = ob(product[ACSetCategory(DDS42())](Z,G))
 @test length(homomorphisms(Z, Fᴳ)) == length(homomorphisms(ZG, F)) == 1024
 
+# ACSet colim
+#############
+
+@test is_isomorphic((@acset_colim y_Graph begin v::V end), Graph(1))
+
+v3e2 = @acset_colim y_Graph begin
+  v1::V; (e1,e2)::E
+  src(e1) == v1
+  tgt(e1) == src(e2)
+end
+
+v3e2′ = @acset Graph begin V=3; E=2; src=[1,2]; tgt=[2,3] end 
+
+@test is_isomorphic(v3e2, v3e2′)
+
 end # module

--- a/test/categorical_algebra/pointwise/varacsetcats/Yoneda.jl
+++ b/test/categorical_algebra/pointwise/varacsetcats/Yoneda.jl
@@ -1,0 +1,29 @@
+module TestYonedaVarACSet 
+
+using Catlab, Test
+
+struct MyStruct 
+  field::Symbol 
+end
+MX = MyStruct(:X)
+
+y_Graph = yoneda(WeightedGraph{MyStruct});
+
+# ACSet colim
+#############
+
+v3e2 = @acset_colim y_Graph begin
+  v1::V; (e1,e2)::E; w::Weight
+  src(e1) == v1
+  tgt(e1) == src(e2)
+  weight(e1)==weight(e2)
+  weight(e2)== $(MyStruct(:X))
+end
+
+v3e2′ = @acset WeightedGraph{MyStruct} begin
+  V=3; E=2; Weight=1; src=[1,2]; tgt=[2,3]; weight=[MX, MX] 
+end
+
+@test is_isomorphic(v3e2, v3e2′)
+
+end # module

--- a/test/categorical_algebra/pointwise/varacsetcats/runtests.jl
+++ b/test/categorical_algebra/pointwise/varacsetcats/runtests.jl
@@ -19,6 +19,11 @@ end
 @testset "Subobjects" begin
   include("Subobjects.jl")
 end
+
 @testset "MCO" begin
   include("MCO.jl")
+end 
+
+@testset "Yoneda" begin
+  include("Yoneda.jl")
 end 


### PR DESCRIPTION
This PR introduces the feature that previously was in DataMigrations.jl. 

`@acset_colim` takes the data of `y = yoneda(MySchema)` (which is a `FinDomFunctor`) and a bunch of generators and relations, e.g. 

```julia
v3e2 = @acset_colim y begin
  v1::V; (e1,e2)::E; w::Weight
  src(e1) == v1
  tgt(e1) == src(e2)
  weight(e1)==weight(e2)
  weight(e2)== $(MyStruct(:X))
end
```

And constructs the ACSet implicitly specified by these.

```julia
v3e2′ = @acset WeightedGraph{MyStruct} begin
  V=3; E=2; Weight=1; 
  src=[1,2]; tgt=[2,3]; 
  weight=[MyStruct(:X),MyStruct(:X)] 
end
```

It does this by first constructing the coproduct of all of the generators. Then, for each `==`, it constructs a span such that a pushout would enforce that equation. Lastly it assembles all of these spans together and performs the merging with one big pushout.

Equations can both identify parts of objects as well as bind attribute variables to concrete values (with the `$(...)` syntax for entering a concrete value).