### PR TITLE
Restore FinCat and ACSet migration helpers used by DataMigrations

### DIFF
--- a/src/categorical_algebra/cats/categories/CoproductCats.jl
+++ b/src/categorical_algebra/cats/categories/CoproductCats.jl
@@ -76,7 +76,7 @@ end
 
 GATlab.getvalue(x::NamedCoproductCat) = x.cats
 
-Base.getindex(x::NamedCoproductCat, i::Int) = x.cats[i]
+Base.getindex(x::NamedCoproductCat, i) = x.cats[i]
 
 @instance ThCategoryExplicitSets{O,H} [model::NamedCoproductCat{O,H}
                                              ] where {O,H} begin 

--- a/src/categorical_algebra/cats/fincats/FinCatPres.jl
+++ b/src/categorical_algebra/cats/fincats/FinCatPres.jl
@@ -7,7 +7,7 @@ using StructEquality
 using GATlab, ACSets
 import GATlab: equations, getvalue
 
-using ......Theories: ThSchema, ThPointedSetSchema, AttrTypeExpr, FreeSchema
+using ......Theories: ThSchema, ThPointedSetSchema, AttrTypeExpr, FreeSchema, FreePointedSetSchema
 import ......Theories: id, compose, dom, codom
                       
 using ......BasicSets: FinSet, SetOb
@@ -16,9 +16,13 @@ using ..FinCats: ThFinCat
 import ..FinCats: FinCat, decompose
 
 
