### PR TITLE
Fix typo in coerce_component

### DIFF
--- a/src/categorical_algebra/pointwise/pointwisecats/CSetCats.jl
+++ b/src/categorical_algebra/pointwise/pointwisecats/CSetCats.jl
@@ -94,7 +94,7 @@ function coerce_component(::Nothing, d::FinSet, cd::FinSet)
   if length(d) == 0
     FinFunction(getvalue(d) isa FinSetInt ? Int[] : Set{eltype(cd)}(), cd)
   elseif length(cd) == 1
-    FinFunction(ConstantFunction(only(parts(Y, o)), d, cd))
+    FinFunction(ConstantFunction(only(cd), d, cd))
   else 
     error("Missing component with dom $d and codom $cd")
   end

--- a/test/categorical_algebra/pointwise/csetcats/ACSetTransformations.jl
+++ b/test/categorical_algebra/pointwise/csetcats/ACSetTransformations.jl
@@ -19,6 +19,10 @@ g, h = path_graph(Graph, 4), cycle_graph(Graph, 2)
 α′′ = ACSetTransformation(g, h, V=FinFunction([1,2,1,2]), E=FinFunction([1,2,1]))
 @test components(α′′) == components(α)
 
+# Coerce component
+g1, g5 = Graph(1), Graph(5)
+@test ACSetTransformation(g5, g1)[:V](4) == 1 # don't need to specify V: unique
+
 # Naturality.
 #-------------
 


### PR DESCRIPTION
The `coerce_component` code which says a component with no provided is well defined if its codomain is singleton has a typo which is addressed in this small PR.