### PR TITLE
Internally expose the name bindings of @acset_colim

### DIFF
--- a/src/categorical_algebra/pointwise/datamigrations/Yoneda.jl
+++ b/src/categorical_algebra/pointwise/datamigrations/Yoneda.jl
@@ -219,6 +219,19 @@ function parse_diagram_data(x::Expr, mod::Module)::DiagramData
     Expr(:$, x) => Base.eval(mod, x)
   end
 
+  function parse_eq(t1t2::Tuple) 
+    p1,p2 = parse_call.(t1t2)
+    if p1 isa RPath
+      if p2 isa RPath 
+        push!(data.eqs, p1 => p2) 
+      else 
+        data.vals[p1] = p2
+      end 
+    else
+      data.vals[p2] = p1
+    end
+  end
+
   for arg in Base.remove_linenums!(x).args
     @match arg begin
       Expr(:(::), partname::Symbol, parttype::Symbol) => begin 
@@ -227,18 +240,13 @@ function parse_diagram_data(x::Expr, mod::Module)::DiagramData
       Expr(:(::), Expr(:tuple, partnames...), parttype::Symbol) => begin
         add_part.(partnames, Ref(parttype))
       end
-      Expr(:call, :(==), t1, t2) => begin
-        p1,p2 = parse_call.([t1,t2])
-        if p1 isa RPath
-          if p2 isa RPath 
-            push!(data.eqs, p1 => p2) 
-          else 
-            data.vals[p1] = p2
-          end 
-        else
-          data.vals[p2] = p1
-        end
+      Expr(:call, :(==), t1, t2) => parse_eq((t1,t2))
+      Expr(:comparison, raw...) => begin
+        all(==(:(==)), raw[2:2:end]) || error("Improper equality $arg")
+        ts = raw[1:2:end]
+        parse_eq.(zip(ts, ts[2:end]))
       end
+      _ => error("Unexpected expr $arg")
     end
   end
   data
