### PR TITLE
`@acset_colim` variants: exposing name mapping, and morphisms 

### DIFF
--- a/test/categorical_algebra/pointwise/csetcats/Yoneda.jl
+++ b/test/categorical_algebra/pointwise/csetcats/Yoneda.jl
@@ -85,7 +85,7 @@ v3e2′ = @acset Graph begin V=3; E=2; src=[1,2]; tgt=[2,3] end
 
 @test is_isomorphic(v3e2, v3e2′)
 
-acs = @named_acset_colim y_Graph MyDomain begin
+MyDomain, acs = @named_acset_colim y_Graph begin
   v::V; e::E; src(e)==v
 end
 


### PR DESCRIPTION
This draft introduces two new macros related to `@acset_colim`. The first, `@named_acset_colim`, takes in an extra parameter which will be assigned a NamedTuple relating the names of the generators to their respective elements (`Pair{Symbol, Int}`).

```julia 
acs = @named_acset_colim y_Graph MyDomain begin
  v::V; e::E; src(e)==v
end

@test acs[MyDomain.e[2],:src] == MyDomain.v[2]
```

The second `@acset_transformation_colim`, accepts two `@acset_colim`-style expressions as well as a sequence of pairs (which initializing a hom search) as well as keyword arguments for hom-search.

```julia
# sending path graph •→•→• to •→•↺↺. 
f = @acset_transformation_colim y_Graph #=domain=# begin
  (vstart,vend)::V; (e1,e2)::E; 
  src(e1)==vstart; tgt(e1)==src(e2); tgt(e2)==vend
end #=codomain =# begin
  v::V; (ea,eb,ec)::E; 
  src(ea)==v; tgt(ea)==src(eb) == tgt(eb) == src(ec) == tgt(ec)
end #=mapping=# begin vstart=>v; end #=kw=# (any=true, monic=[:E])
```

In order for this to truly work, the data of `yoneda` is actually not enough. We are missing the data of, in a representable `Foo`, which element is the representing element. For example, the representable edge in a reflexive graph has three edges in it. Only one of them is the representing element. Presently, for simplicity so that the same data can be plugged into `@acset_colim` and these macros, we throw an error if there is any ambiguity in what the representing element is. 