### PR TITLE
Allow composable pairs for mixed ACSet transformation types

### DIFF
--- a/src/categorical_algebra/cats/freediagrams/ComposableHoms.jl
+++ b/src/categorical_algebra/cats/freediagrams/ComposableHoms.jl
@@ -77,11 +77,19 @@ const ComposablePair{Ob,Hom} = ComposableMorphisms{Ob,Hom,<:StaticVector{2,Hom}}
 # Constructor in which we infer Hom and Ob type
 ComposablePair(f::Hom, g::Hom; kw...) where Hom = ComposablePair{Hom}(f, g; kw...)
 
+# Constructor for composable pairs whose morphisms have different concrete types.
+function ComposablePair(first, last; cat=nothing)
+  Hom = typejoin(typeof(first), typeof(last))
+  𝒞 = isnothing(cat) ? Dispatch(ThCategory, [Union{},Hom]) : cat
+  Ob = Union{typeof.([dom[𝒞](first), dom[𝒞](last), codom[𝒞](last)])...}
+  ComposableMorphisms{Ob, Hom}(SVector{2,Hom}(first, last); cat)
+end
+
 # Constructor in which we infer Ob type
 function ComposablePair{Hom}(first::Hom, last::Hom; cat=nothing) where Hom
   𝒞 = isnothing(cat) ? Dispatch(ThCategory, [Union{},Hom]) : cat
   Ob = Union{typeof.([dom[𝒞](first), dom[𝒞](last), codom[𝒞](last)])...}
-  ComposableMorphisms{Ob, Hom}(SVector(first, last); cat)
+  ComposableMorphisms{Ob, Hom}(SVector{2,Hom}(first, last); cat)
 end
 
 @instance ThFreeDiagram{Int,Int,Ob,Hom} [model::ComposableMorphisms{Ob,Hom}


### PR DESCRIPTION
## Summary

Under Catlab 0.17 the `ComposableHoms` constructor only accepts composable pairs of *identical* concrete ACSet transformation types. In practice downstream rewriting (AlgebraicRewriting.jl) and ABM (AlgebraicABMs.jl) code routinely composes morphisms where one side is a plain `ACSetTransformation` and the other is a `CSetTransformation` / specialized subtype, which currently throws even though the domains/codomains match.

## Changes

- `ComposableHoms.jl`: relax the composable-pair validation so mixed concrete subtypes of `ACSetTransformation` can be composed, provided the codomain of the first and the domain of the second are equal.

## Testing

- Catlab's own test suite continues to pass.
- With this change, AlgebraicRewriting.jl and AlgebraicABMs.jl test suites pass end-to-end against a local Catlab 0.17 + dev stack.

## Context

Companion to the "Restore FinCat and ACSet migration helpers used by DataMigrations" PR (#999); together they complete the Catlab 0.17 surface needed to unblock the AlgebraicJulia downstream stack.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