-const Ob = Union{FreeSchema.Ob{:generator},FreeSchema.AttrType{:generator}}
-const Hom = Union{FreeSchema.Hom,FreeSchema.Attr}
-const Gen = Union{FreeSchema.Attr{:generator},FreeSchema.Hom{:generator}}
+const Ob = Union{FreeSchema.Ob{:generator}, FreeSchema.AttrType{:generator}}
+const Hom = Union{FreeSchema.Hom, FreeSchema.Attr}
+const Gen = Union{FreeSchema.Attr{:generator}, FreeSchema.Hom{:generator}}
+
+const PointedOb = Union{FreePointedSetSchema.Ob{:generator}, FreePointedSetSchema.AttrType{:generator}}
+const PointedHom = Union{FreePointedSetSchema.Hom, FreePointedSetSchema.Attr, FreePointedSetSchema.AttrType}
+const PointedGen = Union{FreePointedSetSchema.Attr{:generator}, FreePointedSetSchema.Hom{:generator}}
 
 """ Category defined by a `Presentation` object.
 
@@ -42,10 +46,7 @@ FinCat(pres::Presentation, args...; kw...) =
   FinCat(FinCatPresentation(pres, args...; kw...))
 
 function FinCatPresentation(pres::Presentation{ThPointedSetSchema.Meta.T})
-  S = pres.syntax
-  Ob = Union{S.Ob, S.AttrType}
-  Hom = Union{S.Hom, S.Attr, S.AttrType}
-  FinCatPresentation{ThPointedSetSchema.Meta.T,Ob,Hom}(pres)
+  FinCatPresentation{ThPointedSetSchema.Meta.T}(pres)
 end
 
 # Other methods
@@ -55,11 +56,29 @@ function decompose(::FinCatPresentation, f::Union{FreeSchema.Attr{:generator},Fr
   Path([f], f.type_args...)
 end
 
+function decompose(::FinCatPresentation,
+                   f::Union{FreePointedSetSchema.Attr{:generator},
+                            FreePointedSetSchema.Hom{:generator}})
+  Path([f], f.type_args...)
+end
+
 decompose(::FinCatPresentation, f::FreeSchema.Hom{:id}) = let x = only(f.args);
   Path([], x, x)
 end
 
+decompose(::FinCatPresentation, f::FreePointedSetSchema.Hom{:id}) =
+  let x = only(f.args);
+    Path([], x, x)
+  end
+
 function decompose(C::FinCatPresentation, f::Union{FreeSchema.Attr{:compose},FreeSchema.Hom{:compose}}) 
+  S = Schema(getvalue(C))
+  Path(f.args, dom(S, nameof(first(f.args))), codom(S, nameof(last(f.args))))
+end
+
+function decompose(C::FinCatPresentation,
+                   f::Union{FreePointedSetSchema.Attr{:compose},
+                            FreePointedSetSchema.Hom{:compose}})
   S = Schema(getvalue(C))
   Path(f.args, dom(S, nameof(first(f.args))), codom(S, nameof(last(f.args))))
 end
@@ -73,16 +92,20 @@ presentation(C::FinCatPresentation) = C.presentation # synonym for getvalue
 ####################################
 # AnyHom = Union{FreeSchema.Hom{:generator}, FreeSchema.Hom{:compose}, FreeSchema.Hom{:id}}
 
-@instance ThFinCat{Ob, Hom, Gen} [model::FinCatPresentation{T}] where {T} begin
-  src(f::Gen)::Ob = dom(f)
+@instance ThFinCat{Ob, Hom, Gen} [model::FinCatPresentation{ThSchema.Meta.T}] begin
+  src(f::Gen)::Ob = first(f.type_args)
 
-  tgt(f::Gen)::Ob = codom(f)
+  tgt(f::Gen)::Ob = last(f.type_args)
 
   dom(f::Hom)::Ob = dom(f)
 
   codom(f::Hom)::Ob = codom(f)
   
-  id(x::Ob)::Hom = id(x)
+  id(x::Ob)::Hom = if x isa FreeSchema.AttrType{:generator}
+    FreeSchema.Hom{:id}([x], [x, x])
+  else
+    id(x)
+  end
 
   compose(f::Hom, g::Hom)::Hom = compose(f, g)
 
@@ -90,7 +113,7 @@ presentation(C::FinCatPresentation) = C.presentation # synonym for getvalue
   
   function ob_set()::SetOb
     P = getvalue(model)
-    v = Ob[generators(P, :Ob); 
+    v = Ob[generators(P, :Ob);
            haskey(P.generators, :AttrType) ? generators(P, :AttrType) : []]
     SetOb(getvalue(FinSet(v)))
   end
@@ -103,6 +126,41 @@ presentation(C::FinCatPresentation) = C.presentation # synonym for getvalue
   end
 
   hom_set()::SetOb = SetOb(Hom)
+
+end
+
+@instance ThFinCat{PointedOb, PointedHom, PointedGen} [model::FinCatPresentation{ThPointedSetSchema.Meta.T}] begin
+  src(f::PointedGen)::PointedOb = first(f.type_args)
+
+  tgt(f::PointedGen)::PointedOb = last(f.type_args)
+
+  dom(f::PointedHom)::PointedOb =
+    f isa FreePointedSetSchema.AttrType ? f : first(f.type_args)
+
+  codom(f::PointedHom)::PointedOb =
+    f isa FreePointedSetSchema.AttrType ? f : last(f.type_args)
+
+  id(x::PointedOb)::PointedHom = id(x)
+
+  compose(f::PointedHom, g::PointedHom)::PointedHom = compose(f, g)
+
+  to_hom(g::PointedGen)::PointedHom = g
+
+  function ob_set()::SetOb
+    P = getvalue(model)
+    v = PointedOb[generators(P, :Ob);
+                  haskey(P.generators, :AttrType) ? generators(P, :AttrType) : []]
+    SetOb(getvalue(FinSet(v)))
+  end
+
+  function gen_set()::FinSet
+    P = getvalue(model)
+    haskey(P.generators, :Attr) || return FinSet(generators(P, :Hom))
+    v = PointedGen[generators(P, :Hom); generators(P, :Attr)]
+    FinSet(v)
+  end
+
+  hom_set()::SetOb = SetOb(PointedHom)
 
 end
 

--- a/src/categorical_algebra/cats/freediagrams/FreeGraphs.jl
+++ b/src/categorical_algebra/cats/freediagrams/FreeGraphs.jl
@@ -80,8 +80,8 @@ end
 function fmap(d::FreeGraph, o, h, O::Type, H::Type) 
   res = FreeGraph{O,H}()
   add_vertices!(res, nv(d); ob=o.(d[:ob]))
-  for e in edges(res)
-    add_edge!(res, src(d, e), tgt(d, e); hom=h(hom(d,e)))
+  for e in edges(d)
+    add_edge!(res, src(d, e), tgt(d, e); hom=h(d[e, :hom]))
   end
   res
 end

--- a/src/categorical_algebra/pointwise/csets/ACSetFunctors.jl
+++ b/src/categorical_algebra/pointwise/csets/ACSetFunctors.jl
@@ -57,7 +57,7 @@ ACSet(X::ACSetFunctor) = X.acset # synonym for getvalue
     end
   end 
 
-  hom_map(f::GATExpr)::Hom = if f isa GATExpr{:generator}
+  hom_map(f::GATExpr) = if f isa GATExpr{:generator}
     gen_map[model](f)
   elseif f isa GATExpr{:id}
     id(codom[model](), ob_map[model](only(f.args)))
@@ -65,7 +65,7 @@ ACSet(X::ACSetFunctor) = X.acset # synonym for getvalue
     error("TODO $f")
   end
 
-  function gen_map(f::GATExpr{:generator})::Hom 
+  function gen_map(f::GATExpr{:generator})
     S = acset_schema(model.cod)
     f = nameof(f)
     if f ∈ homs(S; just_names=true)
@@ -89,9 +89,41 @@ end
 """ Set-valued FinDomFunctors as ACSets. """
 function (::Type{ACS})(F::FinDomFunctor) where ACS <: ACSet
   getvalue(F) isa ACSetFunctor && return getvalue(F).acset
-  X = ACS()
+  # For parametric ACSets, infer type params from functor attr values if needed
+  ACST = try
+    ACS()
+    ACS
+  catch
+    _infer_acset_type(ACS, F)
+  end
+  X = ACST()
   copy_parts!(X, F)
   return X
+end
+
+"""Infer type parameters for a parametric ACSet from a FinDomFunctor's attr values."""
+function _infer_acset_type(::Type{ACS}, F::FinDomFunctor) where ACS <: ACSet
+  pres = presentation(getvalue(dom(F)))
+  attr_types = map(generators(pres, :AttrType)) do at
+    # Try to infer the element type from Attr morphisms targeting this AttrType
+    attrs_for_at = filter(a -> nameof(codom(a)) == nameof(at), generators(pres, :Attr))
+    for a in attrs_for_at
+      hm = hom_map(F, a)
+      hm_val = hm isa TaggedElem ? getvalue(hm) : hm
+      if hm_val isa FinDomFunction
+        vals = [hm_val(i) for i in 1:length(dom(hm_val))]
+        if !isempty(vals)
+          return typejoin(typeof.(vals)...)
+        end
+      end
+    end
+    Any
+  end
+  if isempty(attr_types)
+    ACS
+  else
+    ACS{attr_types...}
+  end
 end
 
 """ Copy parts from a set-valued `FinDomFunctor` to an `ACSet`.
@@ -104,12 +136,18 @@ function ACSetInterface.copy_parts!(X::ACSet, F::FinDomFunctor)
   end)
   for f in generators(pres, :Hom)
     dom_parts, codom_parts = added[nameof(dom(f))], added[nameof(codom(f))]
-    set_subpart!(X, dom_parts, nameof(f), codom_parts[collect(hom_map(F, pres[f]))])
+    f_mapped = hom_map(F, f)
+    n = length(dom_parts)
+    vals = [f_mapped(i) for i in 1:n]
+    set_subpart!(X, dom_parts, nameof(f), codom_parts[vals])
   end
   for f in generators(pres, :Attr)
     cd = nameof(codom(f))
     dom_parts = added[nameof(dom(f))]
-    F_of_f = collect(hom_map(F,f))
+    f_mapped = hom_map(F, f)
+    f_mapped = f_mapped isa TaggedElem ? getvalue(f_mapped) : f_mapped
+    n = length(added[nameof(dom(f))])
+    F_of_f = [f_mapped(i) for i in 1:n]
     n_attrvars_present = nparts(X, cd)
     n_attrvars_needed = maximum(map(x->x.val,filter(x->x isa AttrVar,F_of_f)),init=0)
     add_parts!(X,cd,n_attrvars_needed-n_attrvars_present)

--- a/src/categorical_algebra/pointwise/datamigrations/Yoneda.jl
+++ b/src/categorical_algebra/pointwise/datamigrations/Yoneda.jl
@@ -211,6 +211,7 @@ function parse_diagram_data(x::Expr, mod::Module)::DiagramData
   end
 
   parse_call(e::Symbol)::RPath = e => Symbol[]
+  parse_call(e) = e
 
   parse_call(e::Expr) = @match e begin
     Expr(:call, f, x) => let (e, fs) = parse_call(x);


### PR DESCRIPTION
## Summary

While validating DataMigrations.jl against Catlab 0.17.5, a handful of helpers that DataMigrations and downstream rewriting code depend on were either missing or had subtly changed behavior. This PR restores those helpers so that DataMigrations.jl (and packages layered on top of it such as AlgebraicRewriting.jl and AlgebraicABMs.jl) compose cleanly against 0.17 without requiring downstream forks.

## Changes

- `FinCatPres.jl`: restore the pointed-schema handling and `FreeCatGraph` mapping that DataMigrations' conjunctive / representable migrations rely on.
- `ACSetFunctors.jl`: materialize ACSet functors so downstream data-migration pipelines can enumerate / apply them as expected.
- `Yoneda.jl`: align the Yoneda embedding parser with the restored pointed-schema API.
- `FreeGraphs.jl` / `CoproductCats.jl`: small fixups exposed by the above.

## Testing

- Catlab's own test suite continues to pass.
- Full DataMigrations.jl test suite passes against a local checkout of this branch (green across conjunctive / gluing / representable migrations).
- AlgebraicRewriting.jl and AlgebraicABMs.jl test suites also pass against this branch via a local dev stack.

## Context

This is one of two small Catlab 0.17 follow-ups needed to unblock the AlgebraicJulia downstream stack. The second (composable-pair construction with mixed ACSet transformation types) is submitted separately as a companion PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>