### PR TITLE
`fmap` for free graphs fix

### DIFF
--- a/src/categorical_algebra/cats/freediagrams/FreeGraphs.jl
+++ b/src/categorical_algebra/cats/freediagrams/FreeGraphs.jl
@@ -76,12 +76,12 @@ FreeCatGraph(n::FreeGraph) =  FreeCatGraph(getvalue(n))
 end
 
 
-""" Replace homs via a replacement function """
-function fmap(d::FreeGraph, o, h, O::Type, H::Type) 
+""" Replace obs / homs via a replacement function """
+function fmap(old_graph::FreeGraph, ofun, hfun, O::Type, H::Type) 
   res = FreeGraph{O,H}()
-  add_vertices!(res, nv(d); ob=o.(d[:ob]))
-  for e in edges(res)
-    add_edge!(res, src(d, e), tgt(d, e); hom=h(hom(d,e)))
+  add_vertices!(res, nv(old_graph); ob=ofun.(old_graph[:ob]))
+  for e in edges(old_graph)
+    add_edge!(res, src(old_graph, e), tgt(old_graph, e); hom=hfun(old_graph[e,:hom]))
   end
   res
 end

--- a/src/categorical_algebra/cats/slice/LimitsColimits.jl
+++ b/src/categorical_algebra/cats/slice/LimitsColimits.jl
@@ -112,14 +112,18 @@ function limit_slice(model, diagram::FreeDiagram)
   lim = limit[𝒞](FG)
 
   new_apex = SliceOb(apex(lim), first(legs(lim.cone)))
-  spn = Multispan(new_apex, legs(lim.cone)[2:end], FG[:ob][2:end])
+  lgs = map(zip(legs(lim.cone)[2:end], ob(diagram))) do (l, o)
+    SliceHom(new_apex, o, l; cat=𝒞)
+  end
+  spn = Multispan(new_apex, lgs, ob(diagram))
   SliceLimitCone(spn, diagram, lim)
 end
 
 """ Use the universal property of the underlying category. """
 function slice_limit_universal(model, lim::AbsLimit, _::FreeDiagram, sp::Multispan)
   𝒞, apx = model.cat, apex(sp)
-  universal[𝒞](lim.underlying, Multispan(apx.ob, [apx.hom, sp...]; cat=𝒞))
+  res = universal[𝒞](lim.underlying, Multispan(apx.ob, [apx.hom, [f.hom for f in sp]...]; cat=𝒞))
+  SliceHom(apx, apex(lim), res; cat=𝒞)
 end
 
 end # module

--- a/src/categorical_algebra/cats/slice/SliceCategories.jl
+++ b/src/categorical_algebra/cats/slice/SliceCategories.jl
@@ -37,6 +37,10 @@ SliceOb(hom; cat=nothing) =
   end
 end
 
+function force(f::SliceHom{O,H}; cat=nothing) where {O,H} 
+  SliceHom(f.dom, f.codom, force(f.hom); cat) 
+end
+
 # We want to use this for potentially many theories (e.g. the various (co)limit
 # theories) so it doesn't make sense to store a wrapped model. Just store raw 
 # model.
@@ -102,7 +106,7 @@ using .ThCategoryExplicitSets
   codom(h::SliceHom{<:ObT, <:HomT}) = h.codom
 
   function compose(f::SliceHom{<:ObT, <:HomT}, g::SliceHom{<:ObT, <:HomT})
-    SliceHom(f.dom, g.codom, compose[model.cat](f.hom, g.hom))
+    SliceHom(f.dom, g.codom, compose[model.cat](f.hom, g.hom); cat=model.cat)
   end
 
   # Actually we can get more specific than this with PredicatedSets.

--- a/test/categorical_algebra/cats/FreeDiagrams.jl
+++ b/test/categorical_algebra/cats/FreeDiagrams.jl
@@ -169,6 +169,13 @@ diagram = FreeGraph([A,B,C], [(f,1,3),(g,2,3),(h,1,2)]) |> FreeDiagram
 @test (src(diagram), tgt(diagram)) == ([1,2,1], [3,3,2])
 @test_throws Exception FreeDiagram([A,B,C], [(f,1,2),(g,2,3),(h,1,2)])
 
+double(f) = let n = string(nameof(f)); Hom(Symbol(n*n), dom(f), codom(f)) end
+diagram′ = fmap(diagram, identity, double, FreeCategory.Ob,FreeCategory.Hom).val
+
+@test nv(diagram′) == 3
+@test ne(diagram′) == 3
+@test Hom(:gg, B, C) ∈ diagram′[:hom]
+
 # Bipartite free diagrams
 #------------------------
 

--- a/test/categorical_algebra/cats/SliceCategories.jl
+++ b/test/categorical_algebra/cats/SliceCategories.jl
@@ -65,10 +65,13 @@ slic = SliceHom(A,A,id[𝒞](G2); cat=𝒞)
 slice_lim = π₁, π₂ = product[𝒞3](A,B);
 
 # test universal property
-mA, mB = [ACSetTransformation(G1,G2;V=x) for x in [[1],[2]]]
-sp = Multispan(SliceOb(ACSetTransformation(G1, G3; V=[2])), [mA, mB], [A,B])
+X = SliceOb(ACSetTransformation(G1, G3; V=[1]))
+mA, mB = map([A=>[1],B=>[2]]) do (L,x)
+  SliceHom(X, L, ACSetTransformation(G1,G2;V=x); cat=𝒞)
+end
+sp = Span(mA,mB; cat=𝒞3)
 u = universal[𝒞3](slice_lim, sp)
-@test force(compose[𝒞](u, π₁)) == mA
-@test force(compose[𝒞](u, π₂)) == mB
+@test force(compose[𝒞3](u, π₁); cat=𝒞) == mA
+@test force(compose[𝒞3](u, π₂); cat=𝒞) == mB
 
 end # module


### PR DESCRIPTION
As pointed on in https://github.com/AlgebraicJulia/Catlab.jl/issues/996, there was an error in how Catlab maps `Ob` and `Hom` functions over a graph (it would simply produce a discrete graph no matter what). This was a simple fix (we just need to iterate over edges in the _old_ graph in order to produce edges in the new graph). 

Fixing that also surfaced an error in the slice category limit code which was not being tested due to the limits being trivialized by the `fmap` bug. That error was simply an inconsistency between two strategies for morphisms in slice categories: one could simply use morphisms in the original category, or one could use a dedicated struct `SliceHom` which knows its domain and codomain slices. Catlab currently uses the latter, but the limit code had parts which assumed the former. 