@@ -255,8 +263,8 @@ end
 ```
 """
 macro acset_colim(yon, body)
-  quote 
-    colimit_representables($(parse_diagram_data(body, __module__)), $(esc(yon)))
+  quote
+    colimit_representables($(parse_diagram_data(body, __module__)), $(esc(yon)))[2]
   end
 end
 
@@ -267,7 +275,10 @@ representables and relations. Assumes a background context of VarACSetCategory
 function colimit_representables(data::DiagramData, y::FinDomFunctor)
   # Warning: we assume FinDomFunctor is implemented by FinDomFunctorMap to
   # get access to an arbitrary element (not part of the FinCat interface)
-  arb = last(first(getvalue(y).ob_map))
+  vy = getvalue(y)
+  vy isa FinDomFunctorMap || error("Expected FinDomFunctorMap")
+  arb = last(first(vy.ob_map))
+
   S = acset_schema(arb)
   P = Presentation(S)
   
@@ -276,6 +287,7 @@ function colimit_representables(data::DiagramData, y::FinDomFunctor)
   ks = collect(keys(data.reprs))
 
   𝒞 = ACSetCategory(VarACSetCat(arb))
+  cat(x::Symbol) = x ∈ ob(S) ? entity_cat(𝒞) : attr_cat(𝒞, x)
   𝒞′ = TypedCatWithCoproducts(𝒞)
 
   # Total order on the representables 
@@ -284,6 +296,8 @@ function colimit_representables(data::DiagramData, y::FinDomFunctor)
     push!(reprs, (k, v))
   end
 
+  isempty(reprs) && return ((;), apex(initial[𝒞]()))
+  
   # Construct a coproduct of all representables
   representable_csets = ob_map.(Ref(y), gen.(first.(reprs)))
   Σ = coproduct[𝒞](representable_csets...)
@@ -292,34 +306,17 @@ function colimit_representables(data::DiagramData, y::FinDomFunctor)
   # Given a name of some representable, get its corresponding inclusion into Σ
   lookup = Dict([v=>ι[i] for (i,(_,v)) in enumerate(reprs)])
 
-  # Convert a morphism out of a representable into an ACSetTransformation into Σ
-  function list_to_hom(rep_f::RPath)::ACSetTransformation
-    rep, f = rep_f
-    p = if isempty(f)
-      k = ks[findfirst(k->rep ∈ data.reprs[k], ks)]
-      id(gen(k))
-    else
-      compose(gen.(f))
-    end
-    m = @match only(typeof(p).parameters) begin 
-      :generator => gen_map(y, p) 
-      :compose => hom_map(y, p)
-      :id => id[𝒞](ob_map(y, dom(p)))
-    end
-    compose[𝒞](m, lookup[rep])
-  end
-
   # A quotient for each equation: if we are identifying a rep x, this is a span 
   # x ⇇ x² ⇉ Σᵢrᵢ where the left is merge + the right map comes from an equation
   spans = map(data.eqs) do lr
-    l, r = map(list_to_hom,lr)
+    l, r = [list_to_hom(y, 𝒞, lookup, x) for x in lr]
     merge = let idᵣ = id[𝒞](dom(l)); copair[𝒞′](idᵣ,idᵣ) end
     Span(merge, copair[𝒞′](l,r))
   end
 
   # A quotient for each fixed value: assert the attrvar is equal via pushout
   for (rp,val) in pairs(data.vals)
-    h = list_to_hom(rp)
+    h = list_to_hom(y, 𝒞, lookup, rp)
     T = codom(S, last(last(rp))) 
     set_val = ACSetTransformation(ob_map(y, gen(T)), constructor(𝒞); 
                                   Dict([T=>[val]])...)
@@ -327,11 +324,38 @@ function colimit_representables(data::DiagramData, y::FinDomFunctor)
   end
 
   # If we are just asking for a coproduct of representables
-  isempty(spans) && return apex(Σ)
+  colim, incl = if isempty(spans) 
+    Σ, Dict(k => id[cat(k)](get_ob(𝒞, apex(Σ), k)) for k in types(S))
+  else 
+    # Perform all pushouts at once by putting spans together in parallel
+    lefts, rights = left.(spans), right.(spans)
+    _,bigι = big_colim = pushout[𝒞](
+      foldl(oplus[𝒞′], lefts), foldl(copair[𝒞′], rights))
+    (big_colim, bigι)
+  end
 
-  # Perform all pushouts at once by putting the spans together in parallel
-  lefts, rights = left.(spans), right.(spans)
-  apex(pushout[𝒞](foldl(oplus[𝒞′], lefts), foldl(copair[𝒞′], rights)))
+  # TODO get representing element for real. Requires passing in extra data.
+  names = NamedTuple(map(reprs) do (repr_type, repr_name)
+    c = cat(repr_type)
+    ι = compose[c](lookup[repr_name][repr_type],incl[repr_type])
+    length(dom[c](ι)) == 1 || error("Assumption that representing element is "*
+    "unique has been violated, more data required by `colimit_representables`")
+    e = (repr_type ∈ ob(S) ? identity : Left)(only(dom[c](ι)))
+    repr_name => (repr_type, hom_map[c](ι)(e))
+  end)
+
+  (names, apex(colim))
+end
+
+# Helper function for colimit_representables
+# Convert a morphism out of a representable into an ACSetTransformation into Σ
+function list_to_hom(y::FinDomFunctor, 𝒞::ACSetCategory, 
+                     lookup::Dict{Symbol, <:ACSetTransformation}, 
+                     rep_f::RPath)::ACSetTransformation
+  rep, f = rep_f
+  gen(x) = generator(Presentation(acset_schema(𝒞)), x)
+  hs = gen_map.(Ref(y), gen.(f))
+  foldl(compose[𝒞], [hs..., lookup[rep]])
 end
 
 end # module

--- a/test/categorical_algebra/pointwise/csetcats/Yoneda.jl
+++ b/test/categorical_algebra/pointwise/csetcats/Yoneda.jl
@@ -71,8 +71,9 @@ ZG = ob(product[ACSetCategory(DDS42())](Z,G))
 
 # ACSet colim
 #############
-
+@test is_isomorphic((@acset_colim y_Graph begin end), Graph())
 @test is_isomorphic((@acset_colim y_Graph begin v::V end), Graph(1))
+@test is_isomorphic((@acset_colim y_Graph begin (v1,v2,v3)::V; v1==v2==v3 end), Graph(1))
 
 v3e2 = @acset_colim y_Graph begin
   v1::V; (e1,e2)::E


### PR DESCRIPTION
This PR takes just the uncontroversial core of https://github.com/AlgebraicJulia/Catlab.jl/pull/986.

The present implementation of `colimit_representables` constructs a colimit which has the data of mapping user-inputted names to certain parts in the resulting ACSet, but it then throws this information away and just returns the ACSet. This PR has the function also return this extra data which can be useful because the names the user picks may be meaningful.

This also introduces a user-facing feature to allow parsing equations of the form `f(x)==g(y)==h(z)` rather than having to do those pairwise. It also fixes a bug where the empty `block` would error rather than produce an initial object.