### PR TITLE
Equalizers in FinSetC

### DIFF
--- a/test/categorical_algebra/setcats/finsetcat/Limits.jl
+++ b/test/categorical_algebra/setcats/finsetcat/Limits.jl
@@ -33,4 +33,17 @@ u = pair[𝒞](lim, sp...)
 @test collect(u) == [(:a,:a),(:b,:b),(:b,:a)]
 @test force(universal[𝒞](lim, sp)) == force(u)
 
+# Equalizer
+###########
+
+f = FinFunction([2,1,3],4)
+g = FinFunction([1,2,3],4)
+eq1 = equalizer[𝒞](f,g)
+e = dom(only(eq1))
+@test collect(e) == [3]
+@test only(eq1)(3) == 3
+
+h = FinFunction([3,3],4)
+@test factorize[𝒞](eq1, h) == FinFunction([1,1])
+
 end # module


### PR DESCRIPTION
This provides an implementation of `ThCategoryWithEqualizers` for `FinSetC`.

```julia
f = FinFunction([2,1,3],4)
g = FinFunction([1,2,3],4)
eq1 = equalizer[𝒞](f,g)
e = dom(only(eq1))
@test collect(e) == [3]
@test only(eq1)(3) == 3

h = FinFunction([3,3],4)
@test factorize[𝒞](eq1, h) == FinFunction([1,1])
```